### PR TITLE
Fix feed author attribution fetching and UI threading

### DIFF
--- a/fedi-reader/Models/MastodonTypes/AccountSource.swift
+++ b/fedi-reader/Models/MastodonTypes/AccountSource.swift
@@ -3,8 +3,17 @@ import Foundation
 struct AccountSource: Codable, Hashable, Sendable {
     let note: String?
     let fields: [Field]?
+
+    init(note: String?, fields: [Field]?) {
+        self.note = note
+        self.fields = fields
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        note = try container.decodeIfPresent(String.self, forKey: .note)
+        fields = try container.decodeIfPresent([Field].self, forKey: .fields)
+    }
 }
 
 // MARK: - Field (Profile fields)
-
-

--- a/fedi-reader/Models/MastodonTypes/AuthorAttribution.swift
+++ b/fedi-reader/Models/MastodonTypes/AuthorAttribution.swift
@@ -23,6 +23,21 @@ struct AuthorAttribution: Sendable {
         self.mastodonProfileURL = mastodonProfileURL
         self.profilePictureURL = profilePictureURL
     }
-}
 
+    var preferredName: String? {
+        name ?? mastodonHandle
+    }
+
+    var preferredURL: URL? {
+        if let mastodonProfileURL, let url = URL(string: mastodonProfileURL) {
+            return url
+        }
+
+        if let url, let parsedURL = URL(string: url) {
+            return parsedURL
+        }
+
+        return nil
+    }
+}
 

--- a/fedi-reader/Models/MastodonTypes/CustomEmoji.swift
+++ b/fedi-reader/Models/MastodonTypes/CustomEmoji.swift
@@ -12,8 +12,29 @@ struct CustomEmoji: Codable, Hashable, Sendable {
         case staticUrl = "static_url"
         case visibleInPicker = "visible_in_picker"
     }
+
+    init(
+        shortcode: String,
+        url: String,
+        staticUrl: String,
+        visibleInPicker: Bool,
+        category: String?
+    ) {
+        self.shortcode = shortcode
+        self.url = url
+        self.staticUrl = staticUrl
+        self.visibleInPicker = visibleInPicker
+        self.category = category
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        shortcode = try container.decode(String.self, forKey: .shortcode)
+        url = try container.decode(String.self, forKey: .url)
+        staticUrl = try container.decode(String.self, forKey: .staticUrl)
+        visibleInPicker = try container.decode(Bool.self, forKey: .visibleInPicker)
+        category = try container.decodeIfPresent(String.self, forKey: .category)
+    }
 }
 
 // MARK: - Poll
-
-

--- a/fedi-reader/Models/MastodonTypes/Field.swift
+++ b/fedi-reader/Models/MastodonTypes/Field.swift
@@ -16,7 +16,7 @@ struct Field: Codable, Hashable, Sendable {
         self.verifiedAt = verifiedAt
     }
 
-    init(from decoder: Decoder) throws {
+    nonisolated init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         name = try container.decode(String.self, forKey: .name)
@@ -46,5 +46,4 @@ struct Field: Codable, Hashable, Sendable {
 }
 
 // MARK: - Media Attachment
-
 

--- a/fedi-reader/Models/MastodonTypes/MastodonAccount.swift
+++ b/fedi-reader/Models/MastodonTypes/MastodonAccount.swift
@@ -78,7 +78,7 @@ struct MastodonAccount: Codable, Identifiable, Hashable, Sendable {
         self.source = source
     }
 
-    init(from decoder: Decoder) throws {
+    nonisolated init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         id = try container.decode(String.self, forKey: .id)
@@ -125,6 +125,9 @@ struct MastodonAccount: Codable, Identifiable, Hashable, Sendable {
         }
         return source?.fields ?? []
     }
+
+    var preferredDisplayName: String {
+        let trimmed = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? acct : trimmed
+    }
 }
-
-

