### PR TITLE
Add CLAUDE.md documentation for project architecture and conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md — Fedi Reader
+
+Link-focused Mastodon news reader for iOS/macOS. Pure Swift, SwiftUI + SwiftData, `@Observable` services — no MVVM, no external dependencies.
+
+## Build & Test Commands
+
+```bash
+# Build (iOS Simulator)
+xcodebuild -scheme "fedi-reader" \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' build
+
+# Run all tests
+xcodebuild -scheme "fedi-reader" \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' test
+
+# Unit tests only
+xcodebuild -scheme "fedi-reader" \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:fedi-readerTests test
+
+# Single test suite
+xcodebuild -scheme "fedi-reader" \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:fedi-readerTests/HTMLParserTests test
+
+# Single test method
+xcodebuild -scheme "fedi-reader" \
+  -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+  -only-testing:fedi-readerTests/HTMLParserTests/extractsLinks test
+
+# Clean
+xcodebuild -scheme "fedi-reader" clean
+```
+
+## Architecture
+
+Flat, service-oriented design. Views consume `@Observable` services directly via `@Environment` — no ViewModels.
+
+### Data Flow
+
+```
+MastodonClient (OAuth + REST)
+  → TimelineService (fetch & paginate)
+    → LinkFilterService (extract link-only posts)
+      → AttributionChecker (enrich with author metadata)
+  → ReadLaterManager (save to Pocket/Instapaper/Omnivore/Readwise/Raindrop)
+```
+
+### Key Services
+
+| Service | Purpose |
+|---------|---------|
+| `MastodonClient` | OAuth 2.0 flow, authenticated REST calls, rate limiting |
+| `AuthService` | Account management, credential storage, OAuth flow |
+| `TimelineService` | Timeline fetching with `maxId`/`minId` pagination |
+| `LinkFilterService` | Link extraction, domain filtering, per-feed caching |
+| `AttributionChecker` | Author extraction via Link headers, OG tags, JSON-LD |
+| `AppState` | Global observable state (navigation, sheets, errors) |
+| `ReadLaterManager` | Unified interface to 5 read-later service adapters |
+| `EmojiService` | Custom emoji caching per Mastodon instance |
+
+## File Layout
+
+```
+fedi-reader/
+├── App/                    # FediReaderApp.swift (entry point, SwiftData ModelContainer)
+├── Models/                 # SwiftData models (Account, CachedStatus, ReadLaterConfig)
+│                           # + MastodonTypes.swift (API types with CodingKeys)
+├── Services/               # @Observable @MainActor service classes
+│   └── ReadLater/          # Protocol-based adapters (Pocket, Instapaper, etc.)
+├── Views/                  # SwiftUI views by feature
+│   ├── Actions/            # ComposeView, StatusActionsView
+│   ├── Auth/               # LoginView, ReadLaterLoginView
+│   ├── Components/         # Reusable UI (avatars, badges, thread view, filters)
+│   ├── Feed/               # LinkFeedView, ExploreFeedView, MentionsView, StatusDetailView
+│   ├── Profile/            # ProfileView, AccountSettingsView, followers/following
+│   ├── Root/               # ContentView, MainTabView, WelcomeView
+│   ├── Settings/           # SettingsView, ReadLaterSettingsView
+│   └── Web/                # ArticleWebView, WebViewComponents
+└── Utilities/              # HTMLParser, KeychainHelper, Constants, TimeFormatter
+```
+
+## Code Conventions
+
+### Patterns to Follow
+
+- **Service classes**: `@Observable @MainActor final class`
+- **Dependency injection**: Services created in `ContentView`, passed via `@Environment`
+- **Concurrency**: `async`/`await` throughout, no Combine
+- **Error handling**: Guard-based early returns; errors as enums conforming to `LocalizedError`
+- **Logging**: `Logger(subsystem: "app.fedi-reader", category: "ServiceName")`
+- **API types**: `Codable` structs with `CodingKeys` mapping snake_case JSON
+- **SwiftData models**: `@Model final class` with `@Attribute(.unique)` for IDs
+- **Section organization**: `// MARK: -` comments to group related code
+
+### Testing
+
+- **Framework**: Swift Testing (`import Testing`, `@Test`, `@Suite`) — not XCTest
+- **Assertions**: `#expect()` — not `XCTAssert`
+- **Mocks**: `MockURLProtocol` for network isolation; `MockStatusFactory` for domain objects
+- **Test files**: `fedi-readerTests/` directory, ~2,100 LOC across 11 test files
+
+### Style
+
+- No linter or formatter configured (no SwiftLint/SwiftFormat)
+- PascalCase for types, camelCase for properties/methods
+- No external dependencies — all functionality via Apple frameworks
+
+## Configuration
+
+- **URL scheme**: `fedi-reader://` (OAuth callbacks, registered in Info.plist)
+- **Credentials**: Stored in Keychain via `KeychainHelper`
+- **Targets**: iOS 26.0+ / macOS 26.0+, Xcode 16.0+
+- **No CI/CD** pipeline configured
+- **BSP**: `buildServer.json` for IDE build-server integration


