### PR TITLE
Add list management access via feed rows and profile navigation

### DIFF
--- a/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
@@ -24,12 +24,12 @@ struct LinkStatusRow: View {
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
 
-    @State private var isShowingActions = false
     @State private var blueskyDescription: String?
     @State private var hasLoadedBlueskyDescription = false
     @State private var resolvedMastodonAccount: MastodonAccount?
     @State private var isProcessing = false
     @State private var localBookmarked: Bool?
+    @State private var isManagingLists = false
 
     private var themeColor: Color {
         ThemeColor(rawValue: themeColorName)?.color ?? .blue
@@ -95,6 +95,9 @@ struct LinkStatusRow: View {
                 localBookmarked = updated.bookmarked
             }
         }
+        .sheet(isPresented: $isManagingLists) {
+            ListManagementView(account: linkStatus.status.displayStatus.account)
+        }
         .task(id: blueskyCardURL?.absoluteString) {
             guard let url = blueskyCardURL, !hasLoadedBlueskyDescription else { return }
             hasLoadedBlueskyDescription = true
@@ -150,7 +153,14 @@ struct LinkStatusRow: View {
 
     private var authorHeader: some View {
         HStack(spacing: 10) {
-            ProfileAvatarView(url: linkStatus.status.displayStatus.account.avatarURL, size: Constants.UI.avatarSize)
+            Button {
+                deferPostNavigation {
+                    appState.navigate(to: .profile(linkStatus.status.displayStatus.account))
+                }
+            } label: {
+                ProfileAvatarView(url: linkStatus.status.displayStatus.account.avatarURL, size: Constants.UI.avatarSize)
+            }
+            .buttonStyle(.plain)
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
@@ -541,6 +551,12 @@ struct LinkStatusRow: View {
             appState.present(sheet: .compose(quote: linkStatus.status))
         } label: {
             Label("Quote", systemImage: "quote.bubble")
+        }
+
+        Button {
+            isManagingLists = true
+        } label: {
+            Label("Manage Lists", systemImage: "list.bullet")
         }
     }
     

--- a/fedi-reader/Views/Feed/StatusRowView.swift
+++ b/fedi-reader/Views/Feed/StatusRowView.swift
@@ -26,6 +26,7 @@ struct StatusRowView: View {
     @State private var fediverseCreatorURL: URL?
     @State private var isProcessing = false
     @State private var localBookmarked: Bool?
+    @State private var isManagingLists = false
     
     var displayStatus: Status {
         status.displayStatus
@@ -95,6 +96,9 @@ struct StatusRowView: View {
             if updated.id == displayStatus.id {
                 localBookmarked = updated.bookmarked
             }
+        }
+        .sheet(isPresented: $isManagingLists) {
+            ListManagementView(account: displayStatus.account)
         }
     }
     
@@ -190,30 +194,30 @@ struct StatusRowView: View {
                 ProfileAvatarView(url: displayStatus.account.avatarURL, size: Constants.UI.avatarSize)
             }
             .buttonStyle(.plain)
-            
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 4) {
-                        Text(displayStatus.account.displayName)
-                            .font(.roundedSubheadline.bold())
-                            .lineLimit(1)
-                    
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(displayStatus.account.displayName)
+                        .font(.roundedSubheadline.bold())
+                        .lineLimit(1)
+
                     AccountBadgesView(account: displayStatus.account, size: .small)
                 }
-                    if showHandleInFeed {
-                        Text("@\(displayStatus.account.acct)")
-                            .font(.roundedCaption)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
+                if showHandleInFeed {
+                    Text("@\(displayStatus.account.acct)")
+                        .font(.roundedCaption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
-            
+
             Spacer()
-            
+
             VStack(alignment: .trailing, spacing: 2) {
                 Text(TimeFormatter.relativeTimeString(from: displayStatus.createdAt))
                     .font(.roundedCaption)
                     .foregroundStyle(.tertiary)
-                
+
                 if displayStatus.visibility != .public {
                     Image(systemName: visibilityIcon)
                         .font(.roundedCaption2)
@@ -602,6 +606,12 @@ struct StatusRowView: View {
             appState.present(sheet: .compose(quote: status))
         } label: {
             Label("Quote", systemImage: "quote.bubble")
+        }
+        
+        Button {
+            isManagingLists = true
+        } label: {
+            Label("Manage Lists", systemImage: "list.bullet")
         }
         
         // Share and Copy Link (if URL available)

--- a/fedi-reader/Views/Profile/FollowersListView.swift
+++ b/fedi-reader/Views/Profile/FollowersListView.swift
@@ -20,17 +20,17 @@ struct FollowersListView: View {
     var body: some View {
         Group {
             if !accounts.isEmpty {
-                List(accounts) { account in
-                    NavigationLink {
-                        ProfileDetailView(account: account)
-                    } label: {
-                        AccountRowView(account: account)
+                List(accounts) { listedAccount in
+                    AccountRowView(account: listedAccount)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        appState.navigate(to: .profile(listedAccount))
                     }
                     .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
                     .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
                     .onAppear {
-                        if account.id == accounts.last?.id {
+                        if listedAccount.id == accounts.last?.id {
                             loadMore()
                         }
                     }

--- a/fedi-reader/Views/Profile/FollowingListView.swift
+++ b/fedi-reader/Views/Profile/FollowingListView.swift
@@ -20,17 +20,17 @@ struct FollowingListView: View {
     var body: some View {
         Group {
             if !accounts.isEmpty {
-                List(accounts) { account in
-                    NavigationLink {
-                        ProfileDetailView(account: account)
-                    } label: {
-                        AccountRowView(account: account)
+                List(accounts) { listedAccount in
+                    AccountRowView(account: listedAccount)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        appState.navigate(to: .profile(listedAccount))
                     }
                     .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
                     .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
                     .onAppear {
-                        if account.id == accounts.last?.id {
+                        if listedAccount.id == accounts.last?.id {
                             loadMore()
                         }
                     }
@@ -92,18 +92,10 @@ struct FollowingListView: View {
 
 struct AccountRowView: View {
     let account: MastodonAccount
-    @State private var isManagingLists = false
     
     var body: some View {
         HStack(spacing: 12) {
             ProfileAvatarView(url: account.avatarURL, size: 50)
-                .contextMenu {
-                    Button {
-                        isManagingLists = true
-                    } label: {
-                        Label("Manage Lists", systemImage: "list.bullet")
-                    }
-                }
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 4) {
@@ -130,9 +122,6 @@ struct AccountRowView: View {
                 .font(.roundedCaption)
                 .foregroundStyle(.tertiary)
                 .padding(.trailing, 8)
-        }
-        .sheet(isPresented: $isManagingLists) {
-            ListManagementView(account: account)
         }
     }
 }

--- a/fedi-reader/Views/Profile/ListManagementView.swift
+++ b/fedi-reader/Views/Profile/ListManagementView.swift
@@ -189,7 +189,7 @@ private extension String {
             followersCount: 0,
             followingCount: 0,
             statusesCount: 0,
-            lastStatusAt: Date(),
+            lastStatusAt: nil,
             emojis: [],
             fields: []
         )

--- a/fedi-reader/Views/Profile/ProfileDetailView.swift
+++ b/fedi-reader/Views/Profile/ProfileDetailView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ProfileDetailView: View {
     let account: MastodonAccount
     @Environment(AppState.self) private var appState
-    @State private var isManagingLists = false
 
     var body: some View {
         ScrollView {
@@ -46,13 +45,6 @@ struct ProfileDetailView: View {
                         .offset(y: account.headerURL != nil ? -40 : 0)
                         .padding(.bottom, account.headerURL != nil ? -40 : 0)
                         .padding(.top, account.headerURL != nil ? 0 : 16)
-                        .contextMenu {
-                            Button {
-                                isManagingLists = true
-                            } label: {
-                                Label("Manage Lists", systemImage: "list.bullet")
-                            }
-                        }
 
                     VStack(spacing: 4) {
                         HStack(spacing: 4) {
@@ -99,9 +91,6 @@ struct ProfileDetailView: View {
         .contentMargins(.top, 0, for: .scrollContent)
         .ignoresSafeArea(edges: .top)
         .navigationBarTitleDisplayMode(.inline)
-        .sheet(isPresented: $isManagingLists) {
-            ListManagementView(account: account)
-        }
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text(account.displayName)


### PR DESCRIPTION
## Summary
- add a Manage Lists sheet trigger to feed status rows and wire avatar taps to profile navigation
- simplify follower/following list navigation so tapping rows navigates without extra buttons
- update ListManagementView preview data and bump project version metadata to 49

## Testing
- Not run (not requested)