### PR TITLE
Improve predicted swipe intent filtering

### DIFF
--- a/fedi-reader/Utilities/FeedSwipeGestureEvaluator.swift
+++ b/fedi-reader/Utilities/FeedSwipeGestureEvaluator.swift
@@ -20,7 +20,8 @@ struct FeedSwipeGestureEvaluator {
     static let visualFollowFactor: CGFloat = 0.35
     static let maxVisualOffset: CGFloat = 72
     static let postSwipeSuppressionNanoseconds: UInt64 = 120_000_000
-    private static let horizontalDominanceRatio: CGFloat = 1.05
+    private static let projectedIntentDistance: CGFloat = 24
+    private static let horizontalDominanceRatio: CGFloat = 1.35
 
     static func visualOffset(translation: CGSize) -> CGFloat {
         guard isHorizontalIntent(translation: translation) else {
@@ -40,7 +41,12 @@ struct FeedSwipeGestureEvaluator {
             return direction(forHorizontalDistance: translation.width)
         }
 
+        // Predicted translation is useful for confident flicks, but only after the
+        // active drag has already established clear horizontal intent in one direction.
         if isHorizontalIntent(translation: predictedEndTranslation),
+           isHorizontalIntent(translation: translation),
+           abs(translation.width) >= projectedIntentDistance,
+           translation.width * predictedEndTranslation.width > 0,
            abs(predictedEndTranslation.width) >= predictedCommitDistance {
             return direction(forHorizontalDistance: predictedEndTranslation.width)
         }

--- a/fedi-readerTests/FeedSwipeGestureEvaluatorTests.swift
+++ b/fedi-readerTests/FeedSwipeGestureEvaluatorTests.swift
@@ -39,6 +39,33 @@ struct FeedSwipeGestureEvaluatorTests {
         #expect(direction == .none)
     }
 
+    @Test("Does not commit from diagonal drag that mostly represents scrolling")
+    func doesNotCommitForNearDiagonalGesture() {
+        let direction = FeedSwipeGestureEvaluator.shouldCommit(
+            translation: CGSize(width: 64, height: 50),
+            predictedEndTranslation: CGSize(width: 70, height: 54)
+        )
+        #expect(direction == .none)
+    }
+
+    @Test("Predicted end does not override missing horizontal intent")
+    func predictedEndRequiresEstablishedHorizontalIntent() {
+        let direction = FeedSwipeGestureEvaluator.shouldCommit(
+            translation: CGSize(width: 18, height: 72),
+            predictedEndTranslation: CGSize(width: 96, height: 18)
+        )
+        #expect(direction == .none)
+    }
+
+    @Test("Predicted end requires matching horizontal direction")
+    func predictedEndRequiresMatchingDirection() {
+        let direction = FeedSwipeGestureEvaluator.shouldCommit(
+            translation: CGSize(width: 30, height: 4),
+            predictedEndTranslation: CGSize(width: -96, height: 6)
+        )
+        #expect(direction == .none)
+    }
+
     @Test("Visual offset uses resistance and clamp")
     func visualOffsetResistsAndClamps() {
         let resisted = FeedSwipeGestureEvaluator.visualOffset(translation: CGSize(width: 40, height: 0))
@@ -62,6 +89,7 @@ struct FeedSwipeGestureEvaluatorTests {
         #expect(FeedSwipeGestureEvaluator.isHorizontalIntent(translation: CGSize(width: 10, height: 0)))
         #expect(!FeedSwipeGestureEvaluator.isHorizontalIntent(translation: CGSize(width: 9.9, height: 0)))
         #expect(!FeedSwipeGestureEvaluator.isHorizontalIntent(translation: CGSize(width: 10, height: 10)))
+        #expect(!FeedSwipeGestureEvaluator.isHorizontalIntent(translation: CGSize(width: 30, height: 23)))
     }
 
     @Test("Suppression is enabled for swipe-like gestures")


### PR DESCRIPTION
Summary
- tighten the horizontal dominance ratio threshold when evaluating swipe intent
- require an established horizontal drag before trusting predicted end translation and reject mismatched directions or mostly vertical gestures
- expand gesture tests to cover these regression scenarios

Testing
- Not run (not requested)