### PR TITLE
Show parent reply when opening post detail

### DIFF
--- a/fedi-reader/Models/MastodonTypes/StatusContext.swift
+++ b/fedi-reader/Models/MastodonTypes/StatusContext.swift
@@ -20,6 +20,17 @@ struct StatusContext: Codable, Sendable {
     }
 }
 
-// MARK: - Author Attribution
+extension StatusContext {
+    nonisolated func parentStatus(for status: Status) -> Status? {
+        let targetStatus = status.displayStatus
 
+        guard let replyToId = targetStatus.inReplyToId else {
+            return nil
+        }
+
+        return ancestors.last(where: { $0.id == replyToId }) ?? ancestors.last
+    }
+}
+
+// MARK: - Author Attribution
 

--- a/fedi-reader/Views/Feed/StatusDetailView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailView.swift
@@ -11,10 +11,29 @@ struct StatusDetailView: View {
     
     private let threadingService = ThreadingService()
 
+    private var threadStatus: Status {
+        status.displayStatus
+    }
+
+    private var parentStatus: Status? {
+        context?.parentStatus(for: status)
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Parent post as its own card at the top
+                if let parentStatus {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("In Reply To", systemImage: "arrow.turn.down.right")
+                            .font(.roundedCaption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+
+                        StatusDetailRowView(status: parentStatus)
+                    }
+                    .padding(.horizontal)
+                    .padding(.vertical, 5)
+                }
+
                 StatusDetailRowView(status: status)
                     .padding(.horizontal)
                     .padding(.vertical, 5)
@@ -46,14 +65,14 @@ struct StatusDetailView: View {
                                 Spacer()
                                 
                                 // Show expected count if we have more replies
-                                if status.repliesCount > context.descendants.count {
-                                    Text("\(context.descendants.count) of \(status.repliesCount)")
+                                if threadStatus.repliesCount > context.descendants.count {
+                                    Text("\(context.descendants.count) of \(threadStatus.repliesCount)")
                                         .font(.roundedCaption)
                                         .foregroundStyle(.secondary)
                                 }
                                 
                                 // Button to fetch remote replies
-                                if status.repliesCount > context.descendants.count && !isLoadingRemoteReplies {
+                                if threadStatus.repliesCount > context.descendants.count && !isLoadingRemoteReplies {
                                     Button {
                                         Task {
                                             await refreshReplies()
@@ -78,7 +97,7 @@ struct StatusDetailView: View {
                         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Constants.UI.cardCornerRadius))
                         .padding(.horizontal)
                         .padding(.vertical, 5)
-                    } else if status.repliesCount > 0 {
+                    } else if threadStatus.repliesCount > 0 {
                         // Show message if we expect replies but don't have any yet
                         VStack(alignment: .leading, spacing: 0) {
                             HStack {
@@ -135,12 +154,12 @@ struct StatusDetailView: View {
             await refreshReplies()
         }
         .onDisappear {
-            timelineWrapper.service?.cancelAsyncRefreshPolling(forStatusId: status.id)
+            timelineWrapper.service?.cancelAsyncRefreshPolling(forStatusId: threadStatus.id)
         }
         .onReceive(NotificationCenter.default.publisher(for: .statusContextDidUpdate)) { notification in
             // Update context when remote replies are fetched
             if let payload = notification.object as? StatusContextUpdatePayload,
-               payload.statusId == status.id {
+               payload.statusId == threadStatus.id {
                 // Replace context with updated one (it already contains all replies)
                 context = payload.context
                 isLoadingRemoteReplies = false
@@ -155,7 +174,7 @@ struct StatusDetailView: View {
         }
 
         do {
-            let loadedContext = try await service.getStatusContext(for: status)
+            let loadedContext = try await service.getStatusContext(for: threadStatus)
             context = loadedContext
             isLoading = false
             
@@ -173,7 +192,7 @@ struct StatusDetailView: View {
     
     private func shouldFetchRemoteReplies(context: StatusContext) -> Bool {
         // Fetch if we have fewer descendants than expected
-        if status.repliesCount > context.descendants.count {
+        if threadStatus.repliesCount > context.descendants.count {
             return true
         }
         
@@ -191,11 +210,10 @@ struct StatusDetailView: View {
         isLoadingRemoteReplies = true
         
         do {
-            try await service.refreshContextForStatus(status)
+            try await service.refreshContextForStatus(threadStatus)
             // Context updated via notification (immediate if no async refresh, else when polling finishes)
         } catch {
             isLoadingRemoteReplies = false
         }
     }
 }
-

--- a/fedi-readerTests/MastodonTypesTests.swift
+++ b/fedi-readerTests/MastodonTypesTests.swift
@@ -47,6 +47,34 @@ struct MastodonTypesTests {
         // For non-reblog, displayStatus should return self
         #expect(status.displayStatus.id == status.id)
     }
+
+    @Test("StatusContext returns immediate parent for replies")
+    func statusContextReturnsImmediateParent() {
+        let root = MockStatusFactory.makeStatus(id: "root")
+        let parent = MockStatusFactory.makeStatus(id: "parent", inReplyToId: root.id)
+        let current = MockStatusFactory.makeStatus(id: "current", inReplyToId: parent.id)
+        let context = StatusContext(ancestors: [root, parent], descendants: [])
+
+        #expect(context.parentStatus(for: current)?.id == parent.id)
+    }
+
+    @Test("StatusContext falls back to latest ancestor when direct parent is missing")
+    func statusContextFallsBackToLatestAncestor() {
+        let root = MockStatusFactory.makeStatus(id: "root")
+        let parent = MockStatusFactory.makeStatus(id: "parent", inReplyToId: root.id)
+        let current = MockStatusFactory.makeStatus(id: "current", inReplyToId: "missing-parent")
+        let context = StatusContext(ancestors: [root, parent], descendants: [])
+
+        #expect(context.parentStatus(for: current)?.id == parent.id)
+    }
+
+    @Test("StatusContext does not return a parent for top-level posts")
+    func statusContextReturnsNilForTopLevelPost() {
+        let current = MockStatusFactory.makeStatus(id: "current")
+        let context = StatusContext(ancestors: [MockStatusFactory.makeStatus(id: "root")], descendants: [])
+
+        #expect(context.parentStatus(for: current) == nil)
+    }
     
     // MARK: - Visibility Tests
     


### PR DESCRIPTION
## Summary
- surface an explicit parent card in StatusDetailView using the context-derived parent status
- compute the thread root status once and consistently operate on it (status context lookups, counts, and polling)
- add unit coverage for the new StatusContext helper to locate the immediate parent reply

## Testing
- Not run (not requested)