### PR TITLE
Allow list preview to handle missing last status

### DIFF
--- a/fedi-reader/Views/Profile/ListManagementView.swift
+++ b/fedi-reader/Views/Profile/ListManagementView.swift
@@ -189,9 +189,10 @@ private extension String {
             followersCount: 0,
             followingCount: 0,
             statusesCount: 0,
-            lastStatusAt: Date(),
+            lastStatusAt: nil,
             emojis: [],
-            fields: []
+            fields: [],
+            source: nil
         )
     )
     .environment(AppState())


### PR DESCRIPTION
## Summary
- stop providing a `Date` where the preview expects a `String` by letting `lastStatusAt` be nil
- add missing dummy fields to keep the preview data consistent

## Testing
- Not run (not requested)