### PR TITLE
Remove primary and secondary theme colors

### DIFF
--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -144,8 +144,6 @@ enum ThemeColor: String, CaseIterable {
     case gray
     case black
     case white
-    case primary
-    case secondary
     
     var displayName: String {
         rawValue.capitalized
@@ -168,8 +166,6 @@ enum ThemeColor: String, CaseIterable {
         case .gray: return .gray
         case .black: return .black
         case .white: return .white
-        case .primary: return .primary
-        case .secondary: return .secondary
         }
     }
 }


### PR DESCRIPTION
Summary
- delete the unused Primary and Secondary options from the theme color enum so they no longer appear in the picker
- keep the available color set limited to the actual supported colors

Testing
- Not run (not requested)