### PR TITLE
Add list management UI and Mastodon list APIs (profile context menu)

### DIFF
--- a/fedi-reader/Views/Profile/FollowingListView.swift
+++ b/fedi-reader/Views/Profile/FollowingListView.swift
@@ -92,10 +92,18 @@ struct FollowingListView: View {
 
 struct AccountRowView: View {
     let account: MastodonAccount
+    @State private var isManagingLists = false
     
     var body: some View {
         HStack(spacing: 12) {
             ProfileAvatarView(url: account.avatarURL, size: 50)
+                .contextMenu {
+                    Button {
+                        isManagingLists = true
+                    } label: {
+                        Label("Manage Lists", systemImage: "list.bullet")
+                    }
+                }
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 4) {
@@ -122,6 +130,9 @@ struct AccountRowView: View {
                 .font(.roundedCaption)
                 .foregroundStyle(.tertiary)
                 .padding(.trailing, 8)
+        }
+        .sheet(isPresented: $isManagingLists) {
+            ListManagementView(account: account)
         }
     }
 }

--- a/fedi-reader/Views/Profile/ListManagementView.swift
+++ b/fedi-reader/Views/Profile/ListManagementView.swift
@@ -1,0 +1,199 @@
+//
+//  ListManagementView.swift
+//  fedi-reader
+//
+//  Manage list membership for an account.
+//
+
+import SwiftUI
+
+struct ListManagementView: View {
+    let account: MastodonAccount
+
+    @Environment(AppState.self) private var appState
+    @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedListIds = Set<String>()
+    @State private var updatingListIds = Set<String>()
+    @State private var isLoading = true
+    @State private var isCreatingList = false
+    @State private var newListTitle = ""
+
+    private var timelineService: TimelineService? {
+        timelineWrapper.service
+    }
+
+    private var lists: [MastodonList] {
+        timelineService?.lists ?? []
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Lists") {
+                    if isLoading {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                            Spacer()
+                        }
+                    } else if lists.isEmpty {
+                        Text("No lists yet.")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(lists) { list in
+                            Toggle(isOn: binding(for: list)) {
+                                Text(list.title)
+                            }
+                            .disabled(updatingListIds.contains(list.id))
+                        }
+                    }
+                }
+
+                Section("Create New List") {
+                    TextField("List name", text: $newListTitle)
+                    Button {
+                        createList()
+                    } label: {
+                        Label("Create & Add", systemImage: "plus")
+                    }
+                    .disabled(newListTitle.trimmed().isEmpty || isCreatingList)
+                }
+            }
+            .navigationTitle("Manage Lists")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .task {
+            await loadListMembership()
+        }
+    }
+
+    private func binding(for list: MastodonList) -> Binding<Bool> {
+        Binding(
+            get: { selectedListIds.contains(list.id) },
+            set: { shouldInclude in
+                Task {
+                    await updateMembership(listId: list.id, shouldInclude: shouldInclude)
+                }
+            }
+        )
+    }
+
+    private func loadListMembership() async {
+        guard let service = timelineService else { return }
+        isLoading = true
+        await service.loadLists()
+        let accountLists = await service.fetchListsContainingAccount(accountId: account.id)
+        selectedListIds = Set(accountLists.map { $0.id })
+        isLoading = false
+    }
+
+    private func updateMembership(listId: String, shouldInclude: Bool) async {
+        guard let service = timelineService else { return }
+        guard !updatingListIds.contains(listId) else { return }
+        updatingListIds.insert(listId)
+
+        let previousValue = selectedListIds.contains(listId)
+        if shouldInclude {
+            selectedListIds.insert(listId)
+        } else {
+            selectedListIds.remove(listId)
+        }
+
+        let success: Bool
+        if shouldInclude {
+            success = await service.addAccount(account.id, toList: listId)
+        } else {
+            success = await service.removeAccount(account.id, fromList: listId)
+        }
+
+        if success {
+            await refreshCurrentListIfNeeded(listId: listId)
+        } else {
+            if previousValue {
+                selectedListIds.insert(listId)
+            } else {
+                selectedListIds.remove(listId)
+            }
+            if let error = service.error {
+                appState.handleError(error)
+            }
+        }
+
+        updatingListIds.remove(listId)
+    }
+
+    private func createList() {
+        guard let service = timelineService else { return }
+        let title = newListTitle.trimmed()
+        guard !title.isEmpty else { return }
+
+        isCreatingList = true
+        Task {
+            let list = await service.createList(title: title)
+            if let list {
+                selectedListIds.insert(list.id)
+                let added = await service.addAccount(account.id, toList: list.id)
+                if !added {
+                    selectedListIds.remove(list.id)
+                }
+                await refreshCurrentListIfNeeded(listId: list.id)
+            }
+
+            if let error = service.error {
+                appState.handleError(error)
+            }
+
+            newListTitle = ""
+            isCreatingList = false
+        }
+    }
+
+    private func refreshCurrentListIfNeeded(listId: String) async {
+        guard let service = timelineService else { return }
+        guard appState.selectedListId == listId else { return }
+        await service.refreshListTimeline(listId: listId)
+        await service.refreshListAccounts(listId: listId)
+    }
+}
+
+private extension String {
+    func trimmed() -> String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+#Preview {
+    ListManagementView(
+        account: MastodonAccount(
+            id: "1",
+            username: "user",
+            acct: "user@example.com",
+            displayName: "Example User",
+            locked: false,
+            bot: false,
+            createdAt: Date(),
+            note: "",
+            url: "https://example.com/@user",
+            avatar: "",
+            avatarStatic: "",
+            header: "",
+            headerStatic: "",
+            followersCount: 0,
+            followingCount: 0,
+            statusesCount: 0,
+            lastStatusAt: Date(),
+            emojis: [],
+            fields: []
+        )
+    )
+    .environment(AppState())
+    .environment(TimelineServiceWrapper())
+}

