### PR TITLE
Fix theme color refresh in Settings

### DIFF
--- a/fedi-reader/App/FediReaderApp.swift
+++ b/fedi-reader/App/FediReaderApp.swift
@@ -41,7 +41,7 @@ struct FediReaderApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .tint(ThemeColor(rawValue: themeColorName)?.color ?? .blue)
+                .tint(ThemeColor.resolved(from: themeColorName).color)
         }
         .modelContainer(sharedModelContainer)
         

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -25,6 +25,10 @@ struct SettingsView: View {
         timelineWrapper.service?.lists ?? []
     }
     
+    private var selectedThemeColor: Color {
+        ThemeColor.resolved(from: themeColorName).color
+    }
+    
     var body: some View {
         List {
             // Display
@@ -40,14 +44,10 @@ struct SettingsView: View {
                     HStack {
                         Text("Theme Color")
                         Spacer()
-                        if let selectedColor = ThemeColor(rawValue: themeColorName) {
-                            ThemeColorPreviewCircle(themeColor: selectedColor)
-                            Text(selectedColor.displayName)
-                                .foregroundStyle(.secondary)
-                        } else {
-                            Text(themeColorName.capitalized)
-                                .foregroundStyle(.secondary)
-                        }
+                        let selectedColor = ThemeColor.resolved(from: themeColorName)
+                        ThemeColorPreviewCircle(themeColor: selectedColor)
+                        Text(selectedColor.displayName)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }
@@ -128,6 +128,9 @@ struct SettingsView: View {
             #endif
         }
         .navigationTitle("Settings")
+        .tint(selectedThemeColor)
+        // Rebuild row styling when theme changes so text updates immediately.
+        .id("settings-theme-\(themeColorName)")
     }
 }
 
@@ -161,6 +164,10 @@ private struct ThemeColorPreviewCircle: View {
 private struct ThemeColorSelectionView: View {
     @Binding var selection: String
     
+    private var selectedThemeColor: Color {
+        ThemeColor.resolved(from: selection).color
+    }
+    
     var body: some View {
         List {
             ForEach(ThemeColor.allCases, id: \.rawValue) { color in
@@ -183,6 +190,7 @@ private struct ThemeColorSelectionView: View {
             }
         }
         .navigationTitle("Theme Color")
+        .tint(selectedThemeColor)
     }
 }
 
@@ -230,6 +238,10 @@ enum ThemeColor: String, CaseIterable {
         default:
             return false
         }
+    }
+    
+    static func resolved(from rawValue: String) -> ThemeColor {
+        ThemeColor(rawValue: rawValue) ?? .blue
     }
 }
 

--- a/fedi-readerTests/ThemeColorTests.swift
+++ b/fedi-readerTests/ThemeColorTests.swift
@@ -37,4 +37,15 @@ struct ThemeColorTests {
         #expect(rawValues.contains("white") == false)
         #expect(rawValues.contains("blue") == true)
     }
+    
+    @Test("Theme resolver returns matching color for valid value")
+    func resolverReturnsMatchingThemeColor() {
+        #expect(ThemeColor.resolved(from: "mint") == .mint)
+        #expect(ThemeColor.resolved(from: "purple") == .purple)
+    }
+    
+    @Test("Theme resolver falls back to blue for unknown value")
+    func resolverFallsBackToBlue() {
+        #expect(ThemeColor.resolved(from: "not-a-theme-color") == .blue)
+    }
 }


### PR DESCRIPTION
Summary
- ensure theme resolver always returns a valid color and apply it in the app/root tinting
- rebuild the settings view when the theme name changes so the preview text and tint update immediately
- add tests for the new ThemeColor resolver helper

Testing
- Not run (not requested)