### PR TITLE
Prevent page sections from being parsed as hashtags

### DIFF
--- a/fedi-reader/Views/Components/TagExtractor.swift
+++ b/fedi-reader/Views/Components/TagExtractor.swift
@@ -21,12 +21,11 @@ struct TagExtractor {
 
     /// Extract tags from status content (hashtags)
     nonisolated static func extractTags(from content: String) -> [String] {
-        // Strip HTML first to avoid matching HTML entities like &#39; as #39
-        let plainText = HTMLParser.stripHTML(content)
+        let plainText = plainTextForTagExtraction(from: content)
         
         // Extract hashtags from plain text
-        // Pattern requires at least one letter to avoid pure number tags
-        let pattern = #"#([a-zA-Z][\w]*)"#
+        // Pattern requires at least one letter and avoids matching URL fragments like /story#section.
+        let pattern = #"(?<![\w/])#([a-zA-Z][\w]*)"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
             return []
         }
@@ -48,6 +47,81 @@ struct TagExtractor {
         }
         
         return tags
+    }
+
+    private nonisolated static func plainTextForTagExtraction(from html: String) -> String {
+        let linkPattern = #"<a\b[^>]*>(.*?)</a\s*>"#
+        guard let regex = try? NSRegularExpression(
+            pattern: linkPattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return HTMLParser.stripHTML(html)
+        }
+
+        var sanitizedHTML = html
+        let range = NSRange(sanitizedHTML.startIndex..., in: sanitizedHTML)
+        let matches = regex.matches(in: sanitizedHTML, options: [], range: range)
+
+        for match in matches.reversed() {
+            guard let elementRange = Range(match.range, in: sanitizedHTML),
+                  let innerRange = Range(match.range(at: 1), in: sanitizedHTML) else {
+                continue
+            }
+
+            let anchorHTML = String(sanitizedHTML[elementRange])
+            let innerHTML = String(sanitizedHTML[innerRange])
+            let replacement = shouldPreserveLinkedHashtag(anchorHTML) ? innerHTML : " "
+
+            sanitizedHTML.replaceSubrange(elementRange, with: replacement)
+        }
+
+        return HTMLParser.stripHTML(sanitizedHTML)
+    }
+
+    private nonisolated static func shouldPreserveLinkedHashtag(_ anchorHTML: String) -> Bool {
+        guard let tagEnd = anchorHTML.firstIndex(of: ">") else {
+            return false
+        }
+
+        let openingTag = String(anchorHTML[...tagEnd])
+        let classNames = attribute(named: "class", in: openingTag)?
+            .split(whereSeparator: \.isWhitespace)
+            .map { $0.lowercased() } ?? []
+
+        if classNames.contains("hashtag") {
+            return true
+        }
+
+        guard let rawHref = attribute(named: "href", in: openingTag)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return false
+        }
+
+        let href = HTMLParser.decodeHTMLEntities(rawHref)
+        guard let url = URL(string: href) else {
+            return href.lowercased().hasPrefix("/tags/") || href.lowercased().hasPrefix("/tagged/")
+        }
+
+        let path = url.path.lowercased()
+        return path.hasPrefix("/tags/") || path.hasPrefix("/tagged/")
+    }
+
+    private nonisolated static func attribute(named name: String, in tag: String) -> String? {
+        let escapedName = NSRegularExpression.escapedPattern(for: name)
+        let pattern = #"\b\#(escapedName)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))"#
+
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+              let match = regex.firstMatch(in: tag, options: [], range: NSRange(tag.startIndex..., in: tag)) else {
+            return nil
+        }
+
+        for captureIndex in 1...3 {
+            if let valueRange = Range(match.range(at: captureIndex), in: tag) {
+                return String(tag[valueRange])
+            }
+        }
+
+        return nil
     }
     
     /// Extract tags from status, checking multiple sources

