### PR TITLE
Fix Instapaper save flow and alerts

### DIFF
--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -86,6 +86,12 @@ final class AppState {
                 message: message
             )
             Self.logger.info("Presented error alert: \(title, privacy: .public)")
+        } else {
+            presentedAlert = AlertItem(
+                title: "Error",
+                message: error.localizedDescription
+            )
+            Self.logger.info("Presented generic error alert")
         }
     }
     

--- a/fedi-reader/Services/ReadLater/ReadLaterManager.swift
+++ b/fedi-reader/Services/ReadLater/ReadLaterManager.swift
@@ -132,7 +132,9 @@ final class ReadLaterManager {
             NotificationCenter.default.post(name: .readLaterDidSave, object: result)
         } catch {
             Self.logger.error("Failed to save to \(serviceType.rawValue, privacy: .public): \(error.localizedDescription)")
-            lastSaveResult = .failure(url: url, service: serviceType, error: error)
+            let failure = ReadLaterSaveResult.failure(url: url, service: serviceType, error: error)
+            lastSaveResult = failure
+            NotificationCenter.default.post(name: .readLaterDidSave, object: failure)
             throw error
         }
     }

--- a/fedi-reader/Utilities/Constants.swift
+++ b/fedi-reader/Utilities/Constants.swift
@@ -110,7 +110,7 @@ enum Constants {
         
         // Instapaper
         static let instapaperAuthURL = "https://www.instapaper.com/api/1/oauth/access_token"
-        static let instapaperAddURL = "https://www.instapaper.com/api/1/bookmarks/add"
+        static let instapaperAddURL = "https://www.instapaper.com/api/add"
         
         // Omnivore
         static let omnivoreAPIURL = "https://api-prod.omnivore.app/api/graphql"

--- a/fedi-reader/Views/Auth/ReadLaterLoginView.swift
+++ b/fedi-reader/Views/Auth/ReadLaterLoginView.swift
@@ -232,7 +232,7 @@ struct ReadLaterLoginView: View {
                 }
                 
             case .instapaper:
-                // Store credentials (simplified - real implementation needs xAuth)
+                // Store credentials for Instapaper basic-auth save endpoint
                 try await readLaterManager.configureService(
                     .instapaper,
                     token: "\(username):\(password)",

--- a/fedi-reader/Views/Root/ContentView.swift
+++ b/fedi-reader/Views/Root/ContentView.swift
@@ -42,6 +42,10 @@ struct ContentView: View {
         .onOpenURL { url in
             handleOpenURL(url)
         }
+        .onReceive(NotificationCenter.default.publisher(for: .readLaterDidSave)) { notification in
+            guard let result = notification.object as? ReadLaterSaveResult else { return }
+            handleReadLaterSaveResult(result)
+        }
         .sheet(item: $appState.presentedSheet) { sheet in
             sheetContent(for: sheet)
         }
@@ -96,6 +100,26 @@ struct ContentView: View {
                     appState.handleError(error)
                 }
             }
+        }
+    }
+    
+    private func handleReadLaterSaveResult(_ result: ReadLaterSaveResult) {
+        if result.success {
+            let message = result.url.host ?? result.url.absoluteString
+            appState.presentedAlert = AlertItem(
+                title: "Saved to \(result.serviceType.displayName)",
+                message: message
+            )
+            return
+        }
+        
+        if let error = result.error {
+            appState.handleError(error)
+        } else {
+            appState.presentedAlert = AlertItem(
+                title: "Save Failed",
+                message: "Could not save to \(result.serviceType.displayName)"
+            )
         }
     }
 

--- a/fedi-readerTests/AppStateTests.swift
+++ b/fedi-readerTests/AppStateTests.swift
@@ -9,6 +9,12 @@ import Testing
 import Foundation
 @testable import fedi_reader
 
+private struct GenericTestError: LocalizedError {
+    var errorDescription: String? {
+        "Something went wrong"
+    }
+}
+
 @Suite("AppState Tests")
 @MainActor
 struct AppStateTests {
@@ -53,5 +59,15 @@ struct AppStateTests {
         #expect(state.userFilterPerFeedId["home"] == "a1")
         #expect(state.userFilterPerFeedId["list-1"] == nil)
         #expect(state.userFilterPerFeedId["list-2"] == "a3")
+    }
+    
+    @Test("handleError shows alert for non-FediReaderError values")
+    func handleErrorShowsGenericAlert() async {
+        let state = AppState()
+        
+        state.handleError(GenericTestError())
+        
+        #expect(state.presentedAlert?.title == "Error")
+        #expect(state.presentedAlert?.message == "Something went wrong")
     }
 }

