### PR TITLE
Rename Mentions tab to Messages

### DIFF
--- a/fedi-reader/Models/CachedStatus.swift
+++ b/fedi-reader/Models/CachedStatus.swift
@@ -86,7 +86,7 @@ enum TimelineType: String, CaseIterable, Sendable {
     var displayName: String {
         switch self {
         case .home: return "Home"
-        case .mentions: return "Mentions"
+        case .mentions: return "Messages"
         case .explore: return "Explore"
         case .links: return "Links"
         }

--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -174,7 +174,7 @@ enum AppTab: String, CaseIterable, Identifiable {
         switch self {
         case .links: return "Home"
         case .explore: return "Explore"
-        case .mentions: return "Mentions"
+        case .mentions: return "Messages"
         case .profile: return "Profile"
         }
     }

--- a/fedi-reader/Views/Root/MainTabView.swift
+++ b/fedi-reader/Views/Root/MainTabView.swift
@@ -2,7 +2,7 @@
 //  MainTabView.swift
 //  fedi-reader
 //
-//  Main tab navigation with Home, Explore, Mentions, Profile.
+//  Main tab navigation with Home, Explore, Messages, Profile.
 //
 
 import SwiftUI
@@ -53,7 +53,7 @@ struct MainTabView: View {
                 }
             }
 
-            Tab(hideTabBarLabels ? "" : "Mentions", systemImage: "at", value: .mentions) {
+            Tab(hideTabBarLabels ? "" : "Messages", systemImage: "at", value: .mentions) {
                 NavigationStack {
                     MentionsView()
                         .navigationDestination(for: NavigationDestination.self) { destination in

--- a/fedi-readerTests/fedi_readerTests.swift
+++ b/fedi-readerTests/fedi_readerTests.swift
@@ -75,6 +75,11 @@ struct TimelineTypeTests {
         #expect(types.contains(.explore))
         #expect(types.contains(.links))
     }
+    
+    @Test("Mentions timeline uses Messages display name")
+    func mentionsTimelineUsesMessagesDisplayName() {
+        #expect(TimelineType.mentions.displayName == "Messages")
+    }
 }
 
 // MARK: - App Tab Tests
@@ -104,6 +109,11 @@ struct AppTabTests {
         #expect(tabs.contains(.explore))
         #expect(tabs.contains(.mentions))
         #expect(tabs.contains(.profile))
+    }
+    
+    @Test("Mentions tab uses Messages title")
+    func mentionsTabUsesMessagesTitle() {
+        #expect(AppTab.mentions.title == "Messages")
     }
 }
 


### PR DESCRIPTION
**Summary**
- update `TimelineType` display name and `AppTab` title from “Mentions” to “Messages” to match the view title
- refresh the main tab view label and add tests verifying the new wording for timeline and tab enums

**Testing**
- Not run (not requested)