--- a/fedi-readerTests/AttributionCheckerTests.swift
+++ b/fedi-readerTests/AttributionCheckerTests.swift
@@ -76,16 +76,13 @@ struct AttributionCheckerTests {
 
     @Test("Extracts rel author from anchor tags and resolves relative URLs")
     func extractsRelAuthorFromAnchorTags() async {
-        AttributionCheckerMockURLProtocol.reset()
-        defer { AttributionCheckerMockURLProtocol.reset() }
-
-        let articleURL = "https://example.com/articles/story"
-        let authorURL = "https://example.com/authors/jane"
+        let articleURL = "https://example.com/articles/story-rel-author"
+        let authorURL = "https://example.com/authors/jane-rel-author"
         let html = """
         <html>
             <body>
                 <p class="byline">
-                    <a href="/authors/jane" rel="author">Jane Doe</a>
+                    <a href="/authors/jane-rel-author" rel="author">Jane Doe</a>
                 </p>
             </body>
         </html>
@@ -114,11 +111,8 @@ struct AttributionCheckerTests {
 
     @Test("Merges Link header URLs with meta author names")
     func mergesLinkHeaderURLsWithMetaNames() async {
-        AttributionCheckerMockURLProtocol.reset()
-        defer { AttributionCheckerMockURLProtocol.reset() }
-
-        let articleURL = "https://example.com/articles/story"
-        let authorURL = "https://example.com/authors/jane"
+        let articleURL = "https://example.com/articles/story-link-header"
+        let authorURL = "https://example.com/authors/jane-link-header"
         let html = """
         <html>
             <head>
@@ -154,11 +148,8 @@ struct AttributionCheckerTests {
 
     @Test("Extracts authors from JSON-LD graphs")
     func extractsAuthorsFromJSONLDGraphs() async {
-        AttributionCheckerMockURLProtocol.reset()
-        defer { AttributionCheckerMockURLProtocol.reset() }
-
-        let articleURL = "https://example.com/articles/story"
-        let authorURL = "https://example.com/authors/jane"
+        let articleURL = "https://example.com/articles/story-jsonld"
+        let authorURL = "https://example.com/authors/jane-jsonld"
         let html = """
         <html>
             <head>
@@ -174,7 +165,7 @@ struct AttributionCheckerTests {
                       "@id": "#author-jane",
                       "@type": "Person",
                       "name": "Jane Doe",
-                      "url": "/authors/jane"
+                      "url": "/authors/jane-jsonld"
                     }
                   ]
                 }

--- a/fedi-readerTests/LinkFilterServiceTests.swift
+++ b/fedi-readerTests/LinkFilterServiceTests.swift
@@ -225,6 +225,50 @@ struct LinkFilterServiceTests {
         #expect(linkStatuses.first?.tags.contains("swiftui") == false)
         #expect(linkStatuses.first?.tags.contains("openai") == false)
     }
+
+    @Test("Ignores linked page sections when extracting content tags")
+    func ignoresLinkedPageSectionsWhenExtractingContentTags() async {
+        let status = MockStatusFactory.makeStatus(
+            id: "1",
+            content: """
+            <p>
+            Read <a href="https://example.com/article#overview">#Overview</a>
+            and follow #Swift
+            </p>
+            """,
+            hasCard: true,
+            cardURL: "https://example.com/article"
+        )
+
+        let linkStatuses = await service.processStatuses([status])
+
+        #expect(linkStatuses.count == 1)
+        #expect(linkStatuses.first?.tags == ["Swift"])
+    }
+
+    @Test("Preserves hashtags from Mastodon hashtag links in post content")
+    func preservesHashtagsFromMastodonHashtagLinksInPostContent() async {
+        let status = MockStatusFactory.makeStatus(
+            id: "1",
+            content: """
+            <p>
+            <a href="https://mastodon.social/tags/SwiftUI" class="mention hashtag" rel="tag">
+            #<span>SwiftUI</span>
+            </a>
+            </p>
+            """,
+            hasCard: true,
+            cardURL: "https://example.com/article",
+            tags: [
+                Tag(name: "swiftui", url: "https://mastodon.social/tags/swiftui", history: nil)
+            ]
+        )
+
+        let linkStatuses = await service.processStatuses([status])
+
+        #expect(linkStatuses.count == 1)
+        #expect(linkStatuses.first?.tags == ["SwiftUI"])
+    }
     
     // MARK: - Threads/Instagram Exclusion
     

--- a/fedi-readerTests/MastodonClientTests.swift
+++ b/fedi-readerTests/MastodonClientTests.swift
@@ -7,12 +7,9 @@ import Foundation
 struct MastodonClientTests {
     @Test("lookupAccount uses configured session and auth snapshot")
     func lookupAccountUsesConfiguredSession() async throws {
-        MockURLProtocol.reset()
-        defer { MockURLProtocol.reset() }
-
-        let account = makeAccount(acct: "alice@example.com", username: "alice")
+        let account = makeAccount(acct: "alice-lookup@example.com", username: "alice")
         MockURLProtocol.setMockResponse(
-            for: lookupAccountURL(instance: "mastodon.social", acct: "alice@example.com"),
+            for: lookupAccountURL(instance: "mastodon.social", acct: "alice-lookup@example.com"),
             data: try makeEncoder().encode(account)
         )
 
@@ -20,27 +17,24 @@ struct MastodonClientTests {
         client.currentInstance = "mastodon.social"
         client.currentAccessToken = "secret-token"
 
-        let resolved = try await client.lookupAccount(acct: "alice@example.com")
+        let resolved = try await client.lookupAccount(acct: "alice-lookup@example.com")
 
-        #expect(resolved.acct == "alice@example.com")
+        #expect(resolved.acct == "alice-lookup@example.com")
         #expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret-token")
     }
 
     @Test("resolveProfileAccount falls back to search when lookup fails")
     func resolveProfileAccountFallsBackToSearch() async throws {
-        MockURLProtocol.reset()
-        defer { MockURLProtocol.reset() }
-
-        let account = makeAccount(acct: "alice@example.com", username: "alice")
+        let account = makeAccount(acct: "alice-resolve@example.com", username: "alice")
         MockURLProtocol.setMockResponse(
-            for: lookupAccountURL(instance: "mastodon.social", acct: "alice@example.com"),
+            for: lookupAccountURL(instance: "mastodon.social", acct: "alice-resolve@example.com"),
             data: Data("not found".utf8),
             statusCode: 404
         )
 
         let searchResults = SearchResults(accounts: [account], statuses: [], hashtags: [])
         MockURLProtocol.setMockResponse(
-            for: searchURL(instance: "mastodon.social", query: "alice@example.com", type: "accounts", limit: 5),
+            for: searchURL(instance: "mastodon.social", query: "alice-resolve@example.com", type: "accounts", limit: 5),
             data: try makeEncoder().encode(searchResults)
         )
 
@@ -48,7 +42,7 @@ struct MastodonClientTests {
         client.currentInstance = "mastodon.social"
         client.currentAccessToken = "secret-token"
 
-        let resolved = await client.resolveProfileAccount(handle: "@alice@example.com")
+        let resolved = await client.resolveProfileAccount(handle: "@alice-resolve@example.com")
 
         #expect(resolved?.id == account.id)
         #expect(resolved?.preferredDisplayName == account.displayName)

--- a/fedi-readerTests/MockStatusFactory.swift
+++ b/fedi-readerTests/MockStatusFactory.swift
@@ -181,6 +181,7 @@ class MockURLProtocol: URLProtocol {
     static var mockResponses: [String: (Data, HTTPURLResponse)] = [:]
     static var mockErrors: [String: Error] = [:]
     static var lastRequest: URLRequest?
+    private static let lock = NSLock()
     
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -191,19 +192,23 @@ class MockURLProtocol: URLProtocol {
     }
     
     override func startLoading() {
+        Self.lock.lock()
         Self.lastRequest = request
+        let mockErrors = Self.mockErrors
+        let mockResponses = Self.mockResponses
+        Self.lock.unlock()
         
         guard let url = request.url?.absoluteString else {
             client?.urlProtocolDidFinishLoading(self)
             return
         }
         
-        if let error = Self.mockErrors[url] {
+        if let error = mockErrors[url] {
             client?.urlProtocol(self, didFailWithError: error)
             return
         }
         
-        if let (data, response) = Self.mockResponses[url] {
+        if let (data, response) = mockResponses[url] {
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
         }
@@ -214,6 +219,8 @@ class MockURLProtocol: URLProtocol {
     override func stopLoading() {}
     
     static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
         mockResponses.removeAll()
         mockErrors.removeAll()
         lastRequest = nil
@@ -226,14 +233,17 @@ class MockURLProtocol: URLProtocol {
             httpVersion: nil,
             headerFields: nil
         )!
+        lock.lock()
+        defer { lock.unlock() }
         mockResponses[url] = (data, response)
     }
     
     static func setMockError(for url: String, error: Error) {
+        lock.lock()
+        defer { lock.unlock() }
         mockErrors[url] = error
     }
 }
 
 // MARK: - Mock Keychain Helper
-
 


### PR DESCRIPTION
Summary
- ignore linked page sections (and other non-hashtag anchors) when extracting tags from post content by stripping out HTML anchors unless they are real hashtag links
- enhance TagExtractor to decode link metadata safely, and tighten the hashtag regex to avoid URL fragments
- expand LinkFilterService tests to cover the new behavior and keep Mastodon client/location-specific tests deterministic

Testing
- Not run (not requested)