### PR TITLE
Include quote_uri with quote boosts and append status URL fallback

### DIFF
--- a/fedi-reader/Services/MastodonClient.swift
+++ b/fedi-reader/Services/MastodonClient.swift
@@ -816,7 +816,8 @@ final class MastodonClient {
         spoilerText: String? = nil,
         visibility: Visibility = .public,
         language: String? = nil,
-        quoteId: String? = nil
+        quoteId: String? = nil,
+        quoteURL: String? = nil
     ) async throws -> Status {
         Self.logger.info("Posting status, visibility: \(visibility.rawValue, privacy: .public), replyTo: \(inReplyToId?.prefix(8) ?? "nil", privacy: .public), mediaCount: \(mediaIds?.count ?? 0)")
         let url = try buildURL(instance: instance, path: Constants.API.statuses)
@@ -832,6 +833,7 @@ final class MastodonClient {
         if let spoilerText, !spoilerText.isEmpty { params["spoiler_text"] = spoilerText }
         if let language { params["language"] = language }
         if let quoteId { params["quote_id"] = quoteId } // For instances supporting quote posts
+        if let quoteURL { params["quote_uri"] = quoteURL } // Some implementations use quote_uri
         
         let body = try JSONSerialization.data(withJSONObject: params)
         let request = buildRequest(url: url, method: "POST", accessToken: accessToken, body: body)


### PR DESCRIPTION
### Motivation
- Some Mastodon-compatible instances expect a `quote_uri` parameter for quote-boosts while others only accept a quoted URL in the status text, so postings were not reliably linking to the original post. 
- Ensure quoted boosts link to the original status across server implementations to improve interoperability and UX.

### Description
- Add an optional `quoteURL` parameter to `MastodonClient.postStatus` and include it as `quote_uri` in the JSON body when present. 
- Update `TimelineService.quoteBoost` to compute a `quoteURL` from `Status` (`url` or `uri`, with an `https://<instance>/@<user>/<id>` fallback) and pass it to `postStatus`. 
- Add `appendQuoteURLIfNeeded(_:, quoteURL:)` to append the status URL to the post content only when necessary and fall back to including the URL in the content if the API call with `quote_uri`/`quote_id` fails.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a68754e20833287387fdcde5ab26e)