### PR TITLE
Show theme color previews in picker

### DIFF
--- a/fedi-readerTests/ThemeColorTests.swift
+++ b/fedi-readerTests/ThemeColorTests.swift
@@ -1,0 +1,40 @@
+//
+//  ThemeColorTests.swift
+//  fedi-readerTests
+//
+//  Unit tests for theme color preview behavior.
+//
+
+import Testing
+@testable import fedi_reader
+
+@Suite("Theme Color Tests")
+struct ThemeColorTests {
+    
+    @Test("Light theme colors use contrast stroke in preview")
+    func lightThemeColorsUseContrastStroke() {
+        let lightColors: [ThemeColor] = [.yellow, .mint, .cyan]
+        
+        for color in lightColors {
+            #expect(color.requiresContrastStrokeInPreview == true)
+        }
+    }
+    
+    @Test("Non-light theme colors do not use contrast stroke in preview")
+    func nonLightThemeColorsDoNotUseContrastStroke() {
+        let lightColors: Set<ThemeColor> = [.yellow, .mint, .cyan]
+        
+        for color in ThemeColor.allCases where !lightColors.contains(color) {
+            #expect(color.requiresContrastStrokeInPreview == false)
+        }
+    }
+    
+    @Test("Theme colors do not include black or white")
+    func themeColorsDoNotIncludeBlackOrWhite() {
+        let rawValues = Set(ThemeColor.allCases.map(\.rawValue))
+        
+        #expect(rawValues.contains("black") == false)
+        #expect(rawValues.contains("white") == false)
+        #expect(rawValues.contains("blue") == true)
+    }
+}


### PR DESCRIPTION
Summary
- replace the inline theme color picker with a navigation destination that lists tappable rows per color
- add a circular preview that handles contrast strokes and remove the legacy black/white options
- surface the current selection in Settings with the new preview badge

Testing
- Not run (not requested)