### PR TITLE
Route explore links through in-app browser navigation

### DIFF
--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -32,6 +32,7 @@ final class AppState {
     
     // Navigation state (per-tab so switching tabs shows correct root)
     var linksNavigationPath: [NavigationDestination] = []
+    var exploreNavigationPath: [NavigationDestination] = []
     var profileNavigationPath: [NavigationDestination] = []
     var presentedSheet: SheetDestination?
     var presentedAlert: AlertItem?
@@ -109,9 +110,11 @@ final class AppState {
         switch selectedTab {
         case .links:
             linksNavigationPath.append(destination)
+        case .explore:
+            exploreNavigationPath.append(destination)
         case .profile:
             profileNavigationPath.append(destination)
-        case .explore, .mentions:
+        case .mentions:
             break
         }
     }
@@ -126,6 +129,14 @@ final class AppState {
             } else {
                 Self.logger.debug("Navigate back called but navigation path is empty")
             }
+        case .explore:
+            if !exploreNavigationPath.isEmpty {
+                let previous = exploreNavigationPath.last
+                exploreNavigationPath.removeLast()
+                Self.logger.info("Navigating back from: \(String(describing: previous), privacy: .public)")
+            } else {
+                Self.logger.debug("Navigate back called but navigation path is empty")
+            }
         case .profile:
             if !profileNavigationPath.isEmpty {
                 let previous = profileNavigationPath.last
@@ -134,7 +145,7 @@ final class AppState {
             } else {
                 Self.logger.debug("Navigate back called but navigation path is empty")
             }
-        case .explore, .mentions:
+        case .mentions:
             break
         }
     }
@@ -145,11 +156,15 @@ final class AppState {
             let count = linksNavigationPath.count
             linksNavigationPath.removeAll()
             Self.logger.info("Navigating to root, cleared \(count) destinations")
+        case .explore:
+            let count = exploreNavigationPath.count
+            exploreNavigationPath.removeAll()
+            Self.logger.info("Navigating to root, cleared \(count) destinations")
         case .profile:
             let count = profileNavigationPath.count
             profileNavigationPath.removeAll()
             Self.logger.info("Navigating to root, cleared \(count) destinations")
-        case .explore, .mentions:
+        case .mentions:
             break
         }
     }
@@ -205,7 +220,7 @@ enum AppTab: String, CaseIterable, Identifiable {
 enum NavigationDestination: Hashable {
     case status(Status)
     case profile(MastodonAccount)
-    case article(url: URL, status: Status)
+    case article(url: URL, status: Status?)
     case thread(statusId: String)
     case hashtag(String)
     case settings

--- a/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
+++ b/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
@@ -20,11 +20,7 @@ struct TrendingLinkRow: View {
     var body: some View {
         Button {
             if let url = link.linkURL {
-                #if os(iOS)
-                UIApplication.shared.open(url)
-                #elseif os(macOS)
-                NSWorkspace.shared.open(url)
-                #endif
+                appState.navigate(to: .article(url: url, status: nil))
             }
         } label: {
             LinkCardContent(link: link)

--- a/fedi-reader/Views/Root/MainTabView.swift
+++ b/fedi-reader/Views/Root/MainTabView.swift
@@ -61,7 +61,7 @@ struct MainTabView: View {
             }
 
             Tab(useSidebarLayout ? "Explore" : (hideTabBarLabels ? "" : "Explore"), systemImage: "globe", value: .explore) {
-                NavigationStack {
+                NavigationStack(path: $state.exploreNavigationPath) {
                     ExploreFeedView()
                         .navigationDestination(for: NavigationDestination.self) { destination in
                             destinationView(for: destination)

--- a/fedi-reader/Views/Web/ArticleWebView.swift
+++ b/fedi-reader/Views/Web/ArticleWebView.swift
@@ -10,7 +10,7 @@ import WebKit
 
 struct ArticleWebView: View {
     let url: URL
-    let status: Status
+    let status: Status?
     
     @Environment(AppState.self) private var appState
     @Environment(ReadLaterManager.self) private var readLaterManager
@@ -124,11 +124,14 @@ struct ArticleWebView: View {
         }
     }
 
+    @ViewBuilder
     private var actionToolbar: some View {
-        StatusActionsToolbar(status: status)
-            .glassEffect(.regular)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 6)
+        if let status {
+            StatusActionsToolbar(status: status)
+                .glassEffect(.regular)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 6)
+        }
     }
 }
 

--- a/fedi-readerTests/AppStateTests.swift
+++ b/fedi-readerTests/AppStateTests.swift
@@ -80,4 +80,46 @@ struct AppStateTests {
 
         #expect(state.linksScrollToTopRequestID == initialRequestID + 1)
     }
+
+    @Test("navigate routes explore destinations to the explore navigation path")
+    func navigateRoutesExploreDestinationsToExplorePath() async {
+        let state = AppState()
+        let destination = NavigationDestination.article(
+            url: URL(string: "https://example.com")!,
+            status: nil
+        )
+
+        state.selectedTab = .explore
+        state.navigate(to: destination)
+
+        #expect(state.exploreNavigationPath == [destination])
+        #expect(state.linksNavigationPath.isEmpty == true)
+        #expect(state.profileNavigationPath.isEmpty == true)
+    }
+
+    @Test("navigateBack removes the last explore destination")
+    func navigateBackRemovesLastExploreDestination() async {
+        let state = AppState()
+
+        state.selectedTab = .explore
+        state.navigate(to: .settings)
+        state.navigate(to: .readLaterSettings)
+
+        state.navigateBack()
+
+        #expect(state.exploreNavigationPath == [.settings])
+    }
+
+    @Test("navigateToRoot clears the explore navigation path")
+    func navigateToRootClearsExploreNavigationPath() async {
+        let state = AppState()
+
+        state.selectedTab = .explore
+        state.navigate(to: .settings)
+        state.navigate(to: .readLaterSettings)
+
+        state.navigateToRoot()
+
+        #expect(state.exploreNavigationPath.isEmpty == true)
+    }
 }


### PR DESCRIPTION
Summary
- add an explore navigation stack so Explore tab destinations open via the shared navigation logic
- keep article navigation destination optional for missing status context and guard the actions toolbar appropriately
- update AppState tests to cover explore navigation behavior

Testing
- Not run (not requested)