### PR DESCRIPTION
## Summary

Add comprehensive project documentation (`CLAUDE.md`) that serves as a reference guide for understanding the codebase architecture, build/test procedures, file organization, and development conventions.

## Key Changes

- **Build & Test Commands**: Documented xcodebuild commands for building, running tests (all, unit-only, by suite, by method), and cleaning
- **Architecture Overview**: Explained the flat, service-oriented design with `@Observable` services and no MVVM/ViewModels
- **Data Flow Diagram**: Visualized the pipeline from `MastodonClient` through `TimelineService`, `LinkFilterService`, and `AttributionChecker` to `ReadLaterManager`
- **Service Reference Table**: Documented 8 core services with their purposes (OAuth, timeline fetching, link extraction, read-later integrations, etc.)
- **File Layout**: Provided complete directory structure with descriptions of each module (App, Models, Services, Views, Utilities)
- **Code Conventions**: Established patterns for:
  - Service class structure (`@Observable @MainActor final class`)
  - Dependency injection via `@Environment`
  - Async/await concurrency model
  - Error handling with enums conforming to `LocalizedError`
  - Logging with `Logger`
  - SwiftData model conventions
  - Code organization with `// MARK: -` comments
- **Testing Guidelines**: Specified Swift Testing framework (not XCTest), `#expect()` assertions, mocking strategies, and test file organization
- **Style & Configuration**: Documented no linter/formatter, naming conventions, iOS/macOS deployment targets, Keychain credential storage, and URL scheme registration

## Implementation Details

This documentation captures the current state of the project:
- Pure Swift, SwiftUI + SwiftData stack with no external dependencies
- ~2,100 LOC of tests across 11 test files using Swift Testing
- Xcode 16.0+ with iOS/macOS 26.0+ targets
- Keychain-based credential storage with OAuth 2.0 flow
- Support for 5 read-later services (Pocket, Instapaper, Omnivore, Readwise, Raindrop)

The guide serves as both onboarding documentation and a reference for maintaining consistency across the codebase.

https://claude.ai/code/session_012N1mks69z6BcoiRPSdnGPJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive documentation in `CLAUDE.md`.
> 
> - **Build/Test**: `xcodebuild` commands for build, all/unit/suite/method tests, and clean
> - **Architecture**: Flat service-oriented design; data flow from `MastodonClient` → `TimelineService` → `LinkFilterService` → `AttributionChecker` → `ReadLaterManager`
> - **Key Services**: Table describing 8 core services (auth, timeline, link filtering, attribution, read-later, emoji, app state)
> - **File Layout**: Project directory structure with role descriptions
> - **Conventions**: Service patterns, DI via `@Environment`, async/await, error/logging practices, SwiftData model rules, section organization
> - **Testing**: Swift Testing usage, assertions, mocks, and test organization (~2,100 LOC across 11 files)
> - **Style/Config**: Naming, no external deps/linter, URL scheme, Keychain creds, platform targets, BSP
> 
> No runtime code changes; documentation only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00398b1589255a96aa33829956ee1f71713dc3e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->