### PR TITLE
Prevent vertical scrolling on horizontal feed picker

### DIFF
--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -6,6 +6,9 @@
 //
 
 import SwiftUI
+#if os(iOS)
+import UIKit
+#endif
 
 private struct TabFramePreferenceKey: PreferenceKey {
     static var defaultValue: [Int: CGRect] { [:] }
@@ -13,6 +16,90 @@ private struct TabFramePreferenceKey: PreferenceKey {
         value.merge(nextValue()) { _, new in new }
     }
 }
+
+enum HorizontalListPickerGestureFilter {
+    static func shouldBlockVerticalPan(velocity: CGPoint) -> Bool {
+        abs(velocity.y) > abs(velocity.x)
+    }
+}
+
+#if os(iOS)
+private struct HorizontalListPickerScrollProtector: UIViewRepresentable {
+    typealias UIViewType = UIView
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: UIViewRepresentableContext<HorizontalListPickerScrollProtector>) -> UIView {
+        let view = UIView(frame: .zero)
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<HorizontalListPickerScrollProtector>) {
+        DispatchQueue.main.async {
+            context.coordinator.attachIfNeeded(from: uiView)
+        }
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        private weak var scrollView: UIScrollView?
+        private weak var blockerRecognizer: UIPanGestureRecognizer?
+
+        func attachIfNeeded(from view: UIView) {
+            guard let scrollView = enclosingScrollView(from: view) else {
+                return
+            }
+
+            configure(scrollView)
+        }
+
+        private func enclosingScrollView(from view: UIView) -> UIScrollView? {
+            var candidate = view.superview
+            while let currentView = candidate {
+                if let scrollView = currentView as? UIScrollView {
+                    return scrollView
+                }
+                candidate = currentView.superview
+            }
+            return nil
+        }
+
+        private func configure(_ scrollView: UIScrollView) {
+            scrollView.alwaysBounceVertical = false
+            scrollView.showsVerticalScrollIndicator = false
+
+            guard self.scrollView !== scrollView else { return }
+
+            if let blockerRecognizer, let previousScrollView = self.scrollView {
+                previousScrollView.removeGestureRecognizer(blockerRecognizer)
+            }
+
+            let blockerRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handleVerticalPan))
+            blockerRecognizer.cancelsTouchesInView = true
+            blockerRecognizer.delegate = self
+            scrollView.addGestureRecognizer(blockerRecognizer)
+            scrollView.panGestureRecognizer.require(toFail: blockerRecognizer)
+
+            self.scrollView = scrollView
+            self.blockerRecognizer = blockerRecognizer
+        }
+
+        @objc
+        private func handleVerticalPan(_ gestureRecognizer: UIPanGestureRecognizer) {}
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer else {
+                return false
+            }
+
+            let velocity = panGestureRecognizer.velocity(in: panGestureRecognizer.view)
+            return HorizontalListPickerGestureFilter.shouldBlockVerticalPan(velocity: velocity)
+        }
+    }
+}
+#endif
 
 /// Reusable pills and feed content. When `onArticleSelect` is non-nil, articles open inline (two-column).
 /// When nil, articles push via parent's NavigationStack (single column).
@@ -290,8 +377,11 @@ struct LinkFeedContentView: View {
                 .onPreferenceChange(TabFramePreferenceKey.self) { frames in
                     tabFrames = frames
                 }
+                #if os(iOS)
+                .background(HorizontalListPickerScrollProtector())
+                #endif
             }
-            .scrollBounceBehavior(.basedOnSize)
+            .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
             .onAppear {
                 if selectedTabIndex < feedTabs.count {
                     proxy.scrollTo(feedTabs[selectedTabIndex].id, anchor: .center)

--- a/fedi-readerTests/FeedSwipeGestureEvaluatorTests.swift
+++ b/fedi-readerTests/FeedSwipeGestureEvaluatorTests.swift
@@ -97,4 +97,16 @@ struct FeedSwipeGestureEvaluatorTests {
         #expect(FeedSwipeGestureEvaluator.shouldSuppressTapAfterGesture(translation: CGSize(width: 12, height: 2)))
         #expect(!FeedSwipeGestureEvaluator.shouldSuppressTapAfterGesture(translation: CGSize(width: 2, height: 1)))
     }
+
+    @Test("Horizontal list picker blocks vertical-dominant pans")
+    func horizontalListPickerBlocksVerticalDominantPans() {
+        #expect(HorizontalListPickerGestureFilter.shouldBlockVerticalPan(velocity: CGPoint(x: 80, y: 220)))
+        #expect(HorizontalListPickerGestureFilter.shouldBlockVerticalPan(velocity: CGPoint(x: 0, y: -160)))
+    }
+
+    @Test("Horizontal list picker allows horizontal and tied pans")
+    func horizontalListPickerAllowsHorizontalAndTiedPans() {
+        #expect(!HorizontalListPickerGestureFilter.shouldBlockVerticalPan(velocity: CGPoint(x: 220, y: 80)))
+        #expect(!HorizontalListPickerGestureFilter.shouldBlockVerticalPan(velocity: CGPoint(x: 120, y: 120)))
+    }
 }


### PR DESCRIPTION
Summary
- stop the feed picker from bouncing by blocking vertical pans and attaching a scroll protector to the list
- limit `scrollBounceBehavior` to horizontal drains and ensure the new gesture filter is covered by unit tests

Testing
- Not run (not requested)