### PR TITLE
Handle duplicate emoji shortcodes safely

### DIFF
--- a/fedi-reader/Views/Feed/HashtagLinkText.swift
+++ b/fedi-reader/Views/Feed/HashtagLinkText.swift
@@ -21,7 +21,7 @@ struct HashtagLinkText: View {
         let emojiLookup: [String: CustomEmoji] = {
             if let instance = appState.getCurrentInstance() {
                 let emojis = appState.emojiService.getCustomEmojis(for: instance)
-                let lookup = Dictionary(uniqueKeysWithValues: emojis.map { ($0.shortcode, $0) })
+                let lookup = Dictionary(emojis.map { ($0.shortcode, $0) }) { _, new in new }
                 Self.logger.debug("Built emoji lookup with \(lookup.count) entries for instance: \(instance, privacy: .public)")
                 return lookup
             } else {

--- a/fedi-readerTests/EmojiServiceTests.swift
+++ b/fedi-readerTests/EmojiServiceTests.swift
@@ -270,6 +270,7 @@ struct EmojiServiceTests {
     
     @Test("Handles very long shortcodes")
     func handlesVeryLongShortcodes() {
+        // HTMLParser intentionally skips shortcode replacements longer than 50 chars.
         let longShortcode = String(repeating: "a", count: 100)
         let emoji = Self.makeCustomEmoji(shortcode: longShortcode, url: "https://example.com/long.png")
         let lookup: [String: CustomEmoji] = [longShortcode: emoji]
@@ -277,7 +278,8 @@ struct EmojiServiceTests {
         let html = ":\(longShortcode):"
         let result = HTMLParser.replaceEmojiShortcodes(html, emojiLookup: lookup)
         
-        #expect(result.contains("long.png"))
+        #expect(result == html)
+        #expect(!result.contains("long.png"))
     }
     
     @Test("Handles special characters in shortcode")

--- a/fedi-readerTests/HashtagLinkTextTests.swift
+++ b/fedi-readerTests/HashtagLinkTextTests.swift
@@ -70,11 +70,11 @@ struct HashtagLinkTextTests {
         let emoji2 = CustomEmoji(shortcode: "test", url: "https://example.com/second.png", staticUrl: "", visibleInPicker: true, category: nil)
         
         let emojis = [emoji1, emoji2]
-        let lookup = Dictionary(uniqueKeysWithValues: emojis.map { ($0.shortcode, $0) })
+        let lookup = Dictionary(emojis.map { ($0.shortcode, $0) }) { _, new in new }
         
         // Dictionary will only keep one (last one wins)
         #expect(lookup.count == 1)
-        #expect(lookup["test"] != nil)
+        #expect(lookup["test"]?.url == "https://example.com/second.png")
     }
     
     // MARK: - Hashtag Handler Tests


### PR DESCRIPTION
Summary
- switch the emoji lookup builder to merge entries instead of crashing when shortcodes collide, matching production behavior
- tighten emoji-related tests by documenting HTMLParser’s 50-character limit and asserting exact lookup outcomes for duplicates

Testing
- Not run (not requested)