--- a/fedi-readerTests/MockServices.swift
+++ b/fedi-readerTests/MockServices.swift
@@ -188,6 +188,7 @@ enum MockStatusFactory {
 class MockURLProtocol: URLProtocol {
     static var mockResponses: [String: (Data, HTTPURLResponse)] = [:]
     static var mockErrors: [String: Error] = [:]
+    static var lastRequest: URLRequest?
     
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -198,6 +199,8 @@ class MockURLProtocol: URLProtocol {
     }
     
     override func startLoading() {
+        Self.lastRequest = request
+        
         guard let url = request.url?.absoluteString else {
             client?.urlProtocolDidFinishLoading(self)
             return
@@ -221,6 +224,7 @@ class MockURLProtocol: URLProtocol {
     static func reset() {
         mockResponses.removeAll()
         mockErrors.removeAll()
+        lastRequest = nil
     }
     
     static func setMockResponse(for url: String, data: Data, statusCode: Int = 200) {

--- a/fedi-readerTests/ReadLaterTests.swift
+++ b/fedi-readerTests/ReadLaterTests.swift
@@ -1,0 +1,174 @@
+//
+//  ReadLaterTests.swift
+//  fedi-readerTests
+//
+//  Read-later manager and Instapaper integration tests
+//
+
+import Testing
+import Foundation
+@testable import fedi_reader
+
+private final class InstapaperMockURLProtocol: URLProtocol {
+    static var responseData = Data()
+    static var statusCode = 201
+    static var lastRequest: URLRequest?
+    static var lastRequestBody: Data?
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+    
+    override func startLoading() {
+        Self.lastRequest = request
+        Self.lastRequestBody = request.httpBody ?? requestBodyData(from: request.httpBodyStream)
+        
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://example.com")!,
+            statusCode: Self.statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    
+    override func stopLoading() {}
+    
+    static func reset() {
+        responseData = Data()
+        statusCode = 201
+        lastRequest = nil
+        lastRequestBody = nil
+    }
+    
+    private func requestBodyData(from stream: InputStream?) -> Data? {
+        guard let stream else { return nil }
+        
+        stream.open()
+        defer { stream.close() }
+        
+        var data = Data()
+        let bufferSize = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        
+        while stream.hasBytesAvailable {
+            let bytesRead = stream.read(buffer, maxLength: bufferSize)
+            if bytesRead > 0 {
+                data.append(buffer, count: bytesRead)
+            } else {
+                break
+            }
+        }
+        
+        return data.isEmpty ? nil : data
+    }
+}
+
+private actor NotificationResultStore {
+    private(set) var result: ReadLaterSaveResult?
+    
+    func set(_ newValue: ReadLaterSaveResult?) {
+        result = newValue
+    }
+}
+
+@Suite("Read Later Manager Tests")
+@MainActor
+struct ReadLaterManagerTests {
+    @Test("save posts failure notification when service is not configured")
+    func savePostsFailureNotificationWhenServiceMissing() async {
+        let manager = ReadLaterManager()
+        let articleURL = URL(string: "https://example.com/article")!
+        let resultStore = NotificationResultStore()
+        
+        let observer = NotificationCenter.default.addObserver(
+            forName: .readLaterDidSave,
+            object: nil,
+            queue: nil
+        ) { notification in
+            Task {
+                await resultStore.set(notification.object as? ReadLaterSaveResult)
+            }
+        }
+        
+        defer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        
+        do {
+            try await manager.save(url: articleURL, title: "Example", to: .instapaper)
+            Issue.record("Expected save to throw when Instapaper is not configured")
+        } catch {
+            // Expected path
+        }
+        
+        let receivedResult = await resultStore.result
+        #expect(receivedResult != nil)
+        #expect(receivedResult?.success == false)
+        #expect(receivedResult?.serviceType == .instapaper)
+        #expect(receivedResult?.url == articleURL)
+    }
+}
+
+@Suite("Instapaper Service Tests")
+@MainActor
+struct InstapaperServiceTests {
+    @Test("save uses basic auth credentials and Instapaper add endpoint")
+    func saveUsesBasicAuthCredentials() async throws {
+        InstapaperMockURLProtocol.reset()
+        defer {
+            InstapaperMockURLProtocol.reset()
+        }
+        
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.protocolClasses = [InstapaperMockURLProtocol.self]
+        let session = URLSession(configuration: sessionConfiguration)
+        
+        let config = ReadLaterConfig(serviceType: ReadLaterServiceType.instapaper.rawValue)
+        let service = InstapaperService(
+            config: config,
+            keychain: .shared,
+            session: session,
+            loadStoredCredentials: false
+        )
+        
+        try await service.authenticateWithCredentials(
+            username: "user@example.com",
+            password: "pass:word",
+            persistCredentials: false
+        )
+        
+        try await service.save(
+            url: URL(string: "https://example.com/path?a=1")!,
+            title: "Example & Title"
+        )
+        
+        guard let request = InstapaperMockURLProtocol.lastRequest else {
+            Issue.record("Expected Instapaper request to be captured")
+            return
+        }
+        
+        #expect(request.url?.absoluteString == Constants.ReadLater.instapaperAddURL)
+        
+        let expectedHeader = "Basic \(Data("user@example.com:pass:word".utf8).base64EncodedString())"
+        #expect(request.value(forHTTPHeaderField: "Authorization") == expectedHeader)
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        
+        guard let bodyData = InstapaperMockURLProtocol.lastRequestBody,
+              let bodyString = String(data: bodyData, encoding: .utf8) else {
+            Issue.record("Expected request body for Instapaper save")
+            return
+        }
+        
+        #expect(bodyString.contains("url=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1"))
+        #expect(bodyString.contains("title=Example%20%26%20Title"))
+    }
+}


### PR DESCRIPTION
## Summary
- improve AppState error handling so generic failures show an alert
- add read-later notifications and UI handling so saves surface success/failure feedback
- update Instapaper service to use basic auth, new endpoint, credential storage, and extra error messaging

## Testing
- Not run (not requested)