### PR TITLE
Fix tag overflow and link metadata handling

### DIFF
--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -344,10 +344,7 @@ final class LinkFilterService {
             let targetStatus = status.displayStatus
             
             guard !isQuotePost(targetStatus) else { continue }
-            var tags = TagExtractor.deduplicateCaseInsensitive(targetStatus.tags.map(\.name))
-            if tags.isEmpty {
-                tags = TagExtractor.extractTags(from: targetStatus.content)
-            }
+            let tags = TagExtractor.extractTags(from: targetStatus)
             
             if let card = targetStatus.card,
                card.type == .link,
@@ -501,7 +498,7 @@ struct LinkStatus: Identifiable, Hashable, Sendable {
     }
     
     var displayDescription: String? {
-        description ?? status.displayStatus.content.htmlStripped
+        description
     }
     
     var domain: String {

--- a/fedi-readerTests/LinkFilterServiceTests.swift
+++ b/fedi-readerTests/LinkFilterServiceTests.swift
@@ -170,6 +170,28 @@ struct LinkFilterServiceTests {
         let normalizedTags = Set((linkStatuses.first?.tags ?? []).map { $0.lowercased() })
         #expect(normalizedTags == Set(["ios", "swift"]))
     }
+
+    @Test("Preserves original hashtag case from post content")
+    func preservesOriginalHashtagCaseFromPostContent() async {
+        let status = MockStatusFactory.makeStatus(
+            id: "1",
+            content: "<p>#SwiftUI #OpenAI</p>",
+            hasCard: true,
+            cardURL: "https://example.com/article",
+            tags: [
+                Tag(name: "swiftui", url: "https://mastodon.social/tags/swiftui", history: nil),
+                Tag(name: "openai", url: "https://mastodon.social/tags/openai", history: nil)
+            ]
+        )
+
+        let linkStatuses = await service.processStatuses([status])
+
+        #expect(linkStatuses.count == 1)
+        #expect(linkStatuses.first?.tags.contains("SwiftUI") == true)
+        #expect(linkStatuses.first?.tags.contains("OpenAI") == true)
+        #expect(linkStatuses.first?.tags.contains("swiftui") == false)
+        #expect(linkStatuses.first?.tags.contains("openai") == false)
+    }
     
     // MARK: - Threads/Instagram Exclusion
     

--- a/fedi-readerTests/TagViewLayoutTests.swift
+++ b/fedi-readerTests/TagViewLayoutTests.swift
@@ -1,0 +1,64 @@
+//
+//  TagViewLayoutTests.swift
+//  fedi-readerTests
+//
+//  Tests for TagView collapsed tag partitioning logic.
+//
+
+import CoreGraphics
+import Testing
+@testable import fedi_reader
+
+@Suite("Tag View Layout Tests")
+struct TagViewLayoutTests {
+    @Test("Returns all tags when width is unavailable")
+    func returnsAllTagsWhenWidthUnavailable() {
+        let tags = ["swift", "ios", "fedi"]
+        let partition = TagView.partitionTags(
+            tags,
+            availableWidth: 0,
+            measuredTagSizes: [:]
+        )
+
+        #expect(partition.visible == tags)
+        #expect(partition.hidden.isEmpty)
+    }
+
+    @Test("Reserves room for +N button in collapsed row")
+    func reservesRoomForMoreButton() {
+        let tags = ["swift", "ios", "fedi"]
+        let sizes: [String: CGSize] = [
+            "swift": CGSize(width: 50, height: 24),
+            "ios": CGSize(width: 50, height: 24),
+            "fedi": CGSize(width: 50, height: 24)
+        ]
+
+        let partition = TagView.partitionTags(
+            tags,
+            availableWidth: 120,
+            measuredTagSizes: sizes
+        )
+
+        #expect(partition.visible == ["swift"])
+        #expect(partition.hidden == ["ios", "fedi"])
+    }
+
+    @Test("Keeps first tag visible on extremely narrow widths")
+    func keepsFirstTagVisibleOnNarrowWidths() {
+        let tags = ["swift", "ios", "fedi"]
+        let sizes: [String: CGSize] = [
+            "swift": CGSize(width: 50, height: 24),
+            "ios": CGSize(width: 50, height: 24),
+            "fedi": CGSize(width: 50, height: 24)
+        ]
+
+        let partition = TagView.partitionTags(
+            tags,
+            availableWidth: 20,
+            measuredTagSizes: sizes
+        )
+
+        #expect(partition.visible == ["swift"])
+        #expect(partition.hidden == ["ios", "fedi"])
+    }
+}

--- a/fedi-readerTests/fedi_readerTests.swift
+++ b/fedi-readerTests/fedi_readerTests.swift
@@ -249,4 +249,28 @@ struct LinkStatusTests {
         #expect(withImage.hasImage == true)
         #expect(withoutImage.hasImage == false)
     }
+
+    @Test("LinkStatus uses metadata description for displayDescription")
+    func linkStatusDisplayDescriptionUsesMetadata() {
+        let status = MockStatusFactory.makeStatus(content: "<p>Post body content</p>")
+        let linkStatus = LinkStatus(
+            status: status,
+            primaryURL: URL(string: "https://example.com")!,
+            description: "Preview description"
+        )
+
+        #expect(linkStatus.displayDescription == "Preview description")
+    }
+
+    @Test("LinkStatus does not fall back to post content for displayDescription")
+    func linkStatusDisplayDescriptionNoPostFallback() {
+        let status = MockStatusFactory.makeStatus(content: "<p>Post body content</p>")
+        let linkStatus = LinkStatus(
+            status: status,
+            primaryURL: URL(string: "https://example.com")!,
+            description: nil
+        )
+
+        #expect(linkStatus.displayDescription == nil)
+    }
 }


### PR DESCRIPTION
Summary
- guard tag extraction around the rendered content so hashtags keep their original case and the metadata description no longer falls back to post text
- make the tag row responsive by tracking available width, preserving the first tag on narrow screens, and measuring tag sizes before showing the "+N" control
- add layout and display-description tests covering the new behaviors

Testing
- Not run (not requested)