### PR TITLE
Preserve feed scroll when returning from detail

### DIFF
--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -32,6 +32,9 @@ struct LinkFeedContentView: View {
     @State private var postSwipeTapSuppressionDeadline: TimeInterval = 0
     @State private var retainedLists: [MastodonList] = []
     @State private var tabFrames: [Int: CGRect] = [:]
+    // Scroll position preservation per feed id
+    @State private var lastVisibleStatusIdPerFeed: [String: String] = [:]
+    @State private var hasRestoredScrollForCurrentTab: Bool = false
 
     private var timelineService: TimelineService? {
         timelineWrapper.service
@@ -174,8 +177,11 @@ struct LinkFeedContentView: View {
                 retainedLists = cachedLists
             }
             syncRetainedLists(with: liveLists, allowEmpty: false)
+            // Attempt to restore scroll to last seen item when returning
+            attemptRestoreScrollIfNeeded()
         }
         .onDisappear {
+            hasRestoredScrollForCurrentTab = false
             isHorizontalSwipeIntentActive = false
             postSwipeTapSuppressionDeadline = 0
         }
@@ -236,7 +242,15 @@ struct LinkFeedContentView: View {
                 checkLoadMore(at: index, totalCount: totalCount)
             },
             onArticleSelect: onArticleSelect,
-            scrollProxy: $scrollProxy
+            scrollProxy: $scrollProxy,
+            onFirstVisibleChange: { statusId in
+                // Persist the last visible status id for the current feed tab
+                lastVisibleStatusIdPerFeed[currentTab.id] = statusId
+            },
+            onListAppear: {
+                // When the list appears (e.g., popped back from article), try to restore once
+                attemptRestoreScrollIfNeeded()
+            }
         )
     }
 
@@ -323,6 +337,7 @@ struct LinkFeedContentView: View {
     }
 
     private func handleTabChange(to newIndex: Int) {
+        hasRestoredScrollForCurrentTab = false
         guard newIndex >= 0, newIndex < feedTabs.count else { return }
 
         let tab = feedTabs[newIndex]
@@ -480,6 +495,22 @@ struct LinkFeedContentView: View {
             let newStatuses = await service.loadMoreListTimeline(listId: tab.id)
             guard !newStatuses.isEmpty else { return }
             _ = await linkFilterService.appendStatuses(newStatuses, for: tab.id)
+        }
+    }
+
+    // MARK: - Scroll Position Preservation
+
+    private func attemptRestoreScrollIfNeeded() {
+        guard let proxy = scrollProxy else { return }
+        guard !hasRestoredScrollForCurrentTab else { return }
+        let feedId = currentTab.id
+        guard let statusId = lastVisibleStatusIdPerFeed[feedId] else { return }
+        // Avoid animating to reduce visual jump
+        DispatchQueue.main.async {
+            withAnimation(nil) {
+                proxy.scrollTo(statusId, anchor: .top)
+            }
+            hasRestoredScrollForCurrentTab = true
         }
     }
 }

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedPostList.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedPostList.swift
@@ -15,8 +15,39 @@ struct LinkFeedPostList: View {
     let shouldBlockPostTaps: () -> Bool
     let onItemAppear: (Int, Int) -> Void
     let onArticleSelect: ((URL, Status) -> Void)?
+    
+    // New: scroll position reporting
+    let onFirstVisibleChange: ((String) -> Void)?
+    let onListAppear: (() -> Void)?
+    
+    @State private var rowTopOffsets: [String: CGFloat] = [:]
+    @State private var currentFirstVisibleId: String?
 
     @Binding var scrollProxy: ScrollViewProxy?
+
+    init(
+        statuses: [LinkStatus],
+        isLoading: Bool,
+        shouldShowPaginationLoading: Bool,
+        deferPostNavigation: @escaping ((@escaping () -> Void) -> Void),
+        shouldBlockPostTaps: @escaping (() -> Bool),
+        onItemAppear: @escaping (Int, Int) -> Void,
+        onArticleSelect: ((URL, Status) -> Void)? = nil,
+        scrollProxy: Binding<ScrollViewProxy?>,
+        onFirstVisibleChange: ((String) -> Void)? = nil,
+        onListAppear: (() -> Void)? = nil
+    ) {
+        self.statuses = statuses
+        self.isLoading = isLoading
+        self.shouldShowPaginationLoading = shouldShowPaginationLoading
+        self.deferPostNavigation = deferPostNavigation
+        self.shouldBlockPostTaps = shouldBlockPostTaps
+        self.onItemAppear = onItemAppear
+        self.onArticleSelect = onArticleSelect
+        self._scrollProxy = scrollProxy
+        self.onFirstVisibleChange = onFirstVisibleChange
+        self.onListAppear = onListAppear
+    }
 
     var body: some View {
         GlassEffectContainer {
@@ -31,6 +62,15 @@ struct LinkFeedPostList: View {
                                 onArticleSelect: onArticleSelect
                             )
                             .id(linkStatus.id)
+                            .background(
+                                GeometryReader { geo in
+                                    Color.clear
+                                        .onChange(of: geo.frame(in: .named("feedScroll")).minY) { _, newMinY in
+                                            rowTopOffsets[linkStatus.id] = newMinY
+                                            reportFirstVisibleIfNeeded()
+                                        }
+                                }
+                            )
                             .onAppear {
                                 onItemAppear(index, statuses.count)
                             }
@@ -52,8 +92,11 @@ struct LinkFeedPostList: View {
                     transaction.animation = nil
                 }
                 .background(Color(.systemBackground))
+                .coordinateSpace(name: "feedScroll")
                 .onAppear {
                     scrollProxy = proxy
+                    onListAppear?()
+                    reportFirstVisibleIfNeeded()
                 }
             }
         }
@@ -79,5 +122,20 @@ struct LinkFeedPostList: View {
             Spacer()
         }
         .padding(.vertical, 8)
+    }
+    
+    private func reportFirstVisibleIfNeeded() {
+        guard !rowTopOffsets.isEmpty else { return }
+        // Consider the smallest positive or closest to zero minY as top-most
+        let candidate = rowTopOffsets.min(by: { lhs, rhs in
+            let a = abs(lhs.value)
+            let b = abs(rhs.value)
+            return a < b
+        })
+        guard let (id, _) = candidate else { return }
+        if currentFirstVisibleId != id {
+            currentFirstVisibleId = id
+            onFirstVisibleChange?(id)
+        }
     }
 }


### PR DESCRIPTION
Summary
- track per-feed scroll positions and expose the last visible status back to the parent view
- report when a feed list appears or its first visible status changes so the list can restore its position
- restore the saved scroll position once per tab when the list reappears

Testing
- Not run (not requested)