--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -29,6 +29,7 @@ final class AppState {
     var selectedListId: String? = nil  // nil = Home timeline
     var isUserFilterOpen = false
     var userFilterPerFeedId: [String: String] = [:]  // feedId -> accountId
+    var linksLastVisibleStatusIdPerFeed: [String: String] = [:]
     
     // Navigation state (per-tab so switching tabs shows correct root)
     var linksNavigationPath: [NavigationDestination] = []

--- a/fedi-reader/Services/AttributionChecker.swift
+++ b/fedi-reader/Services/AttributionChecker.swift
@@ -9,7 +9,23 @@ import Foundation
 import os
 
 actor AttributionChecker {
+    static let shared = AttributionChecker()
     private static let logger = Logger(subsystem: "app.fedi-reader", category: "AttributionChecker")
+
+    private static let standardAuthorMetaNames = [
+        "author",
+        "dc.creator",
+        "dcterms.creator",
+        "parsely-author",
+        "sailthru.author",
+        "citation_author"
+    ]
+
+    private static let standardAuthorMetaProperties = [
+        "article:author",
+        "og:article:author",
+        "author"
+    ]
     
     private let session: URLSession
     
@@ -17,8 +33,13 @@ actor AttributionChecker {
     private var cache: [URL: AuthorAttribution] = [:]
     private let cacheLimit = 500
     
-    init() {
-        let config = URLSessionConfiguration.ephemeral
+    init(configuration: URLSessionConfiguration = .default) {
+        let config: URLSessionConfiguration
+        if configuration === URLSessionConfiguration.default {
+            config = URLSessionConfiguration.ephemeral
+        } else {
+            config = configuration
+        }
         config.timeoutIntervalForRequest = 10
         config.httpAdditionalHeaders = [
             "User-Agent": Constants.userAgent
@@ -38,21 +59,27 @@ actor AttributionChecker {
         }
         
         Self.logger.debug("Checking attribution for: \(url.absoluteString, privacy: .public)")
-        
-        // Try HEAD request first (faster, checks headers)
-        if let attribution = await checkHeaderAttribution(for: url) {
-            Self.logger.info("Attribution found via HEAD: \(url.absoluteString, privacy: .public), name: \(attribution.name ?? "nil", privacy: .public), source: \(String(describing: attribution.source), privacy: .public)")
+
+        let headerAttribution = await checkHeaderAttribution(for: url)
+        let shouldFetchDocumentAttribution = headerAttribution == nil
+            || headerAttribution?.name == nil
+            || headerAttribution?.url == nil
+            || headerAttribution?.mastodonHandle == nil
+            || headerAttribution?.mastodonProfileURL == nil
+
+        let documentAttribution = shouldFetchDocumentAttribution
+            ? await checkMetaAttribution(for: url)
+            : nil
+
+        if let attribution = await mergedAttribution(
+            primary: documentAttribution,
+            fallback: headerAttribution
+        ) {
+            Self.logger.info("Attribution found: \(url.absoluteString, privacy: .public), name: \(attribution.name ?? "nil", privacy: .public), source: \(String(describing: attribution.source), privacy: .public)")
             cacheResult(attribution, for: url)
             return attribution
         }
-        
-        // Fall back to fetching HTML meta tags
-        if let attribution = await checkMetaAttribution(for: url) {
-            Self.logger.info("Attribution found via meta tags: \(url.absoluteString, privacy: .public), name: \(attribution.name ?? "nil", privacy: .public), source: \(String(describing: attribution.source), privacy: .public)")
-            cacheResult(attribution, for: url)
-            return attribution
-        }
-        
+
         Self.logger.debug("No attribution found for: \(url.absoluteString, privacy: .public)")
         return nil
     }
@@ -102,7 +129,7 @@ actor AttributionChecker {
             
             // Check Link header for author relation
             if let linkHeader = httpResponse.value(forHTTPHeaderField: "Link") {
-                if let attribution = parseLinkHeader(linkHeader) {
+                if let attribution = parseLinkHeader(linkHeader, relativeTo: url) {
                     Self.logger.debug("Found attribution in Link header: \(url.absoluteString, privacy: .public)")
                     return attribution
                 }
@@ -126,7 +153,7 @@ actor AttributionChecker {
         }
     }
     
-    private func parseLinkHeader(_ header: String) -> AuthorAttribution? {
+    private func parseLinkHeader(_ header: String, relativeTo pageURL: URL) -> AuthorAttribution? {
         // Parse Link header format: <url>; rel="author", <url2>; rel="other"
         let links = header.components(separatedBy: ",")
         
@@ -135,8 +162,8 @@ actor AttributionChecker {
             guard parts.count >= 2 else { continue }
             
             // Check if this is an author relation
-            let relPart = parts[1...].joined(separator: ";").lowercased()
-            guard relPart.contains("rel=\"author\"") || relPart.contains("rel=author") else {
+            let relPart = parts[1...].joined(separator: ";")
+            guard hasAuthorLinkRelation(in: relPart) else {
                 continue
             }
             
@@ -147,10 +174,13 @@ actor AttributionChecker {
             }
             
             let urlString = String(urlPart.dropFirst().dropLast())
+            guard let absoluteURL = absoluteURLString(from: urlString, relativeTo: pageURL) else {
+                continue
+            }
             
             // Return attribution with URL only - don't make up names from URL paths
             // The URL is valid author attribution, but we need actual meta tags for the name
-            return AuthorAttribution(name: nil, url: urlString, source: .linkHeader)
+            return makeURLAttribution(urlString: absoluteURL, source: .linkHeader)
         }
         
         return nil
@@ -162,7 +192,7 @@ actor AttributionChecker {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         // Only request the first part of the document (meta tags are in head)
-        request.setValue("bytes=0-16384", forHTTPHeaderField: "Range")
+        request.setValue("bytes=0-65535", forHTTPHeaderField: "Range")
         
         do {
             let (data, response) = try await session.data(for: request)
@@ -170,7 +200,7 @@ actor AttributionChecker {
             let statusCode = http?.statusCode ?? 0
             Self.logger.debug("GET request for meta attribution: \(url.absoluteString, privacy: .public) -> \(statusCode), size: \(data.count) bytes")
             
-            guard let html = String(data: data, encoding: .utf8) else {
+            guard let html = decodeHTML(data, response: response) else {
                 Self.logger.debug("Failed to decode HTML for attribution: \(url.absoluteString, privacy: .public)")
                 return nil
             }
@@ -192,67 +222,39 @@ actor AttributionChecker {
                     profilePictureURL: profilePicture
                 )
             }
-            
-            // 2. Standard meta author tag
-            if let author = extractMetaContent(from: html, name: "author") {
-                Self.logger.debug("Found attribution in meta author tag: \(url.absoluteString, privacy: .public)")
-                return AuthorAttribution(name: author, url: nil, source: .metaTag)
+
+            // 2. JSON-LD structured data
+            if let attribution = extractJSONLDAuthor(from: html, pageURL: url) {
+                Self.logger.debug("Found attribution in JSON-LD: \(url.absoluteString, privacy: .public)")
+                return await attachProfilePictureIfNeeded(to: attribution)
             }
-            
-            // 3. Open Graph article:author
-            if let author = extractMetaProperty(from: html, property: "article:author") {
-                Self.logger.debug("Found attribution in OG article:author: \(url.absoluteString, privacy: .public)")
-                return AuthorAttribution(name: author, url: nil, source: .openGraph)
+
+            // 3. Open Graph / article author metadata
+            if let author = extractMetaProperty(from: html, properties: Self.standardAuthorMetaProperties),
+               let attribution = makeAuthorAttribution(from: author, source: .openGraph, relativeTo: url) {
+                Self.logger.debug("Found attribution in author meta property: \(url.absoluteString, privacy: .public)")
+                return await attachProfilePictureIfNeeded(to: attribution)
             }
-            
-            // 4. Open Graph og:article:author
-            if let author = extractMetaProperty(from: html, property: "og:article:author") {
-                Self.logger.debug("Found attribution in OG og:article:author: \(url.absoluteString, privacy: .public)")
-                return AuthorAttribution(name: author, url: nil, source: .openGraph)
-            }
-            
-            // 5. Twitter creator
+
+            // 4. Twitter creator
             if let creator = extractMetaContent(from: html, name: "twitter:creator") {
                 // Remove @ prefix if present
                 let name = creator.hasPrefix("@") ? String(creator.dropFirst()) : creator
                 Self.logger.debug("Found attribution in Twitter creator: \(url.absoluteString, privacy: .public)")
                 return AuthorAttribution(name: name, url: nil, source: .twitterCard)
             }
-            
-            // 6. JSON-LD structured data
-            if let attribution = extractJSONLDAuthor(from: html) {
-                Self.logger.debug("Found attribution in JSON-LD: \(url.absoluteString, privacy: .public)")
-                // Fetch profile picture if author URL exists
-                if let authorURL = attribution.url, let url = URL(string: authorURL) {
-                    let profilePicture = await fetchAuthorProfilePicture(from: url)
-                    return AuthorAttribution(
-                        name: attribution.name,
-                        url: attribution.url,
-                        source: attribution.source,
-                        mastodonHandle: attribution.mastodonHandle,
-                        mastodonProfileURL: attribution.mastodonProfileURL,
-                        profilePictureURL: profilePicture
-                    )
-                }
-                return attribution
+
+            // 5. Standard author-style meta tags
+            if let author = extractMetaContent(from: html, names: Self.standardAuthorMetaNames),
+               let attribution = makeAuthorAttribution(from: author, source: .metaTag, relativeTo: url) {
+                Self.logger.debug("Found attribution in author meta tag: \(url.absoluteString, privacy: .public)")
+                return await attachProfilePictureIfNeeded(to: attribution)
             }
-            
-            // 7. Link rel="author" in HTML
-            if let authorLink = extractLinkRelAuthor(from: html) {
+
+            // 6. Link rel="author" in HTML
+            if let authorLink = extractLinkRelAuthor(from: html, relativeTo: url) {
                 Self.logger.debug("Found attribution in link rel=author: \(url.absoluteString, privacy: .public)")
-                // Fetch profile picture if author URL exists
-                if let authorURL = authorLink.url, let url = URL(string: authorURL) {
-                    let profilePicture = await fetchAuthorProfilePicture(from: url)
-                    return AuthorAttribution(
-                        name: authorLink.name,
-                        url: authorLink.url,
-                        source: authorLink.source,
-                        mastodonHandle: authorLink.mastodonHandle,
-                        mastodonProfileURL: authorLink.mastodonProfileURL,
-                        profilePictureURL: profilePicture
-                    )
-                }
-                return authorLink
+                return await attachProfilePictureIfNeeded(to: authorLink)
             }
             
             return nil
@@ -263,111 +265,398 @@ actor AttributionChecker {
     }
     
     private func extractMetaContent(from html: String, name: String) -> String? {
-        // Match <meta name="author" content="...">
-        let pattern = #"<meta[^>]+name\s*=\s*["']\#(name)["'][^>]+content\s*=\s*["']([^"']+)["']"#
-        
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
-            return nil
-        }
-        
-        let range = NSRange(html.startIndex..., in: html)
-        guard let match = regex.firstMatch(in: html, options: [], range: range),
-              let contentRange = Range(match.range(at: 1), in: html) else {
-            return nil
-        }
-        
-        let content = String(html[contentRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-        return content.isEmpty ? nil : content
+        HTMLParser.metaContent(in: html, name: name)
     }
-    
-    private func extractMetaProperty(from html: String, property: String) -> String? {
-        // Match <meta property="og:..." content="...">
-        let escapedProperty = NSRegularExpression.escapedPattern(for: property)
-        let pattern = #"<meta[^>]+property\s*=\s*["']\#(escapedProperty)["'][^>]+content\s*=\s*["']([^"']+)["']"#
-        
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
-            return nil
-        }
-        
-        let range = NSRange(html.startIndex..., in: html)
-        guard let match = regex.firstMatch(in: html, options: [], range: range),
-              let contentRange = Range(match.range(at: 1), in: html) else {
-            return nil
-        }
-        
-        let content = String(html[contentRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-        return content.isEmpty ? nil : content
-    }
-    
-    private func extractJSONLDAuthor(from html: String) -> AuthorAttribution? {
-        // Find JSON-LD script tag
-        let pattern = #"<script[^>]+type\s*=\s*["']application/ld\+json["'][^>]*>([^<]+)</script>"#
-        
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
-            return nil
-        }
-        
-        let range = NSRange(html.startIndex..., in: html)
-        let matches = regex.matches(in: html, options: [], range: range)
-        
-        for match in matches {
-            guard let jsonRange = Range(match.range(at: 1), in: html) else { continue }
-            let jsonString = String(html[jsonRange])
-            
-            guard let jsonData = jsonString.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
-                continue
-            }
-            
-            // Check for author in JSON-LD
-            if let author = json["author"] {
-                if let authorDict = author as? [String: Any] {
-                    if let name = authorDict["name"] as? String {
-                        let url = authorDict["url"] as? String
-                        return AuthorAttribution(name: name, url: url, source: .jsonLD)
-                    }
-                } else if let authorName = author as? String {
-                    return AuthorAttribution(name: authorName, url: nil, source: .jsonLD)
-                } else if let authors = author as? [[String: Any]], let firstAuthor = authors.first {
-                    if let name = firstAuthor["name"] as? String {
-                        let url = firstAuthor["url"] as? String
-                        return AuthorAttribution(name: name, url: url, source: .jsonLD)
-                    }
-                }
-            }
-            
-            // Check for creator
-            if let creator = json["creator"] as? [String: Any],
-               let name = creator["name"] as? String {
-                let url = creator["url"] as? String
-                return AuthorAttribution(name: name, url: url, source: .jsonLD)
+
+    private func extractMetaContent(from html: String, names: [String]) -> String? {
+        for name in names {
+            if let content = HTMLParser.metaContent(in: html, name: name)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !content.isEmpty {
+                return content
             }
         }
-        
+
         return nil
     }
     
-    private func extractLinkRelAuthor(from html: String) -> AuthorAttribution? {
-        // Match <link rel="author" href="...">
-        let pattern = #"<link[^>]+rel\s*=\s*["']author["'][^>]+href\s*=\s*["']([^"']+)["']"#
-        
-        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
-            return nil
+    private func extractMetaProperty(from html: String, property: String) -> String? {
+        HTMLParser.metaProperty(in: html, property: property)
+    }
+
+    private func extractMetaProperty(from html: String, properties: [String]) -> String? {
+        for property in properties {
+            if let content = HTMLParser.metaProperty(in: html, property: property)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !content.isEmpty {
+                return content
+            }
         }
-        
-        let range = NSRange(html.startIndex..., in: html)
-        guard let match = regex.firstMatch(in: html, options: [], range: range),
-              let hrefRange = Range(match.range(at: 1), in: html) else {
-            return nil
-        }
-        
-        let href = String(html[hrefRange])
-        
-        // Return attribution with URL only - don't make up names from URL paths
-        // The URL is valid author attribution, but we need actual meta tags for the name
-        return AuthorAttribution(name: nil, url: href, source: .metaTag)
+
+        return nil
     }
     
+    private func extractJSONLDAuthor(from html: String, pageURL: URL) -> AuthorAttribution? {
+        let pattern = #"<script[^>]+type\s*=\s*["']application/ld\+json["'][^>]*>(.*?)</script>"#
+
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return nil
+        }
+
+        let range = NSRange(html.startIndex..., in: html)
+        let matches = regex.matches(in: html, options: [], range: range)
+
+        for match in matches {
+            guard let jsonRange = Range(match.range(at: 1), in: html) else { continue }
+            let jsonString = String(html[jsonRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard let jsonData = jsonString.data(using: .utf8),
+                  let payload = try? JSONSerialization.jsonObject(with: jsonData) else {
+                continue
+            }
+
+            let nodes = flattenedJSONLDNodes(from: payload)
+            var identifierIndex: [String: [String: Any]] = [:]
+            for node in nodes {
+                if let identifier = node["@id"] as? String, !identifier.isEmpty {
+                    identifierIndex[identifier] = node
+                }
+            }
+
+            for node in nodes {
+                if let author = node["author"],
+                   let attribution = authorAttribution(fromJSONLD: author, identifierIndex: identifierIndex, pageURL: pageURL) {
+                    return attribution
+                }
+
+                if let creator = node["creator"],
+                   let attribution = authorAttribution(fromJSONLD: creator, identifierIndex: identifierIndex, pageURL: pageURL) {
+                    return attribution
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func authorAttribution(fromJSONLD value: Any, identifierIndex: [String: [String: Any]], pageURL: URL) -> AuthorAttribution? {
+        if let stringValue = value as? String {
+            if let resolved = identifierIndex[stringValue] {
+                return authorAttribution(fromJSONLD: resolved, identifierIndex: identifierIndex, pageURL: pageURL)
+            }
+
+            return makeAuthorAttribution(from: stringValue, source: .jsonLD, relativeTo: pageURL)
+        }
+
+        if let arrayValue = value as? [Any] {
+            for item in arrayValue {
+                if let attribution = authorAttribution(fromJSONLD: item, identifierIndex: identifierIndex, pageURL: pageURL) {
+                    return attribution
+                }
+            }
+            return nil
+        }
+
+        guard let dictionaryValue = value as? [String: Any] else {
+            return nil
+        }
+
+        if let identifier = dictionaryValue["@id"] as? String,
+           dictionaryValue.count == 1,
+           let resolved = identifierIndex[identifier] {
+            return authorAttribution(fromJSONLD: resolved, identifierIndex: identifierIndex, pageURL: pageURL)
+        }
+
+        let name = firstTextValue(in: dictionaryValue["name"])?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let urlCandidates = urlValues(in: dictionaryValue["url"]) + urlValues(in: dictionaryValue["sameAs"])
+        let absoluteURLs = urlCandidates.compactMap { absoluteURLString(from: $0, relativeTo: pageURL) }
+        let mastodonProfileURL = absoluteURLs.first(where: isMastodonProfileURL)
+        let fallbackURL = absoluteURLs.first
+
+        let mastodonHandle: String?
+        if let mastodonProfileURL,
+           let resolvedURL = URL(string: mastodonProfileURL),
+           let acct = MastodonProfileReference.acct(from: resolvedURL) {
+            mastodonHandle = "@\(acct)"
+        } else {
+            mastodonHandle = nil
+        }
+
+        if let trimmedName = name, !trimmedName.isEmpty {
+            return AuthorAttribution(
+                name: trimmedName,
+                url: fallbackURL,
+                source: .jsonLD,
+                mastodonHandle: mastodonHandle,
+                mastodonProfileURL: mastodonProfileURL
+            )
+        }
+
+        if let fallbackURL {
+            return makeURLAttribution(
+                urlString: fallbackURL,
+                source: .jsonLD,
+                mastodonHandle: mastodonHandle,
+                mastodonProfileURL: mastodonProfileURL
+            )
+        }
+
+        if let nestedAuthor = dictionaryValue["author"] {
+            return authorAttribution(fromJSONLD: nestedAuthor, identifierIndex: identifierIndex, pageURL: pageURL)
+        }
+
+        if let nestedCreator = dictionaryValue["creator"] {
+            return authorAttribution(fromJSONLD: nestedCreator, identifierIndex: identifierIndex, pageURL: pageURL)
+        }
+
+        return nil
+    }
+
+    private func flattenedJSONLDNodes(from payload: Any) -> [[String: Any]] {
+        if let dictionary = payload as? [String: Any] {
+            var nodes = [dictionary]
+
+            if let graph = dictionary["@graph"] as? [Any] {
+                nodes.append(contentsOf: graph.compactMap { $0 as? [String: Any] })
+            }
+
+            return nodes
+        }
+
+        if let array = payload as? [Any] {
+            return array.flatMap(flattenedJSONLDNodes(from:))
+        }
+
+        return []
+    }
+
+    private func firstTextValue(in value: Any?) -> String? {
+        if let stringValue = value as? String {
+            return stringValue
+        }
+
+        if let arrayValue = value as? [Any] {
+            for item in arrayValue {
+                if let stringValue = firstTextValue(in: item),
+                   !stringValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return stringValue
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func urlValues(in value: Any?) -> [String] {
+        if let stringValue = value as? String {
+            return [stringValue]
+        }
+
+        if let arrayValue = value as? [Any] {
+            return arrayValue.flatMap(urlValues(in:))
+        }
+
+        if let dictionaryValue = value as? [String: Any],
+           let stringValue = dictionaryValue["url"] as? String {
+            return [stringValue]
+        }
+
+        return []
+    }
+
+    private func extractLinkRelAuthor(from html: String, relativeTo pageURL: URL) -> AuthorAttribution? {
+        guard let relation = HTMLParser.authorRelation(in: html),
+              let absoluteURL = absoluteURLString(from: relation.href, relativeTo: pageURL) else {
+            return nil
+        }
+
+        let name = relation.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let urlAttribution = makeURLAttribution(urlString: absoluteURL, source: .metaTag)
+
+        if let name, !name.isEmpty {
+            return AuthorAttribution(
+                name: name,
+                url: urlAttribution.url,
+                source: urlAttribution.source,
+                mastodonHandle: urlAttribution.mastodonHandle,
+                mastodonProfileURL: urlAttribution.mastodonProfileURL,
+                profilePictureURL: urlAttribution.profilePictureURL
+            )
+        }
+
+        return urlAttribution
+    }
+    
+    private func makeAuthorAttribution(from rawValue: String, source: AttributionSource, relativeTo pageURL: URL) -> AuthorAttribution? {
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty else { return nil }
+
+        if let absoluteURL = absoluteURLString(from: trimmedValue, relativeTo: pageURL) {
+            return makeURLAttribution(urlString: absoluteURL, source: source)
+        }
+
+        return AuthorAttribution(name: trimmedValue, url: nil, source: source)
+    }
+
+    private func makeURLAttribution(
+        urlString: String,
+        source: AttributionSource,
+        mastodonHandle: String? = nil,
+        mastodonProfileURL: String? = nil
+    ) -> AuthorAttribution {
+        let parsedURL = URL(string: urlString)
+        let resolvedAcct = parsedURL.flatMap(MastodonProfileReference.acct(from:))
+        let resolvedProfileURL = mastodonProfileURL ?? (resolvedAcct != nil ? urlString : nil)
+        let resolvedHandle = mastodonHandle ?? resolvedAcct.map { "@\($0)" }
+
+        return AuthorAttribution(
+            name: nil,
+            url: urlString,
+            source: source,
+            mastodonHandle: resolvedHandle,
+            mastodonProfileURL: resolvedProfileURL
+        )
+    }
+
+    private func absoluteURLString(from rawValue: String, relativeTo pageURL: URL) -> String? {
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let looksLikePath = trimmedValue.hasPrefix("/") || trimmedValue.hasPrefix("./") || trimmedValue.hasPrefix("../")
+        let looksLikeAbsoluteURL = trimmedValue.contains("://") || trimmedValue.hasPrefix("//")
+        let looksLikeRelativePath = !trimmedValue.contains(" ") && trimmedValue.contains("/")
+        let looksLikeHost = trimmedValue.range(
+            of: #"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(/.*)?$"#,
+            options: .regularExpression
+        ) != nil
+
+        guard !trimmedValue.isEmpty,
+              looksLikePath || looksLikeAbsoluteURL || looksLikeRelativePath || looksLikeHost,
+              let resolvedURL = URL(string: trimmedValue, relativeTo: pageURL)?.absoluteURL,
+              let scheme = resolvedURL.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else {
+            return nil
+        }
+
+        return resolvedURL.absoluteString
+    }
+
+    private func isMastodonProfileURL(_ urlString: String) -> Bool {
+        guard let url = URL(string: urlString) else { return false }
+        return MastodonProfileReference.acct(from: url) != nil
+    }
+
+    private func mergedAttribution(
+        primary: AuthorAttribution?,
+        fallback: AuthorAttribution?
+    ) async -> AuthorAttribution? {
+        let merged = merge(primary: primary, fallback: fallback)
+        return await attachProfilePictureIfNeeded(to: merged)
+    }
+
+    private func merge(primary: AuthorAttribution?, fallback: AuthorAttribution?) -> AuthorAttribution? {
+        switch (primary, fallback) {
+        case (nil, nil):
+            return nil
+        case let (primary?, nil):
+            return primary
+        case let (nil, fallback?):
+            return fallback
+        case let (primary?, fallback?):
+            return AuthorAttribution(
+                name: primary.name ?? fallback.name,
+                url: primary.url ?? fallback.url,
+                source: primary.source,
+                mastodonHandle: primary.mastodonHandle ?? fallback.mastodonHandle,
+                mastodonProfileURL: primary.mastodonProfileURL ?? fallback.mastodonProfileURL,
+                profilePictureURL: primary.profilePictureURL ?? fallback.profilePictureURL
+            )
+        }
+    }
+
+    private func attachProfilePictureIfNeeded(to attribution: AuthorAttribution?) async -> AuthorAttribution? {
+        guard let attribution else {
+            return nil
+        }
+
+        if attribution.profilePictureURL != nil {
+            return attribution
+        }
+
+        if let mastodonProfileURL = attribution.mastodonProfileURL {
+            let profilePictureURL = await fetchMastodonProfilePicture(profileURL: mastodonProfileURL)
+            return AuthorAttribution(
+                name: attribution.name,
+                url: attribution.url,
+                source: attribution.source,
+                mastodonHandle: attribution.mastodonHandle,
+                mastodonProfileURL: attribution.mastodonProfileURL,
+                profilePictureURL: profilePictureURL
+            )
+        }
+
+        if let authorURL = attribution.url,
+           let url = URL(string: authorURL) {
+            let profilePictureURL = await fetchAuthorProfilePicture(from: url)
+            return AuthorAttribution(
+                name: attribution.name,
+                url: attribution.url,
+                source: attribution.source,
+                mastodonHandle: attribution.mastodonHandle,
+                mastodonProfileURL: attribution.mastodonProfileURL,
+                profilePictureURL: profilePictureURL
+            )
+        }
+
+        return attribution
+    }
+
+    private func decodeHTML(_ data: Data, response: URLResponse?) -> String? {
+        if let html = String(data: data, encoding: .utf8) {
+            return html
+        }
+
+        if let html = String(data: data, encoding: .isoLatin1) {
+            return html
+        }
+
+        if let response = response as? HTTPURLResponse,
+           response.textEncodingName?.caseInsensitiveCompare("windows-1252") == .orderedSame,
+           let html = String(data: data, encoding: .windowsCP1252) {
+            return html
+        }
+
+        return nil
+    }
+
+    private func hasAuthorLinkRelation(in parameters: String) -> Bool {
+        let pattern = #"rel\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s;]+))"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return false
+        }
+
+        let range = NSRange(parameters.startIndex..., in: parameters)
+        guard let match = regex.firstMatch(in: parameters, options: [], range: range) else {
+            return false
+        }
+
+        let valueRange = Range(match.range(at: 1), in: parameters)
+            ?? Range(match.range(at: 2), in: parameters)
+            ?? Range(match.range(at: 3), in: parameters)
+
+        guard let valueRange else {
+            return false
+        }
+
+        return parameters[valueRange]
+            .split(whereSeparator: \.isWhitespace)
+            .contains { token in
+                token.caseInsensitiveCompare("author") == .orderedSame
+            }
+    }
+
     // MARK: - Mastodon Handle Parsing
     
     /// Parses a Mastodon handle and returns the handle and profile URL
@@ -405,10 +694,10 @@ actor AttributionChecker {
         // Try to fetch the profile page and extract avatar
         do {
             var request = URLRequest(url: url)
-            request.setValue("bytes=0-32768", forHTTPHeaderField: "Range")
+            request.setValue("bytes=0-65535", forHTTPHeaderField: "Range")
             
-            let (data, _) = try await session.data(for: request)
-            guard let html = String(data: data, encoding: .utf8) else { return nil }
+            let (data, response) = try await session.data(for: request)
+            guard let html = decodeHTML(data, response: response) else { return nil }
             
             // Look for Open Graph image or Twitter card image
             if let ogImage = extractMetaProperty(from: html, property: "og:image") {
@@ -434,10 +723,10 @@ actor AttributionChecker {
     private func fetchAuthorProfilePicture(from url: URL) async -> String? {
         do {
             var request = URLRequest(url: url)
-            request.setValue("bytes=0-32768", forHTTPHeaderField: "Range")
+            request.setValue("bytes=0-65535", forHTTPHeaderField: "Range")
             
-            let (data, _) = try await session.data(for: request)
-            guard let html = String(data: data, encoding: .utf8) else { return nil }
+            let (data, response) = try await session.data(for: request)
+            guard let html = decodeHTML(data, response: response) else { return nil }
             
             // Look for Open Graph image first (most reliable)
             if let ogImage = extractMetaProperty(from: html, property: "og:image") {

--- a/fedi-reader/Services/AuthService.swift
+++ b/fedi-reader/Services/AuthService.swift
@@ -42,6 +42,9 @@ final class AuthService {
             accounts = try modelContext.fetch(descriptor)
             currentAccount = accounts.first(where: { $0.isActive }) ?? accounts.first
             Self.logger.info("Loaded \(self.accounts.count) accounts, current: \(self.currentAccount?.username ?? "none", privacy: .public)@\(self.currentAccount?.instance ?? "none", privacy: .public)")
+            Task {
+                await refreshClientAuthenticationState()
+            }
         } catch {
             Self.logger.error("Failed to load accounts: \(error.localizedDescription)")
         }
@@ -93,6 +96,10 @@ final class AuthService {
         currentAccount = account
         
         try? modelContext.save()
+
+        Task {
+            await refreshClientAuthenticationState()
+        }
         
         NotificationCenter.default.post(name: .accountDidChange, object: account)
     }
@@ -212,6 +219,7 @@ final class AuthService {
             // Update state
             accounts.append(account)
             currentAccount = account
+            await refreshClientAuthenticationState()
             
             // Clear pending state
             pendingInstance = nil
@@ -264,6 +272,8 @@ final class AuthService {
             currentAccount?.isActive = true
             Self.logger.info("Switched to account: \(self.currentAccount?.username ?? "none", privacy: .public)")
         }
+
+        await refreshClientAuthenticationState()
         
         Self.logger.notice("Logout complete for account: \(account.id.prefix(8), privacy: .public)")
         NotificationCenter.default.post(name: .accountDidLogout, object: account)
@@ -336,6 +346,18 @@ final class AuthService {
             // Token is invalid or expired
             return false
         }
+    }
+
+    func refreshClientAuthenticationState() async {
+        guard let account = currentAccount,
+              let token = await getAccessToken(for: account) else {
+            client.currentInstance = nil
+            client.currentAccessToken = nil
+            return
+        }
+
+        client.currentInstance = account.instance
+        client.currentAccessToken = token
     }
     
     /// Handles authentication errors by verifying token and prompting re-auth if needed

--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -42,7 +42,7 @@ final class LinkFilterService {
     var isLoadingAttributions = false
     
     init(attributionChecker: AttributionChecker? = nil) {
-        self.attributionChecker = attributionChecker ?? AttributionChecker()
+        self.attributionChecker = attributionChecker ?? AttributionChecker.shared
     }
     
     // MARK: - Feed Management
@@ -102,13 +102,15 @@ final class LinkFilterService {
         loadingFeeds.insert(feedId)
         defer { loadingFeeds.remove(feedId) }
 
+        let existingStatuses = feedCache[feedId] ?? []
         let processed = await Task.detached(priority: .userInitiated) {
             Self.buildLinkStatuses(from: statuses)
         }.value
 
-        feedCache[feedId] = processed.linkStatuses
-        Self.logger.info("Processed feed '\(feedId, privacy: .public)': \(processed.linkStatuses.count) link statuses (\(processed.cardCount) from cards, \(processed.contentLinkCount) from content)")
-        return processed.linkStatuses
+        let mergedStatuses = Self.mergeExistingMetadata(from: existingStatuses, into: processed.linkStatuses)
+        feedCache[feedId] = mergedStatuses
+        Self.logger.info("Processed feed '\(feedId, privacy: .public)': \(mergedStatuses.count) link statuses (\(processed.cardCount) from cards, \(processed.contentLinkCount) from content)")
+        return mergedStatuses
     }
     
     /// Processes statuses into LinkStatus objects (uses active feed)
@@ -198,26 +200,7 @@ final class LinkFilterService {
                     if let attribution,
                        var cached = feedCache[currentFeedId],
                        originalIndex < cached.count {
-                        // Create updated LinkStatus with all attribution fields
-                        let existing = cached[originalIndex]
-                        let updated = LinkStatus(
-                            status: existing.status,
-                            primaryURL: existing.primaryURL,
-                            tags: existing.tags,
-                            title: existing.title,
-                            description: existing.description,
-                            imageURL: existing.imageURL,
-                            providerName: existing.providerName,
-                            // Preserve existing authorAttribution if it exists, otherwise use new one
-                            authorAttribution: existing.authorAttribution ?? attribution.name,
-                            // Update URL if we got a better one
-                            authorURL: attribution.url ?? existing.authorURL,
-                            authorProfilePictureURL: attribution.profilePictureURL ?? existing.authorProfilePictureURL,
-                            // Always update Mastodon fields if found
-                            mastodonHandle: attribution.mastodonHandle ?? existing.mastodonHandle,
-                            mastodonProfileURL: attribution.mastodonProfileURL ?? existing.mastodonProfileURL
-                        )
-                        cached[originalIndex] = updated
+                        cached[originalIndex] = Self.merging(cached[originalIndex], with: attribution)
                         feedCache[currentFeedId] = cached
                         attributionCount += 1
                     }
@@ -427,6 +410,29 @@ final class LinkFilterService {
     func filterWithImages() -> [LinkStatus] {
         linkStatuses.filter { $0.imageURL != nil }
     }
+
+    func applyAttribution(_ attribution: AuthorAttribution, toLinkStatusID linkStatusID: String) {
+        var updatedFeedIds: [String] = []
+
+        for (feedId, statuses) in feedCache {
+            var updatedStatuses = statuses
+            var didUpdateFeed = false
+
+            for index in updatedStatuses.indices where updatedStatuses[index].id == linkStatusID {
+                updatedStatuses[index] = Self.merging(updatedStatuses[index], with: attribution)
+                didUpdateFeed = true
+            }
+
+            if didUpdateFeed {
+                feedCache[feedId] = updatedStatuses
+                updatedFeedIds.append(feedId)
+            }
+        }
+
+        if !updatedFeedIds.isEmpty {
+            Self.logger.debug("Applied attribution to link status \(linkStatusID, privacy: .public) across \(updatedFeedIds.count) feeds")
+        }
+    }
     
     // MARK: - Clear
     
@@ -434,6 +440,54 @@ final class LinkFilterService {
         let count = linkStatuses.count
         linkStatuses = []
         Self.logger.info("Cleared link statuses: \(count) items removed")
+    }
+
+    private nonisolated static func mergeExistingMetadata(
+        from existingStatuses: [LinkStatus],
+        into newStatuses: [LinkStatus]
+    ) -> [LinkStatus] {
+        guard !existingStatuses.isEmpty, !newStatuses.isEmpty else { return newStatuses }
+
+        let existingByID = Dictionary(uniqueKeysWithValues: existingStatuses.map { ($0.id, $0) })
+        return newStatuses.map { newStatus in
+            guard let existing = existingByID[newStatus.id] else { return newStatus }
+            return merging(newStatus, with: existing)
+        }
+    }
+
+    private nonisolated static func merging(_ base: LinkStatus, with existing: LinkStatus) -> LinkStatus {
+        LinkStatus(
+            status: base.status,
+            primaryURL: base.primaryURL,
+            tags: base.tags,
+            title: base.title ?? existing.title,
+            description: base.description ?? existing.description,
+            imageURL: base.imageURL ?? existing.imageURL,
+            providerName: base.providerName ?? existing.providerName,
+            authorAttribution: existing.authorAttribution ?? base.authorAttribution,
+            authorURL: existing.authorURL ?? base.authorURL,
+            authorProfilePictureURL: existing.authorProfilePictureURL ?? base.authorProfilePictureURL,
+            mastodonHandle: existing.mastodonHandle ?? base.mastodonHandle,
+            mastodonProfileURL: existing.mastodonProfileURL ?? base.mastodonProfileURL
+        )
+    }
+
+    private nonisolated static func merging(_ linkStatus: LinkStatus, with attribution: AuthorAttribution) -> LinkStatus {
+        let preferredAuthorName = attribution.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return LinkStatus(
+            status: linkStatus.status,
+            primaryURL: linkStatus.primaryURL,
+            tags: linkStatus.tags,
+            title: linkStatus.title,
+            description: linkStatus.description,
+            imageURL: linkStatus.imageURL,
+            providerName: linkStatus.providerName,
+            authorAttribution: (preferredAuthorName?.isEmpty == false ? preferredAuthorName : nil) ?? linkStatus.authorAttribution,
+            authorURL: attribution.url ?? linkStatus.authorURL,
+            authorProfilePictureURL: attribution.profilePictureURL ?? linkStatus.authorProfilePictureURL,
+            mastodonHandle: attribution.mastodonHandle ?? linkStatus.mastodonHandle,
+            mastodonProfileURL: attribution.mastodonProfileURL ?? linkStatus.mastodonProfileURL
+        )
     }
 }
 

--- a/fedi-reader/Services/LinkPreviewService.swift
+++ b/fedi-reader/Services/LinkPreviewService.swift
@@ -211,24 +211,6 @@ actor LinkPreviewService {
             )
         }
 
-        func metaContent(name: String) -> String? {
-            let pattern = #"<meta[^>]+name\s*=\s*[\"']\#(NSRegularExpression.escapedPattern(for: name))[\"'][^>]+content\s*=\s*[\"']([^\"']+)[\"']"#
-            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else { return nil }
-            let range = NSRange(html.startIndex..., in: html)
-            guard let match = regex.firstMatch(in: html, options: [], range: range),
-                  let contentRange = Range(match.range(at: 1), in: html) else { return nil }
-            return HTMLParser.decodeHTMLEntities(String(html[contentRange]).trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-
-        func metaProperty(_ property: String) -> String? {
-            let pattern = #"<meta[^>]+property\s*=\s*[\"']\#(NSRegularExpression.escapedPattern(for: property))[\"'][^>]+content\s*=\s*[\"']([^\"']+)[\"']"#
-            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else { return nil }
-            let range = NSRange(html.startIndex..., in: html)
-            guard let match = regex.firstMatch(in: html, options: [], range: range),
-                  let contentRange = Range(match.range(at: 1), in: html) else { return nil }
-            return HTMLParser.decodeHTMLEntities(String(html[contentRange]).trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-
         func titleTag() -> String? {
             let pattern = #"<title[^>]*>(.*?)</title>"#
             guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else { return nil }
@@ -239,13 +221,19 @@ actor LinkPreviewService {
         }
 
         // Prefer Open Graph, then Twitter, then standard meta, then <title>
-        let title = metaProperty("og:title") ?? metaContent(name: "twitter:title") ?? metaContent(name: "title") ?? titleTag()
-        let description = metaProperty("og:description") ?? metaContent(name: "twitter:description") ?? metaContent(name: "description")
-        let siteName = metaProperty("og:site_name")
-        let fediverseCreator = metaContent(name: "fediverse:creator")
+        let title = HTMLParser.metaProperty(in: html, property: "og:title")
+            ?? HTMLParser.metaContent(in: html, name: "twitter:title")
+            ?? HTMLParser.metaContent(in: html, name: "title")
+            ?? titleTag()
+        let description = HTMLParser.metaProperty(in: html, property: "og:description")
+            ?? HTMLParser.metaContent(in: html, name: "twitter:description")
+            ?? HTMLParser.metaContent(in: html, name: "description")
+        let siteName = HTMLParser.metaProperty(in: html, property: "og:site_name")
+        let fediverseCreator = HTMLParser.metaContent(in: html, name: "fediverse:creator")
 
         // Image URL resolution
-        let imageString = metaProperty("og:image") ?? metaContent(name: "twitter:image")
+        let imageString = HTMLParser.metaProperty(in: html, property: "og:image")
+            ?? HTMLParser.metaContent(in: html, name: "twitter:image")
         let imageURL: URL? = {
             guard let imageString else { return nil }
             let decoded = HTMLParser.decodeHTMLEntities(imageString)

--- a/fedi-reader/Services/MastodonClient.swift
+++ b/fedi-reader/Services/MastodonClient.swift
@@ -8,12 +8,186 @@
 import Foundation
 import os
 
+nonisolated private func makeMastodonSessionConfiguration(from configuration: URLSessionConfiguration) -> URLSessionConfiguration {
+    let config = (configuration.copy() as? URLSessionConfiguration) ?? URLSessionConfiguration.default
+    config.timeoutIntervalForRequest = 30
+
+    var headers = config.httpAdditionalHeaders ?? [:]
+    headers["User-Agent"] = Constants.userAgent
+    config.httpAdditionalHeaders = headers
+
+    return config
+}
+
+nonisolated private func makeMastodonDecoder() -> JSONDecoder {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .custom { decoder in
+        let container = try decoder.singleValueContainer()
+        let dateString = try container.decode(String.self)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: dateString) {
+            return date
+        }
+
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: dateString) {
+            return date
+        }
+
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format: \(dateString)")
+    }
+    return decoder
+}
+
+nonisolated private func buildMastodonURL(instance: String, path: String, queryItems: [URLQueryItem]? = nil) throws -> URL {
+    guard !instance.isEmpty,
+          !instance.contains("://"),
+          !instance.contains("/"),
+          !instance.contains("?"),
+          !instance.contains("#"),
+          instance.range(of: #"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$"#, options: .regularExpression) != nil else {
+        throw FediReaderError.invalidURL
+    }
+
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = instance
+    components.path = path
+    components.queryItems = queryItems?.isEmpty == false ? queryItems : nil
+
+    guard let url = components.url else {
+        throw FediReaderError.invalidURL
+    }
+    return url
+}
+
+nonisolated private func buildMastodonRequest(
+    url: URL,
+    method: String = "GET",
+    accessToken: String? = nil,
+    body: Data? = nil,
+    contentType: String = "application/json"
+) -> URLRequest {
+    var request = URLRequest(url: url)
+    request.httpMethod = method
+    request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+    if let token = accessToken {
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+
+    if let body {
+        request.httpBody = body
+    }
+
+    return request
+}
+
+nonisolated private struct MastodonAuthSnapshot: Sendable {
+    let instance: String
+    let accessToken: String
+}
+
+private actor MastodonBackgroundRequestExecutor {
+    private static let logger = Logger(subsystem: "app.fedi-reader", category: "MastodonBackgroundRequestExecutor")
+
+    private let session: URLSession
+    private let decoder: JSONDecoder
+
+    init(configuration: URLSessionConfiguration = .default) {
+        let config = makeMastodonSessionConfiguration(from: configuration)
+        self.session = URLSession(configuration: config)
+        self.decoder = makeMastodonDecoder()
+    }
+
+    func searchAccounts(
+        instance: String,
+        accessToken: String,
+        query: String,
+        limit: Int = 20
+    ) async throws -> ([MastodonAccount], HTTPURLResponse) {
+        let url = try buildMastodonURL(
+            instance: instance,
+            path: "/api/v2/search",
+            queryItems: [
+            URLQueryItem(name: "q", value: query),
+                URLQueryItem(name: "resolve", value: String(true)),
+                URLQueryItem(name: "limit", value: String(limit)),
+                URLQueryItem(name: "type", value: "accounts")
+            ]
+        )
+        let request = buildMastodonRequest(url: url, accessToken: accessToken)
+        let (data, response) = try await performRequest(request)
+
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let accountsObject = object["accounts"] else {
+            throw FediReaderError.decodingError(NSError(domain: "MastodonBackgroundRequestExecutor", code: 1))
+        }
+
+        let accountsData = try JSONSerialization.data(withJSONObject: accountsObject)
+        let accounts = try decoder.decode([MastodonAccount].self, from: accountsData)
+        return (accounts, response)
+    }
+
+    func lookupAccount(
+        instance: String,
+        accessToken: String,
+        acct: String
+    ) async throws -> (MastodonAccount, HTTPURLResponse) {
+        let url = try buildMastodonURL(
+            instance: instance,
+            path: "/api/v1/accounts/lookup",
+            queryItems: [URLQueryItem(name: "acct", value: acct)]
+        )
+        let request = buildMastodonRequest(url: url, accessToken: accessToken)
+        let (data, response) = try await performRequest(request)
+        let account = try decoder.decode(MastodonAccount.self, from: data)
+        return (account, response)
+    }
+
+    private func performRequest(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let method = request.httpMethod ?? "GET"
+        let url = request.url?.absoluteString ?? "unknown"
+
+        do {
+            let (data, response) = try await session.data(for: request)
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw FediReaderError.invalidResponse
+            }
+
+            switch httpResponse.statusCode {
+            case 200..<300:
+                return (data, httpResponse)
+            case 401:
+                throw FediReaderError.unauthorized
+            case 429:
+                let retryAfter = httpResponse.value(forHTTPHeaderField: "Retry-After")
+                    .flatMap { Double($0) }
+                throw FediReaderError.rateLimited(retryAfter: retryAfter)
+            default:
+                let message = String(data: data, encoding: .utf8)
+                throw FediReaderError.serverError(statusCode: httpResponse.statusCode, message: message)
+            }
+        } catch let error as FediReaderError {
+            throw error
+        } catch {
+            Self.logger.debug("Background request failed for \(method, privacy: .public) \(url, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+    }
+}
+
 @Observable
 @MainActor
 final class MastodonClient {
-    private static let logger = Logger(subsystem: "app.fedi-reader", category: "MastodonClient")
+    nonisolated private static let logger = Logger(subsystem: "app.fedi-reader", category: "MastodonClient")
     
     private let session: URLSession
+    nonisolated private let backgroundRequestExecutor: MastodonBackgroundRequestExecutor
     private let decoder: JSONDecoder
     private let encoder: JSONEncoder
     
@@ -25,34 +199,12 @@ final class MastodonClient {
     var currentInstance: String?
     var currentAccessToken: String?
     
-    init() {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = Constants.API.defaultTimeout
-        config.httpAdditionalHeaders = [
-            "User-Agent": Constants.userAgent
-        ]
+    init(configuration: URLSessionConfiguration = .default) {
+        let config = makeMastodonSessionConfiguration(from: configuration)
         self.session = URLSession(configuration: config)
+        self.backgroundRequestExecutor = MastodonBackgroundRequestExecutor(configuration: config)
 
-        self.decoder = JSONDecoder()
-        self.decoder.dateDecodingStrategy = .custom { decoder in
-            let container = try decoder.singleValueContainer()
-            let dateString = try container.decode(String.self)
-
-            // Try ISO8601 with fractional seconds
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let date = formatter.date(from: dateString) {
-                return date
-            }
-
-            // Try without fractional seconds
-            formatter.formatOptions = [.withInternetDateTime]
-            if let date = formatter.date(from: dateString) {
-                return date
-            }
-
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format: \(dateString)")
-        }
+        self.decoder = makeMastodonDecoder()
 
         self.encoder = JSONEncoder()
         self.encoder.dateEncodingStrategy = .iso8601
@@ -61,28 +213,12 @@ final class MastodonClient {
     // MARK: - Request Building
     
     private func buildURL(instance: String, path: String, queryItems: [URLQueryItem]? = nil) throws -> URL {
-        // Security: Validate instance format to prevent SSRF attacks
-        // Instance should be a valid hostname without protocol
-        guard !instance.isEmpty,
-              !instance.contains("://"),
-              !instance.contains("/"),
-              !instance.contains("?"),
-              !instance.contains("#"),
-              instance.range(of: #"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$"#, options: .regularExpression) != nil else {
+        do {
+            return try buildMastodonURL(instance: instance, path: path, queryItems: queryItems)
+        } catch {
             Self.logger.error("Invalid instance format: \(instance, privacy: .public)")
-            throw FediReaderError.invalidURL
+            throw error
         }
-        
-        var components = URLComponents()
-        components.scheme = "https"
-        components.host = instance
-        components.path = path
-        components.queryItems = queryItems?.isEmpty == false ? queryItems : nil
-        
-        guard let url = components.url else {
-            throw FediReaderError.invalidURL
-        }
-        return url
     }
     
     private func buildRequest(
@@ -92,20 +228,13 @@ final class MastodonClient {
         body: Data? = nil,
         contentType: String = "application/json"
     ) -> URLRequest {
-        var request = URLRequest(url: url)
-        request.httpMethod = method
-        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        
-        if let token = accessToken {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        
-        if let body {
-            request.httpBody = body
-        }
-        
-        return request
+        buildMastodonRequest(
+            url: url,
+            method: method,
+            accessToken: accessToken,
+            body: body,
+            contentType: contentType
+        )
     }
 
     private func formEncodedBody(_ items: [URLQueryItem]) -> Data? {
@@ -238,6 +367,22 @@ final class MastodonClient {
            let resetTime = ISO8601DateFormatter().date(from: reset) {
             rateLimitReset = resetTime
             Self.logger.debug("Rate limit resets at: \(resetTime.formatted())")
+        }
+    }
+
+    nonisolated private func currentAuthSnapshot() async throws -> MastodonAuthSnapshot {
+        try await MainActor.run {
+            guard let instance = self.currentInstance, let accessToken = self.currentAccessToken else {
+                throw FediReaderError.noActiveAccount
+            }
+
+            return MastodonAuthSnapshot(instance: instance, accessToken: accessToken)
+        }
+    }
+
+    nonisolated private func publishRateLimits(from response: HTTPURLResponse) async {
+        await MainActor.run {
+            self.updateRateLimits(from: response)
         }
     }
     
@@ -808,19 +953,56 @@ final class MastodonClient {
         return try await getHashtagTimeline(instance: instance, accessToken: token, tag: tag, limit: limit)
     }
     
-    func searchAccounts(query: String, limit: Int = 10) async throws -> [MastodonAccount] {
-        guard let instance = currentInstance, let token = currentAccessToken else {
-            throw FediReaderError.noActiveAccount
-        }
-        let results = try await search(instance: instance, accessToken: token, query: query, type: "accounts", limit: limit)
-        return results.accounts
+    nonisolated func searchAccounts(query: String, limit: Int = 10) async throws -> [MastodonAccount] {
+        let auth = try await currentAuthSnapshot()
+        let (accounts, response) = try await backgroundRequestExecutor.searchAccounts(
+            instance: auth.instance,
+            accessToken: auth.accessToken,
+            query: query,
+            limit: limit
+        )
+        await publishRateLimits(from: response)
+        return accounts
     }
 
-    func lookupAccount(acct: String) async throws -> MastodonAccount {
-        guard let instance = currentInstance, let token = currentAccessToken else {
-            throw FediReaderError.noActiveAccount
+    nonisolated func lookupAccount(acct: String) async throws -> MastodonAccount {
+        let auth = try await currentAuthSnapshot()
+        return try await lookupAccount(instance: auth.instance, accessToken: auth.accessToken, acct: acct)
+    }
+
+    nonisolated func resolveProfileAccount(handle: String? = nil, profileURL: URL? = nil) async -> MastodonAccount? {
+        guard let acct = MastodonProfileReference.acct(handle: handle, profileURL: profileURL) else {
+            return nil
         }
-        return try await lookupAccount(instance: instance, accessToken: token, acct: acct)
+
+        let normalizedAcct = acct.lowercased()
+
+        do {
+            return try await lookupAccount(acct: acct)
+        } catch {
+            Self.logger.debug("Account lookup failed for \(acct, privacy: .public); falling back to search")
+        }
+
+        do {
+            let accounts = try await searchAccounts(query: acct, limit: 5)
+            return accounts.first { account in
+                if let resolvedAcct = MastodonProfileReference.normalizedAcct(from: account.acct),
+                   resolvedAcct.lowercased() == normalizedAcct {
+                    return true
+                }
+
+                if let accountURL = URL(string: account.url),
+                   let resolvedAcct = MastodonProfileReference.acct(from: accountURL),
+                   resolvedAcct.lowercased() == normalizedAcct {
+                    return true
+                }
+
+                return false
+            }
+        } catch {
+            Self.logger.debug("Account search failed for \(acct, privacy: .public): \(error.localizedDescription)")
+            return nil
+        }
     }
     
     func getHashtagTimeline(instance: String, accessToken: String, tag: String, limit: Int = Constants.Pagination.defaultLimit) async throws -> [Status] {
@@ -935,30 +1117,41 @@ final class MastodonClient {
         resolve: Bool = true,
         limit: Int = 20
     ) async throws -> SearchResults {
+        if type == "accounts", resolve {
+            let (accounts, response) = try await backgroundRequestExecutor.searchAccounts(
+                instance: instance,
+                accessToken: accessToken,
+                query: query,
+                limit: limit
+            )
+            updateRateLimits(from: response)
+            return SearchResults(accounts: accounts, statuses: [], hashtags: [])
+        }
+
         var queryItems = [
             URLQueryItem(name: "q", value: query),
             URLQueryItem(name: "resolve", value: String(resolve)),
             URLQueryItem(name: "limit", value: String(limit))
         ]
         if let type { queryItems.append(URLQueryItem(name: "type", value: type)) }
-        
+
         let url = try buildURL(instance: instance, path: Constants.API.search, queryItems: queryItems)
         let request = buildRequest(url: url, accessToken: accessToken)
         return try await execute(request)
     }
 
-    func lookupAccount(
+    nonisolated func lookupAccount(
         instance: String,
         accessToken: String,
         acct: String
     ) async throws -> MastodonAccount {
-        let url = try buildURL(
+        let (account, response) = try await backgroundRequestExecutor.lookupAccount(
             instance: instance,
-            path: "\(Constants.API.accounts)/lookup",
-            queryItems: [URLQueryItem(name: "acct", value: acct)]
+            accessToken: accessToken,
+            acct: acct
         )
-        let request = buildRequest(url: url, accessToken: accessToken)
-        return try await execute(request)
+        await publishRateLimits(from: response)
+        return account
     }
     
     // MARK: - Instance

--- a/fedi-reader/Utilities/HTMLParser/HTMLParser.swift
+++ b/fedi-reader/Utilities/HTMLParser/HTMLParser.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 struct HTMLParser: Sendable {
+
+    struct AuthorRelation: Equatable, Sendable {
+        let href: String
+        let text: String?
+    }
     
     // MARK: - Link Extraction
     
@@ -31,6 +36,46 @@ struct HTMLParser: Sendable {
         }
         
         return urls
+    }
+
+    // MARK: - HTML Metadata Extraction
+
+    nonisolated static func metaContent(in html: String, name: String) -> String? {
+        tagAttributeValue(in: html, tagName: "meta", targetAttribute: "content") { attributes in
+            guard let candidate = attributes["name"] else { return false }
+            return candidate.caseInsensitiveCompare(name) == .orderedSame
+        }
+    }
+
+    nonisolated static func metaProperty(in html: String, property: String) -> String? {
+        tagAttributeValue(in: html, tagName: "meta", targetAttribute: "content") { attributes in
+            guard let candidate = attributes["property"] else { return false }
+            return candidate.caseInsensitiveCompare(property) == .orderedSame
+        }
+    }
+
+    nonisolated static func linkHref(in html: String, rel: String) -> String? {
+        tagAttributeValue(in: html, tagName: "link", targetAttribute: "href") { attributes in
+            relationTokens(in: attributes).contains { token in
+                token.caseInsensitiveCompare(rel) == .orderedSame
+            }
+        }
+    }
+
+    nonisolated static func authorRelation(in html: String) -> AuthorRelation? {
+        if let anchor = tagAttributeAndInnerText(in: html, tagName: "a", targetAttribute: "href", where: hasAuthorRelation) {
+            return AuthorRelation(href: anchor.value, text: anchor.text)
+        }
+
+        if let areaHref = tagAttributeValue(in: html, tagName: "area", targetAttribute: "href", where: hasAuthorRelation) {
+            return AuthorRelation(href: areaHref, text: nil)
+        }
+
+        if let linkHref = linkHref(in: html, rel: "author") {
+            return AuthorRelation(href: linkHref, text: nil)
+        }
+
+        return nil
     }
     
     /// Extracts external links (excludes Mastodon internal links like mentions and hashtags)
@@ -261,6 +306,121 @@ struct HTMLParser: Sendable {
         }
         
         return result
+    }
+
+    nonisolated private static func tagAttributeValue(
+        in html: String,
+        tagName: String,
+        targetAttribute: String,
+        where predicate: ([String: String]) -> Bool
+    ) -> String? {
+        let pattern = #"<\#(tagName)\b[^>]*>"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+
+        let range = NSRange(html.startIndex..., in: html)
+        let tagMatches = regex.matches(in: html, options: [], range: range)
+
+        for match in tagMatches {
+            guard let tagRange = Range(match.range, in: html) else { continue }
+            let tag = String(html[tagRange])
+            let attributes = extractAttributes(from: tag)
+            guard predicate(attributes),
+                  let rawValue = attributes[targetAttribute]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !rawValue.isEmpty else {
+                continue
+            }
+
+            return decodeHTMLEntities(rawValue)
+        }
+
+        return nil
+    }
+
+    nonisolated private static func tagAttributeAndInnerText(
+        in html: String,
+        tagName: String,
+        targetAttribute: String,
+        where predicate: ([String: String]) -> Bool
+    ) -> (value: String, text: String?)? {
+        let pattern = #"<\#(tagName)\b[^>]*>(.*?)</\#(tagName)\s*>"#
+
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return nil
+        }
+
+        let range = NSRange(html.startIndex..., in: html)
+        let matches = regex.matches(in: html, options: [], range: range)
+
+        for match in matches {
+            guard let elementRange = Range(match.range, in: html),
+                  let contentRange = Range(match.range(at: 1), in: html) else {
+                continue
+            }
+
+            let element = String(html[elementRange])
+            guard let openingTagEnd = element.firstIndex(of: ">") else { continue }
+
+            let openingTag = String(element[..<element.index(after: openingTagEnd)])
+            let attributes = extractAttributes(from: openingTag)
+            guard predicate(attributes),
+                  let rawValue = attributes[targetAttribute]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !rawValue.isEmpty else {
+                continue
+            }
+
+            let text = stripHTML(String(html[contentRange])).trimmingCharacters(in: .whitespacesAndNewlines)
+            return (
+                decodeHTMLEntities(rawValue),
+                text.isEmpty ? nil : text
+            )
+        }
+
+        return nil
+    }
+
+    nonisolated private static func hasAuthorRelation(attributes: [String: String]) -> Bool {
+        relationTokens(in: attributes).contains { token in
+            token.caseInsensitiveCompare("author") == .orderedSame
+        }
+    }
+
+    nonisolated private static func relationTokens(in attributes: [String: String]) -> [Substring] {
+        guard let relValue = attributes["rel"] else { return [] }
+        return relValue.split(whereSeparator: \.isWhitespace)
+    }
+
+    nonisolated private static func extractAttributes(from tag: String) -> [String: String] {
+        let pattern = #"([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return [:]
+        }
+
+        let range = NSRange(tag.startIndex..., in: tag)
+        let matches = regex.matches(in: tag, options: [], range: range)
+
+        var attributes: [String: String] = [:]
+        attributes.reserveCapacity(matches.count)
+
+        for match in matches {
+            guard let keyRange = Range(match.range(at: 1), in: tag) else { continue }
+
+            let key = String(tag[keyRange]).lowercased()
+            let valueRange = Range(match.range(at: 2), in: tag)
+                ?? Range(match.range(at: 3), in: tag)
+                ?? Range(match.range(at: 4), in: tag)
+
+            guard let valueRange else { continue }
+            attributes[key] = String(tag[valueRange])
+        }
+
+        return attributes
     }
     
     // MARK: - URL Helpers
@@ -508,5 +668,3 @@ struct HTMLParser: Sendable {
 }
 
 // MARK: - String Extension
-
-

--- a/fedi-reader/Utilities/MastodonProfileReference.swift
+++ b/fedi-reader/Utilities/MastodonProfileReference.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum MastodonProfileReference {
+    nonisolated static func normalizedAcct(from handle: String) -> String? {
+        let trimmed = handle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let withoutLeadingAt = trimmed.hasPrefix("@") ? String(trimmed.dropFirst()) : trimmed
+        let parts = withoutLeadingAt.split(separator: "@", maxSplits: 1).map(String.init)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+
+        return "\(parts[0])@\(parts[1].lowercased())"
+    }
+
+    nonisolated static func acct(from url: URL) -> String? {
+        guard let host = url.host?.lowercased() else { return nil }
+
+        let pathComponents = url.pathComponents.filter { $0 != "/" && !$0.isEmpty }
+        guard !pathComponents.isEmpty else { return nil }
+
+        let username: String?
+        if let first = pathComponents.first, first.hasPrefix("@"), first.count > 1 {
+            username = String(first.dropFirst())
+        } else if pathComponents.count >= 2, pathComponents[0].caseInsensitiveCompare("users") == .orderedSame {
+            username = pathComponents[1]
+        } else {
+            username = nil
+        }
+
+        guard let username,
+              let decodedUsername = username.removingPercentEncoding?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !decodedUsername.isEmpty else {
+            return nil
+        }
+
+        return "\(decodedUsername)@\(host)"
+    }
+
+    nonisolated static func acct(handle: String?, profileURL: URL?) -> String? {
+        if let handle, let acct = normalizedAcct(from: handle) {
+            return acct
+        }
+
+        if let profileURL, let acct = acct(from: profileURL) {
+            return acct
+        }
+
+        return nil
+    }
+}

--- a/fedi-reader/Views/Components/LinkCardContent.swift
+++ b/fedi-reader/Views/Components/LinkCardContent.swift
@@ -113,17 +113,21 @@ extension LinkCardContent {
         showLinkIcon = false
     }
 
-    init(card: PreviewCard, fediverseCreatorName: String?, fediverseCreatorURL: URL?) {
+    init(card: PreviewCard, authorAttribution: AuthorAttribution?, authorDisplayName: String? = nil) {
         title = card.title
         description = card.description
         imageURL = card.imageURL
         providerDisplay = card.providerName ?? (URL(string: card.url).flatMap { HTMLParser.extractDomain(from: $0) } ?? card.url)
-        if let n = fediverseCreatorName {
-            authorName = n
-            authorURL = fediverseCreatorURL
-        } else if let n = card.authorName {
-            authorName = n
-            authorURL = card.authorUrl.flatMap { URL(string: $0) }
+        let cardAuthorURL = card.authorUrl.flatMap { URL(string: $0) }
+        let resolvedAuthorName = authorDisplayName ?? authorAttribution?.preferredName ?? card.authorName
+        let resolvedAuthorURL = authorAttribution?.preferredURL ?? cardAuthorURL
+
+        if let resolvedAuthorURL {
+            authorName = resolvedAuthorName ?? "Author"
+            authorURL = resolvedAuthorURL
+        } else if let resolvedAuthorName {
+            authorName = resolvedAuthorName
+            authorURL = nil
         } else {
             authorName = nil
             authorURL = nil

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -34,8 +34,6 @@ struct LinkFeedContentView: View {
     @State private var retainedLists: [MastodonList] = []
     @State private var feedTabSelectionTracker = SelectionDoubleTapTracker<String>()
     @State private var tabFrames: [Int: CGRect] = [:]
-    // Scroll position preservation per feed id
-    @State private var lastVisibleStatusIdPerFeed: [String: String] = [:]
     @State private var hasRestoredScrollForCurrentTab: Bool = false
 
     private var timelineService: TimelineService? {
@@ -244,8 +242,7 @@ struct LinkFeedContentView: View {
             onArticleSelect: onArticleSelect,
             scrollProxy: $scrollProxy,
             onFirstVisibleChange: { statusId in
-                // Persist the last visible status id for the current feed tab
-                lastVisibleStatusIdPerFeed[currentTab.id] = statusId
+                appState.linksLastVisibleStatusIdPerFeed[currentTab.id] = statusId
             },
             onListAppear: {
                 // When the list appears (e.g., popped back from article), try to restore once
@@ -426,7 +423,15 @@ struct LinkFeedContentView: View {
             selectedTabIndex = index
         }
 
-        await loadContentForTab(currentTab, forceRefresh: true)
+        linkFilterService.switchToFeed(currentTab.id)
+
+        if linkFilterService.hasCachedContent(for: currentTab.id) {
+            Task {
+                await linkFilterService.enrichWithAttributions()
+            }
+        } else {
+            await loadContentForTab(currentTab, forceRefresh: true)
+        }
 
         Task.detached(priority: .background) { [feedTabs, selectedTabIndex] in
             await prefetchAdjacentFeeds(currentIndex: selectedTabIndex, tabs: feedTabs)
@@ -520,7 +525,7 @@ struct LinkFeedContentView: View {
         guard let proxy = scrollProxy else { return }
         guard !hasRestoredScrollForCurrentTab else { return }
         let feedId = currentTab.id
-        guard let statusId = lastVisibleStatusIdPerFeed[feedId] else { return }
+        guard let statusId = appState.linksLastVisibleStatusIdPerFeed[feedId] else { return }
         // Avoid animating to reduce visual jump
         DispatchQueue.main.async {
             withAnimation(nil) {

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedPostList.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedPostList.swift
@@ -126,12 +126,13 @@ struct LinkFeedPostList: View {
     
     private func reportFirstVisibleIfNeeded() {
         guard !rowTopOffsets.isEmpty else { return }
-        // Consider the smallest positive or closest to zero minY as top-most
-        let candidate = rowTopOffsets.min(by: { lhs, rhs in
-            let a = abs(lhs.value)
-            let b = abs(rhs.value)
-            return a < b
-        })
+        let visibleCandidate = rowTopOffsets
+            .filter { $0.value >= 0 }
+            .min(by: { $0.value < $1.value })
+        let candidate = visibleCandidate
+            ?? rowTopOffsets
+                .filter { $0.value < 0 }
+                .max(by: { $0.value < $1.value })
         guard let (id, _) = candidate else { return }
         if currentFirstVisibleId != id {
             currentFirstVisibleId = id

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -28,6 +28,7 @@ struct LinkFeedThreeColumnView: View {
     @State private var isPaginating = false
     @State private var retainedLists: [MastodonList] = []
     @State private var feedTabSelectionTracker = SelectionDoubleTapTracker<String>()
+    @State private var hasRestoredScrollForCurrentTab = false
 
     private static let minListsWidth: CGFloat = 150
     private static let minPostsWidth: CGFloat = 200
@@ -263,6 +264,10 @@ struct LinkFeedThreeColumnView: View {
                 retainedLists = cachedLists
             }
             syncRetainedLists(with: liveLists, allowEmpty: false)
+            attemptRestoreScrollIfNeeded()
+        }
+        .onDisappear {
+            hasRestoredScrollForCurrentTab = false
         }
     }
 
@@ -321,7 +326,13 @@ struct LinkFeedThreeColumnView: View {
                     onArticleSelect: { url, status in
                         selectedArticle = (url: url, status: status)
                     },
-                    scrollProxy: $scrollProxy
+                    scrollProxy: $scrollProxy,
+                    onFirstVisibleChange: { statusId in
+                        appState.linksLastVisibleStatusIdPerFeed[currentTab.id] = statusId
+                    },
+                    onListAppear: {
+                        attemptRestoreScrollIfNeeded()
+                    }
                 )
             }
         }
@@ -395,6 +406,7 @@ struct LinkFeedThreeColumnView: View {
     }
 
     private func handleTabChange(to newIndex: Int) {
+        hasRestoredScrollForCurrentTab = false
         guard newIndex >= 0, newIndex < feedTabs.count else { return }
 
         let tab = feedTabs[newIndex]
@@ -469,7 +481,15 @@ struct LinkFeedThreeColumnView: View {
             selectedTabIndex = index
         }
 
-        await loadContentForTab(currentTab, forceRefresh: true)
+        linkFilterService.switchToFeed(currentTab.id)
+
+        if linkFilterService.hasCachedContent(for: currentTab.id) {
+            Task {
+                await linkFilterService.enrichWithAttributions()
+            }
+        } else {
+            await loadContentForTab(currentTab, forceRefresh: true)
+        }
 
         Task.detached(priority: .background) { [feedTabs, selectedTabIndex] in
             await prefetchAdjacentFeeds(currentIndex: selectedTabIndex, tabs: feedTabs)
@@ -554,6 +574,19 @@ struct LinkFeedThreeColumnView: View {
             let newStatuses = await service.loadMoreListTimeline(listId: tab.id)
             guard !newStatuses.isEmpty else { return }
             _ = await linkFilterService.appendStatuses(newStatuses, for: tab.id)
+        }
+    }
+
+    private func attemptRestoreScrollIfNeeded() {
+        guard let proxy = scrollProxy else { return }
+        guard !hasRestoredScrollForCurrentTab else { return }
+        guard let statusId = appState.linksLastVisibleStatusIdPerFeed[currentTab.id] else { return }
+
+        DispatchQueue.main.async {
+            withAnimation(nil) {
+                proxy.scrollTo(statusId, anchor: .top)
+            }
+            hasRestoredScrollForCurrentTab = true
         }
     }
 }

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
@@ -20,6 +20,7 @@ struct LinkStatusRow: View {
     var onArticleSelect: ((URL, Status) -> Void)?
 
     @Environment(AppState.self) private var appState
+    @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(\.openURL) private var openURL
     @Environment(ReadLaterManager.self) private var readLaterManager
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
@@ -28,6 +29,7 @@ struct LinkStatusRow: View {
 
     @State private var blueskyDescription: String?
     @State private var hasLoadedBlueskyDescription = false
+    @State private var localAuthorAttribution: AuthorAttribution?
     @State private var resolvedMastodonAccount: MastodonAccount?
     @State private var isProcessing = false
     @State private var localBookmarked: Bool?
@@ -106,6 +108,9 @@ struct LinkStatusRow: View {
             guard let url = blueskyCardURL, !hasLoadedBlueskyDescription else { return }
             hasLoadedBlueskyDescription = true
             blueskyDescription = await LinkPreviewService.shared.fetchDescription(for: url)
+        }
+        .task(id: authorAttributionTaskID) {
+            await ensureAuthorAttributionLoaded()
         }
     }
 
@@ -198,6 +203,13 @@ struct LinkStatusRow: View {
         return host.contains("bsky.app") || host.contains("bsky.social")
     }
 
+    private var showsAuthorAttribution: Bool {
+        let hasAuthorName = effectiveAuthorAttribution?.preferredName?.isEmpty == false
+        let hasAuthorURL = effectiveAuthorAttribution?.preferredURL != nil
+        let hasMastodonAttribution = effectiveAuthorAttribution?.mastodonHandle != nil || effectiveAuthorAttribution?.mastodonProfileURL != nil
+        return hasAuthorName || hasAuthorURL || hasMastodonAttribution
+    }
+
     private var linkCard: some View {
         Button {
             deferPostNavigation {
@@ -244,8 +256,7 @@ struct LinkStatusRow: View {
                         .lineLimit(3)
                         .multilineTextAlignment(.leading)
 
-                    // Prominent author attribution (only if valid author tag exists)
-                    if let authorName = linkStatus.authorAttribution, !authorName.isEmpty {
+                    if showsAuthorAttribution {
                         authorAttributionView
                     }
 
@@ -295,65 +306,44 @@ struct LinkStatusRow: View {
     
     @ViewBuilder
     private var authorAttributionView: some View {
-        // Show attribution if we have a name, OR if we have a Mastodon handle/profile URL
-        let hasAuthorName = linkStatus.authorAttribution != nil && !linkStatus.authorAttribution!.isEmpty
-        let hasMastodonAttribution = linkStatus.mastodonHandle != nil || linkStatus.mastodonProfileURL != nil
-        
-        if hasAuthorName || hasMastodonAttribution {
-            let authorName = linkStatus.authorAttribution ?? linkStatus.mastodonHandle ?? "Author"
-            let profilePictureURL = linkStatus.authorProfilePictureURL.flatMap { URL(string: $0) }
-            let isMastodonProfile = linkStatus.mastodonProfileURL != nil
-            let destinationURL: String? = linkStatus.mastodonProfileURL ?? linkStatus.authorURL
-            
-            if let destinationURL {
-                if isMastodonProfile {
-                    // Mastodon profile - navigate in-app
-                    Button {
-                        deferPostNavigation {
-                            handleMastodonProfileNavigation(url: destinationURL)
-                        }
-                    } label: {
-                        authorAttributionContent(
-                            authorName: authorName,
-                            profilePictureURL: profilePictureURL,
-                            mastodonHandle: linkStatus.mastodonHandle,
-                            showNavigationIcon: true
-                        )
+        if showsAuthorAttribution {
+            let authorName = resolvedMastodonAccount?.preferredDisplayName
+                ?? effectiveAuthorAttribution?.preferredName
+                ?? "Author"
+            let profilePictureURL = effectiveAuthorAttribution?.profilePictureURL.flatMap { URL(string: $0) }
+            if authorURL != nil {
+                Button {
+                    deferPostNavigation {
+                        handleAuthorAttributionNavigation()
                     }
-                    .buttonStyle(.plain)
-                    .task(id: destinationURL) {
-                        await resolveMastodonAccount(url: destinationURL)
-                    }
-                } else if let url = URL(string: destinationURL) {
-                    // Regular author URL - open in browser after deferred swipe/tap validation.
-                    Button {
-                        deferPostNavigation {
-                            openURL(url)
-                        }
-                    } label: {
-                        authorAttributionContent(
-                            authorName: authorName,
-                            profilePictureURL: profilePictureURL,
-                            mastodonHandle: linkStatus.mastodonHandle,
-                            showNavigationIcon: true
-                        )
-                    }
-                    .buttonStyle(.plain)
-                } else {
-                    // No valid link, just show attribution
+                } label: {
                     authorAttributionContent(
                         authorName: authorName,
                         profilePictureURL: profilePictureURL,
-                        mastodonHandle: linkStatus.mastodonHandle,
-                        showNavigationIcon: false
+                        mastodonHandle: effectiveAuthorAttribution?.mastodonHandle,
+                        showNavigationIcon: true
                     )
                 }
+                .buttonStyle(.plain)
+            } else if effectiveAuthorAttribution?.mastodonHandle != nil {
+                Button {
+                    deferPostNavigation {
+                        handleAuthorAttributionNavigation()
+                    }
+                } label: {
+                    authorAttributionContent(
+                        authorName: authorName,
+                        profilePictureURL: profilePictureURL,
+                        mastodonHandle: effectiveAuthorAttribution?.mastodonHandle,
+                        showNavigationIcon: true
+                    )
+                }
+                .buttonStyle(.plain)
             } else {
-                // No link, just show attribution
                 authorAttributionContent(
                     authorName: authorName,
                     profilePictureURL: profilePictureURL,
-                    mastodonHandle: linkStatus.mastodonHandle,
+                    mastodonHandle: effectiveAuthorAttribution?.mastodonHandle,
                     showNavigationIcon: false
                 )
             }
@@ -404,76 +394,97 @@ struct LinkStatusRow: View {
         .padding(12)
         .background(Color(.secondarySystemBackground).opacity(0.5), in: RoundedRectangle(cornerRadius: 12))
     }
-    
-    private func handleMastodonProfileNavigation(url: String) {
-        // If we already resolved the account, use it
+
+    private var authorURL: URL? {
+        effectiveAuthorAttribution?.preferredURL
+    }
+
+    private var authorResolutionID: String {
+        "\(effectiveAuthorAttribution?.mastodonHandle ?? "")|\(authorURL?.absoluteString ?? "")"
+    }
+
+    private var authorAttributionTaskID: String {
+        "\(linkStatus.id)|\(linkStatus.primaryURL.absoluteString)|\(linkStatus.authorAttribution ?? "")|\(linkStatus.mastodonHandle ?? "")|\(linkStatus.mastodonProfileURL ?? "")"
+    }
+
+    private var effectiveAuthorAttribution: AuthorAttribution? {
+        localAuthorAttribution ?? linkStatusAuthorAttribution
+    }
+
+    private var linkStatusAuthorAttribution: AuthorAttribution? {
+        guard linkStatus.authorAttribution != nil
+            || linkStatus.authorURL != nil
+            || linkStatus.authorProfilePictureURL != nil
+            || linkStatus.mastodonHandle != nil
+            || linkStatus.mastodonProfileURL != nil else {
+            return nil
+        }
+
+        return AuthorAttribution(
+            name: linkStatus.authorAttribution,
+            url: linkStatus.authorURL,
+            source: .metaTag,
+            mastodonHandle: linkStatus.mastodonHandle,
+            mastodonProfileURL: linkStatus.mastodonProfileURL,
+            profilePictureURL: linkStatus.authorProfilePictureURL
+        )
+    }
+
+    private func handleAuthorAttributionNavigation() {
         if let account = resolvedMastodonAccount {
             appState.navigate(to: .profile(account))
             return
         }
-        
-        // Otherwise, try to parse and search for the account
-        if let (instance, username) = parseMastodonProfileURL(url) {
-            Task {
-                await resolveAndNavigateToMastodonAccount(instance: instance, username: username)
-            }
-        }
-    }
-    
-    private func parseMastodonProfileURL(_ urlString: String) -> (instance: String, username: String)? {
-        // Parse URL like https://instance.com/@username
-        guard let url = URL(string: urlString),
-              let host = url.host else {
-            return nil
-        }
-        
-        let path = url.path
-        // Remove leading /@
-        guard path.hasPrefix("/@") else {
-            return nil
-        }
-        
-        let username = String(path.dropFirst(2)) // Remove "/@"
-        return (host, username)
-    }
-    
-    private func resolveMastodonAccount(url: String) async {
-        guard let (instance, username) = parseMastodonProfileURL(url) else {
-            return
-        }
-        
-        await resolveAndNavigateToMastodonAccount(instance: instance, username: username, setState: true)
-    }
-    
-    private func resolveAndNavigateToMastodonAccount(
-        instance: String,
-        username: String,
-        setState: Bool = false
-    ) async {
-        // Use appState.client for account search
-        let client = appState.client
-        
-        // Try to search for the account
-        do {
-            let query = "@\(username)@\(instance)"
-            let accounts = try await client.searchAccounts(query: query, limit: 1)
-            
-            if let account = accounts.first,
-               account.acct.lowercased() == "\(username)@\(instance)".lowercased() {
-                if setState {
-                    await MainActor.run {
-                        resolvedMastodonAccount = account
-                    }
-                } else {
-                    await MainActor.run {
-                        appState.navigate(to: .profile(account))
-                    }
+
+        let authorURL = self.authorURL
+        let authorHandle = effectiveAuthorAttribution?.mastodonHandle
+        Task {
+            if let account = await appState.client.resolveProfileAccount(handle: authorHandle, profileURL: authorURL) {
+                await MainActor.run {
+                    resolvedMastodonAccount = account
+                    appState.navigate(to: .profile(account))
+                }
+            } else if let authorURL {
+                await MainActor.run {
+                    openURL(authorURL)
                 }
             }
-        } catch {
-            // If search fails, we can't resolve the account
-            // The user can still tap to try navigation
         }
+    }
+
+    private func preloadResolvedAuthorAccount() async {
+        guard resolvedMastodonAccount == nil else { return }
+        guard effectiveAuthorAttribution?.mastodonHandle != nil || authorURL != nil else { return }
+
+        if let account = await appState.client.resolveProfileAccount(
+            handle: effectiveAuthorAttribution?.mastodonHandle,
+            profileURL: authorURL
+        ) {
+            await MainActor.run {
+                resolvedMastodonAccount = account
+            }
+        }
+    }
+
+    private func ensureAuthorAttributionLoaded() async {
+        let shouldFetchAttribution = localAuthorAttribution == nil
+            && (linkStatusAuthorAttribution == nil
+                || linkStatus.mastodonHandle == nil
+                || linkStatus.mastodonProfileURL == nil)
+
+        if shouldFetchAttribution,
+           let attribution = await AttributionChecker.shared.checkAttribution(for: linkStatus.primaryURL) {
+            await MainActor.run {
+                localAuthorAttribution = attribution
+                linkFilterService.applyAttribution(attribution, toLinkStatusID: linkStatus.id)
+            }
+        } else if localAuthorAttribution == nil {
+            await MainActor.run {
+                localAuthorAttribution = linkStatusAuthorAttribution
+            }
+        }
+
+        await preloadResolvedAuthorAccount()
     }
 
     @ViewBuilder

--- a/fedi-reader/Views/Feed/StatusDetailRowView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailRowView.swift
@@ -3,10 +3,11 @@ import SwiftUI
 struct StatusDetailRowView: View {
     let status: Status
     @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
 
-    @State private var fediverseCreatorName: String?
-    @State private var fediverseCreatorURL: URL?
+    @State private var authorAttribution: AuthorAttribution?
+    @State private var resolvedAuthorAccount: MastodonAccount?
 
     var displayStatus: Status {
         status.displayStatus
@@ -103,19 +104,27 @@ struct StatusDetailRowView: View {
                 } label: {
                     LinkCardContent(
                         card: card,
-                        fediverseCreatorName: fediverseCreatorName,
-                        fediverseCreatorURL: fediverseCreatorURL
+                        authorAttribution: authorAttribution,
+                        authorDisplayName: resolvedAuthorAccount?.preferredDisplayName
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .glassEffect(.clear, in: RoundedRectangle(cornerRadius: 10))
                     .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .environment(\.openURL, authorLinkOpenURLAction)
                 }
                 .buttonStyle(.plain)
                 .task(id: cardURL?.absoluteString) {
-                    guard let url = cardURL else { return }
-                    let creator = await LinkPreviewService.shared.fetchFediverseCreator(for: url)
-                    fediverseCreatorName = creator?.name
-                    fediverseCreatorURL = creator?.url
+                    guard let url = cardURL else {
+                        authorAttribution = nil
+                        resolvedAuthorAccount = nil
+                        return
+                    }
+
+                    authorAttribution = await AttributionChecker.shared.checkAttribution(for: url)
+                    resolvedAuthorAccount = await appState.client.resolveProfileAccount(
+                        handle: authorAttribution?.mastodonHandle,
+                        profileURL: currentAuthorURL(for: card)
+                    )
                 }
             }
 
@@ -155,6 +164,39 @@ struct StatusDetailRowView: View {
         }
         .buttonStyle(.plain)
     }
+
+    private func currentAuthorURL(for card: PreviewCard) -> URL? {
+        authorAttribution?.preferredURL ?? card.authorUrl.flatMap { URL(string: $0) }
+    }
+
+    private var authorLinkOpenURLAction: OpenURLAction {
+        OpenURLAction { url in
+            guard MastodonProfileReference.acct(handle: authorAttribution?.mastodonHandle, profileURL: url) != nil else {
+                return .systemAction(url)
+            }
+
+            Task {
+                let account = if let resolvedAuthorAccount {
+                    resolvedAuthorAccount
+                } else {
+                    await appState.client.resolveProfileAccount(
+                        handle: authorAttribution?.mastodonHandle,
+                        profileURL: url
+                    )
+                }
+
+                if let account {
+                    await MainActor.run {
+                        resolvedAuthorAccount = account
+                        appState.navigate(to: .profile(account))
+                    }
+                } else {
+                    await MainActor.run {
+                        openURL(url)
+                    }
+                }
+            }
+            return .handled
+        }
+    }
 }
-
-

--- a/fedi-reader/Views/Feed/StatusRowView.swift
+++ b/fedi-reader/Views/Feed/StatusRowView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct StatusRowView: View {
     let status: Status
     @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
     @Environment(ReadLaterManager.self) private var readLaterManager
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("themeColor") private var themeColorName = "blue"
@@ -10,8 +11,8 @@ struct StatusRowView: View {
     
     @State private var blueskyDescription: String?
     @State private var hasLoadedBlueskyDescription = false
-    @State private var fediverseCreatorName: String?
-    @State private var fediverseCreatorURL: URL?
+    @State private var authorAttribution: AuthorAttribution?
+    @State private var resolvedAuthorAccount: MastodonAccount?
     @State private var isProcessing = false
     @State private var localBookmarked: Bool?
     @State private var isManagingLists = false
@@ -383,15 +384,20 @@ struct StatusRowView: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .minimumScaleFactor(0.8)
-                        
-                        if let authorName = fediverseCreatorName,
-                           let authorURL = fediverseCreatorURL {
+
+                        let authorLink = authorAttribution?.preferredURL ?? card.authorUrl.flatMap { URL(string: $0) }
+                        let authorDisplayName = resolvedAuthorAccount?.preferredDisplayName
+                            ?? authorAttribution?.preferredName
+                            ?? card.authorName
+                            ?? (authorLink != nil ? "Author" : nil)
+
+                        if let authorURL = authorLink {
                             Link(destination: authorURL) {
                                 HStack(spacing: 4) {
                                     Image(systemName: "person.crop.circle")
                                         .font(.roundedCaption)
                                     
-                                    Text(authorName)
+                                    Text(authorDisplayName ?? "Author")
                                         .font(.roundedCaption)
                                         .lineLimit(1)
                                         .minimumScaleFactor(0.8)
@@ -401,31 +407,9 @@ struct StatusRowView: View {
                                 .background(Color(.tertiarySystemBackground), in: Capsule())
                             }
                             .buttonStyle(.plain)
-                        } else if let authorName = fediverseCreatorName {
-                            Text(authorName)
-                                .font(.roundedCaption)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.8)
-                        } else if let authorName = card.authorName,
-                                  let authorUrlString = card.authorUrl,
-                                  let authorURL = URL(string: authorUrlString) {
-                            Link(destination: authorURL) {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "person.crop.circle")
-                                        .font(.roundedCaption)
-                                    
-                                    Text(authorName)
-                                        .font(.roundedCaption)
-                                        .lineLimit(1)
-                                        .minimumScaleFactor(0.8)
-                                }
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(Color(.tertiarySystemBackground), in: Capsule())
-                            }
-                            .buttonStyle(.plain)
-                        } else if let author = card.authorName {
-                            Text(author)
+                            .environment(\.openURL, authorLinkOpenURLAction)
+                        } else if let authorDisplayName {
+                            Text(authorDisplayName)
                                 .font(.roundedCaption)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.8)
@@ -451,10 +435,17 @@ struct StatusRowView: View {
             blueskyDescription = await LinkPreviewService.shared.fetchDescription(for: url)
         }
         .task(id: cardURL?.absoluteString) {
-            guard let url = cardURL else { return }
-            let creator = await LinkPreviewService.shared.fetchFediverseCreator(for: url)
-            fediverseCreatorName = creator?.name
-            fediverseCreatorURL = creator?.url
+            guard let url = cardURL else {
+                authorAttribution = nil
+                resolvedAuthorAccount = nil
+                return
+            }
+
+            authorAttribution = await AttributionChecker.shared.checkAttribution(for: url)
+            resolvedAuthorAccount = await appState.client.resolveProfileAccount(
+                handle: authorAttribution?.mastodonHandle,
+                profileURL: currentAuthorURL(for: card)
+            )
         }
     }
     
@@ -619,6 +610,41 @@ struct StatusRowView: View {
             }
         }
     }
+
+    private func currentAuthorURL(for card: PreviewCard) -> URL? {
+        authorAttribution?.preferredURL ?? card.authorUrl.flatMap { URL(string: $0) }
+    }
+
+    private var authorLinkOpenURLAction: OpenURLAction {
+        OpenURLAction { url in
+            guard MastodonProfileReference.acct(handle: authorAttribution?.mastodonHandle, profileURL: url) != nil else {
+                return .systemAction(url)
+            }
+
+            Task {
+                let account = if let resolvedAuthorAccount {
+                    resolvedAuthorAccount
+                } else {
+                    await appState.client.resolveProfileAccount(
+                        handle: authorAttribution?.mastodonHandle,
+                        profileURL: url
+                    )
+                }
+
+                if let account {
+                    await MainActor.run {
+                        resolvedAuthorAccount = account
+                        appState.navigate(to: .profile(account))
+                    }
+                } else {
+                    await MainActor.run {
+                        openURL(url)
+                    }
+                }
+            }
+            return .handled
+        }
+    }
     
     private func toggleBookmark() async {
         guard let service = timelineWrapper.service else { return }
@@ -640,5 +666,3 @@ struct StatusRowView: View {
 }
 
 // MARK: - Compact Status Row
-
-

--- a/fedi-reader/Views/Root/ContentView.swift
+++ b/fedi-reader/Views/Root/ContentView.swift
@@ -78,6 +78,9 @@ struct ContentView: View {
         }
         .onChange(of: appState.currentAccount?.id) { _, _ in
             updateInboxAutoRefresh(for: scenePhase)
+            Task {
+                await appState.authService.refreshClientAuthenticationState()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .readLaterDidSave)) { notification in
             guard let result = notification.object as? ReadLaterSaveResult else { return }
@@ -97,6 +100,9 @@ struct ContentView: View {
 
     private func setupServices() {
         appState.authService.loadAccounts(from: modelContext)
+        Task {
+            await appState.authService.refreshClientAuthenticationState()
+        }
 
         if timelineWrapper.service == nil {
             timelineWrapper.service = TimelineService(

--- a/fedi-readerTests/AttributionCheckerTests.swift
+++ b/fedi-readerTests/AttributionCheckerTests.swift
@@ -9,28 +9,202 @@ import Testing
 import Foundation
 @testable import fedi_reader
 
-@Suite("Attribution Checker Tests")
-@MainActor
-struct AttributionCheckerTests {
-    
-    // MARK: - Link Header Parsing
-    
-    @Test("Parses author from Link header")
-    @MainActor
-    func parsesLinkHeader() async {
-        // This would require mock URL session setup
-        // For unit testing, we can test the parsing logic directly
-        
-        let checker = AttributionChecker()
-        
-        // The actual parsing happens internally, so we test the full flow
-        // with mock responses in integration tests
-        let cacheCount = await checker.cacheCountForTesting()
-        #expect(cacheCount == 0)
+private final class AttributionCheckerMockURLProtocol: URLProtocol {
+    private static var mockResponses: [String: (Data, HTTPURLResponse)] = [:]
+    private static let lock = NSLock()
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
     }
-    
-    // MARK: - Meta Tag Parsing Verification
-    
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url?.absoluteString,
+              let response = Self.response(for: request.httpMethod ?? "GET", url: url) else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response.1, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: response.0)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        mockResponses.removeAll()
+    }
+
+    static func setMockResponse(
+        method: String,
+        url: String,
+        data: Data = Data(),
+        statusCode: Int = 200,
+        headerFields: [String: String]? = nil
+    ) {
+        let response = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: headerFields
+        )!
+
+        lock.lock()
+        defer { lock.unlock() }
+        mockResponses[key(method: method, url: url)] = (data, response)
+    }
+
+    private static func response(for method: String, url: String) -> (Data, HTTPURLResponse)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return mockResponses[key(method: method, url: url)]
+    }
+
+    private static func key(method: String, url: String) -> String {
+        "\(method.uppercased()) \(url)"
+    }
+}
+
+@Suite("Attribution Checker Tests")
+struct AttributionCheckerTests {
+
+    @Test("Extracts rel author from anchor tags and resolves relative URLs")
+    func extractsRelAuthorFromAnchorTags() async {
+        AttributionCheckerMockURLProtocol.reset()
+        defer { AttributionCheckerMockURLProtocol.reset() }
+
+        let articleURL = "https://example.com/articles/story"
+        let authorURL = "https://example.com/authors/jane"
+        let html = """
+        <html>
+            <body>
+                <p class="byline">
+                    <a href="/authors/jane" rel="author">Jane Doe</a>
+                </p>
+            </body>
+        </html>
+        """
+
+        AttributionCheckerMockURLProtocol.setMockResponse(method: "HEAD", url: articleURL)
+        AttributionCheckerMockURLProtocol.setMockResponse(
+            method: "GET",
+            url: articleURL,
+            data: Data(html.utf8),
+            headerFields: ["Content-Type": "text/html"]
+        )
+        AttributionCheckerMockURLProtocol.setMockResponse(
+            method: "GET",
+            url: authorURL,
+            data: Data("<html></html>".utf8),
+            headerFields: ["Content-Type": "text/html"]
+        )
+
+        let checker = makeChecker()
+        let attribution = await checker.checkAttribution(for: URL(string: articleURL)!)
+
+        #expect(attribution?.name == "Jane Doe")
+        #expect(attribution?.url == authorURL)
+    }
+
+    @Test("Merges Link header URLs with meta author names")
+    func mergesLinkHeaderURLsWithMetaNames() async {
+        AttributionCheckerMockURLProtocol.reset()
+        defer { AttributionCheckerMockURLProtocol.reset() }
+
+        let articleURL = "https://example.com/articles/story"
+        let authorURL = "https://example.com/authors/jane"
+        let html = """
+        <html>
+            <head>
+                <meta name="author" content="Jane Doe">
+            </head>
+        </html>
+        """
+
+        AttributionCheckerMockURLProtocol.setMockResponse(
+            method: "HEAD",
+            url: articleURL,
+            headerFields: ["Link": #"<\#(authorURL)>; rel="alternate author""#]
+        )
+        AttributionCheckerMockURLProtocol.setMockResponse(
+            method: "GET",
+            url: articleURL,
+            data: Data(html.utf8),
+            headerFields: ["Content-Type": "text/html"]
+        )
+        AttributionCheckerMockURLProtocol.setMockResponse(
+            method: "GET",
+            url: authorURL,
+            data: Data("<html></html>".utf8),
+            headerFields: ["Content-Type": "text/html"]
+        )
+
+        let checker = makeChecker()
+        let attribution = await checker.checkAttribution(for: URL(string: articleURL)!)
+
+        #expect(attribution?.name == "Jane Doe")
+        #expect(attribution?.url == authorURL)
+    }
+
+    @Test("Extracts authors from JSON-LD graphs")
+    func extractsAuthorsFromJSONLDGraphs() async {
+        AttributionCheckerMockURLProtocol.reset()
+        defer { AttributionCheckerMockURLProtocol.reset() }
+
+        let articleURL = "https://example.com/articles/story"
+        let authorURL = "https://example.com/authors/jane"
+        let html = """
+        <html>
+            <head>
+                <script type="application/ld+json">
+                {
+                  "@context": "https://schema.org",
+                  "@graph": [
+                    {
+                      "@type": "NewsArticle",
+                      "author": {"@id": "#author-jane"}
+                    },
+                    {
+                      "@id": "#author-jane",
+                      "@type": "Person",
+                      "name": "Jane Doe",
+                      "url": "/authors/jane"
+                    }
+                  ]
+                }
+                </script>
+            </head>
+        </html>
+        """
+
+        AttributionCheckerMockURLProtocol.setMockResponse(method: "HEAD", url: articleURL)
+        AttributionCheckerMockURLProtocol.setMockResponse(
+            method: "GET",
+            url: articleURL,
+            data: Data(html.utf8),
+            headerFields: ["Content-Type": "text/html"]
+        )
+        AttributionCheckerMockURLProtocol.setMockResponse(
+            method: "GET",
+            url: authorURL,
+            data: Data("<html></html>".utf8),
+            headerFields: ["Content-Type": "text/html"]
+        )
+
+        let checker = makeChecker()
+        let attribution = await checker.checkAttribution(for: URL(string: articleURL)!)
+
+        #expect(attribution?.name == "Jane Doe")
+        #expect(attribution?.url == authorURL)
+        #expect(attribution?.source == .jsonLD)
+    }
+
     @Test("AttributionSource enum has expected cases")
     func attributionSourceCases() {
         let sources: [AttributionSource] = [
@@ -40,10 +214,10 @@ struct AttributionCheckerTests {
             .jsonLD,
             .twitterCard
         ]
-        
+
         #expect(sources.count == 5)
     }
-    
+
     @Test("AuthorAttribution stores data correctly")
     func authorAttributionStorage() {
         let attribution = AuthorAttribution(
@@ -51,34 +225,23 @@ struct AttributionCheckerTests {
             url: "https://example.com/authors/john",
             source: .metaTag
         )
-        
+
         #expect(attribution.name == "John Doe")
         #expect(attribution.url == "https://example.com/authors/john")
         #expect(attribution.source == .metaTag)
     }
-    
-    @Test("Handles nil values in attribution")
-    func handlesNilValues() {
-        let attribution = AuthorAttribution(
-            name: nil,
-            url: "https://example.com/author",
-            source: .linkHeader
-        )
-        
-        #expect(attribution.name == nil)
-        #expect(attribution.url != nil)
-    }
-    
-    // MARK: - Cache Management
-    
+
     @Test("Cache can be cleared")
-    @MainActor
     func cacheClearable() async {
-        let checker = AttributionChecker()
+        let checker = makeChecker()
         await checker.clearCache()
-        
-        // No exception thrown means success
         let cacheCount = await checker.cacheCountForTesting()
         #expect(cacheCount == 0)
+    }
+
+    private func makeChecker() -> AttributionChecker {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [AttributionCheckerMockURLProtocol.self]
+        return AttributionChecker(configuration: configuration)
     }
 }

--- a/fedi-readerTests/AuthServiceTests.swift
+++ b/fedi-readerTests/AuthServiceTests.swift
@@ -64,4 +64,29 @@ struct AuthServiceTests {
             Issue.record("Expected FediReaderError.unauthorized, got \(error)")
         }
     }
+
+    @Test("refreshClientAuthenticationState updates the client snapshot")
+    func refreshClientAuthenticationStateUpdatesClientSnapshot() async throws {
+        let client = MastodonClient()
+        let auth = AuthService(client: client, keychain: .shared)
+        let accountID = "mastodon.social:\(UUID().uuidString)"
+        let account = Account(
+            id: accountID,
+            instance: "mastodon.social",
+            username: "tester",
+            displayName: "Tester",
+            acct: "tester@mastodon.social",
+            isActive: true
+        )
+
+        try await KeychainHelper.shared.saveToken("secret-token", forAccount: accountID)
+
+        auth.currentAccount = account
+        await auth.refreshClientAuthenticationState()
+
+        #expect(client.currentInstance == "mastodon.social")
+        #expect(client.currentAccessToken == "secret-token")
+
+        try? await KeychainHelper.shared.deleteToken(forAccount: accountID)
+    }
 }

--- a/fedi-readerTests/HTMLParserTests.swift
+++ b/fedi-readerTests/HTMLParserTests.swift
@@ -48,6 +48,43 @@ struct HTMLParserTests {
         #expect(links.count == 1)
         #expect(links.first?.absoluteString == "https://example.com/article?foo=1&bar=2")
     }
+
+    @Test("Extracts meta name content regardless of attribute order")
+    func extractsMetaNameContentRegardlessOfAttributeOrder() {
+        let html = #"<meta content="Jane Doe" name="author" data-test="true">"#
+
+        let content = HTMLParser.metaContent(in: html, name: "author")
+
+        #expect(content == "Jane Doe")
+    }
+
+    @Test("Extracts meta property content regardless of attribute order")
+    func extractsMetaPropertyContentRegardlessOfAttributeOrder() {
+        let html = #"<meta content="https://example.com/cover.jpg" property="og:image" data-size="large">"#
+
+        let content = HTMLParser.metaProperty(in: html, property: "og:image")
+
+        #expect(content == "https://example.com/cover.jpg")
+    }
+
+    @Test("Extracts link href when rel attribute includes author token")
+    func extractsLinkHrefForAuthorRelation() {
+        let html = #"<link href="https://example.com/authors/jane" rel="alternate author" type="text/html">"#
+
+        let href = HTMLParser.linkHref(in: html, rel: "author")
+
+        #expect(href == "https://example.com/authors/jane")
+    }
+
+    @Test("Extracts author relation from anchor tags")
+    func extractsAuthorRelationFromAnchorTags() {
+        let html = #"<a class="byline" href="/authors/jane" rel="author me"><span>Jane Doe</span></a>"#
+
+        let relation = HTMLParser.authorRelation(in: html)
+
+        #expect(relation?.href == "/authors/jane")
+        #expect(relation?.text == "Jane Doe")
+    }
     
     @Test("Excludes non-HTTP URLs")
     func excludesNonHTTPURLs() {

--- a/fedi-readerTests/LinkFilterServiceTests.swift
+++ b/fedi-readerTests/LinkFilterServiceTests.swift
@@ -135,6 +135,39 @@ struct LinkFilterServiceTests {
         #expect(linkStatuses.first?.primaryURL.absoluteString == "https://example.com/article")
     }
 
+    @Test("Preserves existing attribution when a feed is rebuilt")
+    func preservesExistingAttributionWhenReprocessingFeed() async {
+        let statuses = [
+            MockStatusFactory.makeStatus(
+                id: "1",
+                hasCard: true,
+                cardURL: "https://example.com/article",
+                cardTitle: "Test Article"
+            )
+        ]
+
+        _ = await service.processStatuses(statuses, for: "home")
+        service.applyAttribution(
+            AuthorAttribution(
+                name: "Jane Example",
+                url: "https://mastodon.social/@jane",
+                source: .metaTag,
+                mastodonHandle: "@jane@mastodon.social",
+                mastodonProfileURL: "https://mastodon.social/@jane",
+                profilePictureURL: "https://example.com/jane.jpg"
+            ),
+            toLinkStatusID: "1"
+        )
+
+        let rebuiltStatuses = await service.processStatuses(statuses, for: "home")
+
+        #expect(rebuiltStatuses.count == 1)
+        #expect(rebuiltStatuses.first?.authorAttribution == "Jane Example")
+        #expect(rebuiltStatuses.first?.mastodonHandle == "@jane@mastodon.social")
+        #expect(rebuiltStatuses.first?.mastodonProfileURL == "https://mastodon.social/@jane")
+        #expect(rebuiltStatuses.first?.authorProfilePictureURL == "https://example.com/jane.jpg")
+    }
+
     @Test("Deduplicates API tags case-insensitively")
     func deduplicatesAPITagsCaseInsensitively() async {
         let status = MockStatusFactory.makeStatus(

--- a/fedi-readerTests/LinkPreviewServiceTests.swift
+++ b/fedi-readerTests/LinkPreviewServiceTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+private final class LinkPreviewServiceMockURLProtocol: URLProtocol {
+    static var mockResponses: [String: (Data, HTTPURLResponse)] = [:]
+    private static let lock = NSLock()
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let url = request.url?.absoluteString,
+              let (data, response) = Self.response(for: url) else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        mockResponses.removeAll()
+    }
+
+    static func setMockResponse(
+        for url: String,
+        data: Data,
+        statusCode: Int = 200,
+        headerFields: [String: String]? = nil
+    ) {
+        let response = HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: headerFields
+        )!
+        lock.lock()
+        defer { lock.unlock() }
+        mockResponses[url] = (data, response)
+    }
+
+    private static func response(for url: String) -> (Data, HTTPURLResponse)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return mockResponses[url]
+    }
+}
+
+@Suite("Link Preview Service Tests")
+struct LinkPreviewServiceTests {
+
+    @Test("Fetches fediverse creator when meta attributes are reversed")
+    func fetchesFediverseCreatorWhenMetaAttributesAreReversed() async {
+        LinkPreviewServiceMockURLProtocol.reset()
+
+        let url = "https://example.com/article"
+        let html = """
+        <html>
+            <head>
+                <meta content="@alice@mastodon.social" name="fediverse:creator">
+            </head>
+            <body>Example</body>
+        </html>
+        """
+
+        LinkPreviewServiceMockURLProtocol.setMockResponse(
+            for: url,
+            data: Data(html.utf8),
+            headerFields: ["Content-Type": "text/html"]
+        )
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [LinkPreviewServiceMockURLProtocol.self]
+        let service = LinkPreviewService(configuration: configuration)
+
+        let creator = await service.fetchFediverseCreator(for: URL(string: url)!)
+
+        #expect(creator?.name == "@alice@mastodon.social")
+        #expect(creator?.url?.absoluteString == "https://mastodon.social/@alice")
+    }
+}

--- a/fedi-readerTests/MastodonClientTests.swift
+++ b/fedi-readerTests/MastodonClientTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Mastodon Client Tests")
+@MainActor
+struct MastodonClientTests {
+    @Test("lookupAccount uses configured session and auth snapshot")
+    func lookupAccountUsesConfiguredSession() async throws {
+        MockURLProtocol.reset()
+        defer { MockURLProtocol.reset() }
+
+        let account = makeAccount(acct: "alice@example.com", username: "alice")
+        MockURLProtocol.setMockResponse(
+            for: lookupAccountURL(instance: "mastodon.social", acct: "alice@example.com"),
+            data: try makeEncoder().encode(account)
+        )
+
+        let client = makeClient()
+        client.currentInstance = "mastodon.social"
+        client.currentAccessToken = "secret-token"
+
+        let resolved = try await client.lookupAccount(acct: "alice@example.com")
+
+        #expect(resolved.acct == "alice@example.com")
+        #expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret-token")
+    }
+
+    @Test("resolveProfileAccount falls back to search when lookup fails")
+    func resolveProfileAccountFallsBackToSearch() async throws {
+        MockURLProtocol.reset()
+        defer { MockURLProtocol.reset() }
+
+        let account = makeAccount(acct: "alice@example.com", username: "alice")
+        MockURLProtocol.setMockResponse(
+            for: lookupAccountURL(instance: "mastodon.social", acct: "alice@example.com"),
+            data: Data("not found".utf8),
+            statusCode: 404
+        )
+
+        let searchResults = SearchResults(accounts: [account], statuses: [], hashtags: [])
+        MockURLProtocol.setMockResponse(
+            for: searchURL(instance: "mastodon.social", query: "alice@example.com", type: "accounts", limit: 5),
+            data: try makeEncoder().encode(searchResults)
+        )
+
+        let client = makeClient()
+        client.currentInstance = "mastodon.social"
+        client.currentAccessToken = "secret-token"
+
+        let resolved = await client.resolveProfileAccount(handle: "@alice@example.com")
+
+        #expect(resolved?.id == account.id)
+        #expect(resolved?.preferredDisplayName == account.displayName)
+    }
+
+    private func makeClient() -> MastodonClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return MastodonClient(configuration: configuration)
+    }
+
+    private func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private func lookupAccountURL(instance: String, acct: String) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/accounts/lookup"
+        components.queryItems = [URLQueryItem(name: "acct", value: acct)]
+        return components.url!.absoluteString
+    }
+
+    private func searchURL(instance: String, query: String, type: String, limit: Int) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v2/search"
+        components.queryItems = [
+            URLQueryItem(name: "q", value: query),
+            URLQueryItem(name: "resolve", value: String(true)),
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "type", value: type)
+        ]
+        return components.url!.absoluteString
+    }
+
+    private func makeAccount(acct: String, username: String, displayName: String = "Alice Example") -> MastodonAccount {
+        MastodonAccount(
+            id: UUID().uuidString,
+            username: username,
+            acct: acct,
+            displayName: displayName,
+            locked: false,
+            bot: false,
+            createdAt: Date(),
+            note: "<p>bio</p>",
+            url: "https://mastodon.social/@\(username)",
+            avatar: "https://example.com/avatar.jpg",
+            avatarStatic: "https://example.com/avatar.jpg",
+            header: "https://example.com/header.jpg",
+            headerStatic: "https://example.com/header.jpg",
+            followersCount: 10,
+            followingCount: 20,
+            statusesCount: 30,
+            lastStatusAt: nil,
+            emojis: [],
+            fields: [],
+            source: nil
+        )
+    }
+}

--- a/fedi-readerTests/MastodonProfileReferenceTests.swift
+++ b/fedi-readerTests/MastodonProfileReferenceTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Mastodon Profile Reference Tests")
+struct MastodonProfileReferenceTests {
+
+    @Test("Normalizes handles with or without leading at sign")
+    func normalizesHandles() {
+        #expect(MastodonProfileReference.normalizedAcct(from: "@alice@mastodon.social") == "alice@mastodon.social")
+        #expect(MastodonProfileReference.normalizedAcct(from: "alice@mastodon.social") == "alice@mastodon.social")
+    }
+
+    @Test("Parses Mastodon style at-sign profile URLs")
+    func parsesAtSignProfileURLs() {
+        let url = URL(string: "https://mastodon.social/@alice")!
+
+        #expect(MastodonProfileReference.acct(from: url) == "alice@mastodon.social")
+    }
+
+    @Test("Parses users profile URLs")
+    func parsesUsersProfileURLs() {
+        let url = URL(string: "https://hachyderm.io/users/alice")!
+
+        #expect(MastodonProfileReference.acct(from: url) == "alice@hachyderm.io")
+    }
+
+    @Test("Prefers explicit handles over URLs")
+    func prefersHandleWhenBothHandleAndURLExist() {
+        let url = URL(string: "https://example.com/@ignored")!
+
+        #expect(
+            MastodonProfileReference.acct(
+                handle: "@alice@mastodon.social",
+                profileURL: url
+            ) == "alice@mastodon.social"
+        )
+    }
+}

--- a/fedi-readerTests/MastodonTypesTests.swift
+++ b/fedi-readerTests/MastodonTypesTests.swift
@@ -148,6 +148,26 @@ struct MastodonTypesTests {
         #expect(account.preferredFields.count == 1)
         #expect(account.preferredFields.first?.name == "Top")
     }
+
+    @Test("MastodonAccount preferredDisplayName uses non-empty display name")
+    func accountPreferredDisplayNameUsesDisplayName() {
+        let account = makeAccount(
+            displayName: "Alice Example",
+            acct: "alice@example.com"
+        )
+
+        #expect(account.preferredDisplayName == "Alice Example")
+    }
+
+    @Test("MastodonAccount preferredDisplayName falls back to acct")
+    func accountPreferredDisplayNameFallsBackToAcct() {
+        let account = makeAccount(
+            displayName: "   ",
+            acct: "alice@example.com"
+        )
+
+        #expect(account.preferredDisplayName == "alice@example.com")
+    }
     
     // MARK: - Preview Card Tests
     
@@ -303,16 +323,18 @@ struct MastodonTypesTests {
     }
 
     private func makeAccount(
-        note: String,
-        sourceNote: String?,
+        displayName: String = "Test User",
+        acct: String = "testuser",
+        note: String = "<p>bio</p>",
+        sourceNote: String? = nil,
         fields: [Field] = [],
         sourceFields: [Field]? = nil
     ) -> MastodonAccount {
         MastodonAccount(
             id: "123",
             username: "testuser",
-            acct: "testuser",
-            displayName: "Test User",
+            acct: acct,
+            displayName: displayName,
             locked: false,
             bot: false,
             createdAt: Date(),


### PR DESCRIPTION
Summary
- ensure feed link cards update author attributions using the display name as metadata arrives instead of waiting for detail view
- verify attribution fetching work runs off the main thread and keep feed position steady while switching between feed and post content

Testing
- Not run (not requested)