--- a/fedi-reader/Views/Profile/ProfileDetailView.swift
+++ b/fedi-reader/Views/Profile/ProfileDetailView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProfileDetailView: View {
     let account: MastodonAccount
     @Environment(AppState.self) private var appState
+    @State private var isManagingLists = false
 
     var body: some View {
         ScrollView {
@@ -45,6 +46,13 @@ struct ProfileDetailView: View {
                         .offset(y: account.headerURL != nil ? -40 : 0)
                         .padding(.bottom, account.headerURL != nil ? -40 : 0)
                         .padding(.top, account.headerURL != nil ? 0 : 16)
+                        .contextMenu {
+                            Button {
+                                isManagingLists = true
+                            } label: {
+                                Label("Manage Lists", systemImage: "list.bullet")
+                            }
+                        }
 
                     VStack(spacing: 4) {
                         HStack(spacing: 4) {
@@ -91,6 +99,9 @@ struct ProfileDetailView: View {
         .contentMargins(.top, 0, for: .scrollContent)
         .ignoresSafeArea(edges: .top)
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $isManagingLists) {
+            ListManagementView(account: account)
+        }
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text(account.displayName)


### PR DESCRIPTION
### Motivation

- Implement list management so users can long-press a profile avatar to add/remove that account from any of their Mastodon lists or create a new list, and have the active feed update accordingly.
- Provide client and service APIs to create lists and modify list membership required by the UI.

### Description

- Added form URL-encoding helper and new Mastodon list endpoints in `MastodonClient`: `getAccountLists`, `createList`, `addAccountsToList`, and `removeAccountsFromList`, plus `formEncodedBody` for `application/x-www-form-urlencoded` request bodies (`Services/MastodonClient.swift`).
- Extended `TimelineService` with helpers to fetch lists containing a given account (`fetchListsContainingAccount`), create a list and update the local `lists` cache (`createList`), and add/remove a single account from a list (`addAccount` / `removeAccount`) with error handling and logging (`Services/TimelineService.swift`).
- Added a new SwiftUI sheet `ListManagementView` that loads the current user lists, shows toggles for membership, supports creating a new list and adding the account to it, and refreshes the current list timeline/accounts when membership changes (`Views/Profile/ListManagementView.swift`).
- Exposed the list-management sheet from profile UI by adding a context menu entry on avatars in `ProfileDetailView` and `FollowingListView` so users can long-press the avatar to open `ListManagementView` (`Views/Profile/ProfileDetailView.swift`, `Views/Profile/FollowingListView.swift`).

### Testing

- No automated tests were run as part of this change; unit/UI test suites were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a688d599c83328f985019a0502943)