### PR TITLE
Fix reply fetching reliability and UI counts

### DIFF
--- a/fedi-reader/Models/MastodonTypes/AsyncRefresh.swift
+++ b/fedi-reader/Models/MastodonTypes/AsyncRefresh.swift
@@ -10,11 +10,24 @@ struct AsyncRefresh: Codable, Sendable {
         case resultCount = "result_count"
     }
     
-    init(id: String, status: String, resultCount: Int? = nil) {
+    nonisolated init(id: String, status: String, resultCount: Int? = nil) {
         self.id = id
         self.status = status
         self.resultCount = resultCount
     }
-}
 
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        status = try container.decode(String.self, forKey: .status)
+        resultCount = try container.decodeIfPresent(Int.self, forKey: .resultCount)
+    }
+
+    nonisolated func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(status, forKey: .status)
+        try container.encodeIfPresent(resultCount, forKey: .resultCount)
+    }
+}
 

--- a/fedi-reader/Models/MastodonTypes/AsyncRefreshHeader.swift
+++ b/fedi-reader/Models/MastodonTypes/AsyncRefreshHeader.swift
@@ -6,7 +6,7 @@ struct AsyncRefreshHeader: Sendable {
     let resultCount: Int?
     
     /// Parses the raw header value. Returns nil if missing or malformed.
-    static func parse(headerValue: String?) -> AsyncRefreshHeader? {
+    nonisolated static func parse(headerValue: String?) -> AsyncRefreshHeader? {
         guard let raw = headerValue?.trimmingCharacters(in: .whitespaces), !raw.isEmpty else { return nil }
         var id: String?
         var retrySeconds: Int?
@@ -29,5 +29,4 @@ struct AsyncRefreshHeader: Sendable {
 }
 
 // MARK: - Async Refresh (API entity)
-
 

--- a/fedi-reader/Models/MastodonTypes/AsyncRefreshResponse.swift
+++ b/fedi-reader/Models/MastodonTypes/AsyncRefreshResponse.swift
@@ -6,8 +6,21 @@ struct AsyncRefreshResponse: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case asyncRefresh = "async_refresh"
     }
+
+    nonisolated init(asyncRefresh: AsyncRefresh) {
+        self.asyncRefresh = asyncRefresh
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        asyncRefresh = try container.decode(AsyncRefresh.self, forKey: .asyncRefresh)
+    }
+
+    nonisolated func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(asyncRefresh, forKey: .asyncRefresh)
+    }
 }
 
 // MARK: - Status Context
-
 

--- a/fedi-reader/Models/MastodonTypes/IndirectStatus.swift
+++ b/fedi-reader/Models/MastodonTypes/IndirectStatus.swift
@@ -3,16 +3,16 @@ import Foundation
 final class IndirectStatus: Codable, Hashable, @unchecked Sendable {
     let value: Status
     
-    init(_ value: Status) {
+    nonisolated init(_ value: Status) {
         self.value = value
     }
     
-    init(from decoder: Decoder) throws {
+    nonisolated init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         value = try container.decode(Status.self)
     }
     
-    func encode(to encoder: Encoder) throws {
+    nonisolated func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(value)
     }
@@ -27,5 +27,4 @@ final class IndirectStatus: Codable, Hashable, @unchecked Sendable {
 }
 
 // MARK: - Visibility
-
 

--- a/fedi-reader/Models/MastodonTypes/Status.swift
+++ b/fedi-reader/Models/MastodonTypes/Status.swift
@@ -109,7 +109,7 @@ struct Status: Codable, Identifiable, Hashable, Sendable {
         self.inReplyToAccountId = inReplyToAccountId
     }
     
-    init(from decoder: Decoder) throws {
+    nonisolated init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         id = try container.decode(String.self, forKey: .id)
@@ -146,7 +146,7 @@ struct Status: Codable, Identifiable, Hashable, Sendable {
         inReplyToAccountId = try container.decodeIfPresent(String.self, forKey: .inReplyToAccountId)
     }
     
-    func encode(to encoder: Encoder) throws {
+    nonisolated func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         
         try container.encode(id, forKey: .id)
@@ -212,5 +212,4 @@ struct Status: Codable, Identifiable, Hashable, Sendable {
 }
 
 // MARK: - IndirectStatus wrapper for recursive Status references
-
 

--- a/fedi-reader/Models/MastodonTypes/StatusContext.swift
+++ b/fedi-reader/Models/MastodonTypes/StatusContext.swift
@@ -12,11 +12,27 @@ struct StatusContext: Codable, Sendable {
         case asyncRefreshId = "async_refresh_id"
     }
     
-    init(ancestors: [Status], descendants: [Status], hasMoreReplies: Bool? = nil, asyncRefreshId: String? = nil) {
+    nonisolated init(ancestors: [Status], descendants: [Status], hasMoreReplies: Bool? = nil, asyncRefreshId: String? = nil) {
         self.ancestors = ancestors
         self.descendants = descendants
         self.hasMoreReplies = hasMoreReplies
         self.asyncRefreshId = asyncRefreshId
+    }
+
+    nonisolated init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        ancestors = try container.decode([Status].self, forKey: .ancestors)
+        descendants = try container.decode([Status].self, forKey: .descendants)
+        hasMoreReplies = try container.decodeIfPresent(Bool.self, forKey: .hasMoreReplies)
+        asyncRefreshId = try container.decodeIfPresent(String.self, forKey: .asyncRefreshId)
+    }
+
+    nonisolated func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(ancestors, forKey: .ancestors)
+        try container.encode(descendants, forKey: .descendants)
+        try container.encodeIfPresent(hasMoreReplies, forKey: .hasMoreReplies)
+        try container.encodeIfPresent(asyncRefreshId, forKey: .asyncRefreshId)
     }
 }
 
@@ -30,7 +46,59 @@ extension StatusContext {
 
         return ancestors.last(where: { $0.id == replyToId }) ?? ancestors.last
     }
+
+    nonisolated var hasPendingAsyncRefresh: Bool {
+        guard let asyncRefreshId else {
+            return false
+        }
+
+        return !asyncRefreshId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    nonisolated func needsRemoteReplyFetch(for status: Status, localInstance: String? = nil) -> Bool {
+        let targetStatus = status.displayStatus
+
+        if hasPendingAsyncRefresh || hasMoreReplies == true {
+            return true
+        }
+
+        return targetStatus.repliesCount > descendants.count
+    }
+
+    nonisolated func resolvedReplyCount(for status: Status) -> Int {
+        let targetStatus = status.displayStatus
+        let discoveredReplyCount = descendants.count
+
+        if hasPendingAsyncRefresh || hasMoreReplies == true {
+            return max(targetStatus.repliesCount, discoveredReplyCount)
+        }
+
+        return discoveredReplyCount
+    }
+
+    nonisolated func merged(with newerContext: StatusContext) -> StatusContext {
+        StatusContext(
+            ancestors: mergeStatuses(ancestors, with: newerContext.ancestors),
+            descendants: mergeStatuses(descendants, with: newerContext.descendants)
+                .sorted { $0.createdAt < $1.createdAt },
+            hasMoreReplies: newerContext.hasMoreReplies ?? hasMoreReplies,
+            asyncRefreshId: newerContext.hasPendingAsyncRefresh ? newerContext.asyncRefreshId : nil
+        )
+    }
+}
+
+private nonisolated func mergeStatuses(_ existing: [Status], with incoming: [Status]) -> [Status] {
+    var mergedById: [String: Status] = [:]
+    var orderedIds: [String] = []
+
+    for status in existing + incoming {
+        if mergedById[status.id] == nil {
+            orderedIds.append(status.id)
+        }
+        mergedById[status.id] = status
+    }
+
+    return orderedIds.compactMap { mergedById[$0] }
 }
 
 // MARK: - Author Attribution
-

--- a/fedi-reader/Services/AuthService.swift
+++ b/fedi-reader/Services/AuthService.swift
@@ -114,6 +114,18 @@ final class AuthService {
             return nil
         }
     }
+
+    func activeSessionSnapshot() async -> AuthSessionSnapshot? {
+        guard let currentAccount,
+              let accessToken = await getAccessToken(for: currentAccount) else {
+            return nil
+        }
+
+        return AuthSessionSnapshot(
+            instance: currentAccount.instance,
+            accessToken: accessToken
+        )
+    }
     
     // MARK: - OAuth Flow
     
@@ -402,6 +414,11 @@ final class AuthService {
         return components.scheme == Constants.OAuth.redirectScheme &&
                components.host == Constants.OAuth.redirectHost
     }
+}
+
+struct AuthSessionSnapshot: Sendable {
+    let instance: String
+    let accessToken: String
 }
 
 // MARK: - ASWebAuthenticationSession Support

--- a/fedi-reader/Services/MastodonClient.swift
+++ b/fedi-reader/Services/MastodonClient.swift
@@ -148,6 +148,43 @@ private actor MastodonBackgroundRequestExecutor {
         return (account, response)
     }
 
+    func getStatusContextWithRefresh(
+        instance: String,
+        accessToken: String,
+        id: String
+    ) async throws -> MastodonClient.StatusContextWithRefresh {
+        let url = try buildMastodonURL(instance: instance, path: "/api/v1/statuses/\(id)/context")
+        let request = buildMastodonRequest(url: url, accessToken: accessToken)
+        let (data, httpResponse) = try await performRequest(request)
+        let context = try decoder.decode(StatusContext.self, from: data)
+
+        let rawHeader = httpResponse.value(forHTTPHeaderField: Constants.RemoteReplies.asyncRefreshHeader)
+        let asyncRefreshHeader = AsyncRefreshHeader.parse(headerValue: rawHeader)
+        let enhancedContext = StatusContext(
+            ancestors: context.ancestors,
+            descendants: context.descendants,
+            hasMoreReplies: context.hasMoreReplies,
+            asyncRefreshId: asyncRefreshHeader?.id ?? context.asyncRefreshId
+        )
+
+        return MastodonClient.StatusContextWithRefresh(
+            context: enhancedContext,
+            asyncRefreshHeader: asyncRefreshHeader
+        )
+    }
+
+    func getAsyncRefresh(
+        instance: String,
+        accessToken: String,
+        id: String
+    ) async throws -> AsyncRefresh {
+        let url = try buildMastodonURL(instance: instance, path: "\(Constants.API.asyncRefreshes)/\(id)")
+        let request = buildMastodonRequest(url: url, accessToken: accessToken)
+        let (data, _) = try await performRequest(request)
+        let wrapper = try decoder.decode(AsyncRefreshResponse.self, from: data)
+        return wrapper.asyncRefresh
+    }
+
     private func performRequest(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
         let method = request.httpMethod ?? "GET"
         let url = request.url?.absoluteString ?? "unknown"
@@ -804,6 +841,18 @@ final class MastodonClient {
         }
         return try await getStatusContextWithRefresh(instance: instance, accessToken: token, id: id)
     }
+
+    nonisolated func getStatusContextWithRefreshInBackground(
+        instance: String,
+        accessToken: String,
+        id: String
+    ) async throws -> StatusContextWithRefresh {
+        try await backgroundRequestExecutor.getStatusContextWithRefresh(
+            instance: instance,
+            accessToken: accessToken,
+            id: id
+        )
+    }
     
     // MARK: - Async Refreshes (Mastodon 4.5+)
     
@@ -819,6 +868,18 @@ final class MastodonClient {
             throw FediReaderError.noActiveAccount
         }
         return try await getAsyncRefresh(instance: instance, accessToken: token, id: id)
+    }
+
+    nonisolated func getAsyncRefreshInBackground(
+        instance: String,
+        accessToken: String,
+        id: String
+    ) async throws -> AsyncRefresh {
+        try await backgroundRequestExecutor.getAsyncRefresh(
+            instance: instance,
+            accessToken: accessToken,
+            id: id
+        )
     }
     
     // MARK: - Remote Status Resolution

--- a/fedi-reader/Services/RemoteReplyService.swift
+++ b/fedi-reader/Services/RemoteReplyService.swift
@@ -8,105 +8,123 @@
 import Foundation
 import os
 
-@Observable
-@MainActor
 final class RemoteReplyService {
     private static let logger = Logger(subsystem: "app.fedi-reader", category: "RemoteReplyService")
     
     private let client: MastodonClient
     private let authService: AuthService
+    private let contextRefetchDelaySeconds: TimeInterval
     
     // Cache for resolved remote statuses to avoid redundant fetches
     private var resolvedStatusCache: [String: Status] = [:]
     private var cacheLock = NSLock()
     
-    init(client: MastodonClient, authService: AuthService) {
+    init(
+        client: MastodonClient,
+        authService: AuthService,
+        contextRefetchDelaySeconds: TimeInterval = Constants.RemoteReplies.contextRefetchDelaySeconds
+    ) {
         self.client = client
         self.authService = authService
+        self.contextRefetchDelaySeconds = contextRefetchDelaySeconds
     }
     
     // MARK: - Public API
     
-    /// Fetches remote replies for a given status, resolving any missing remote statuses
-    func fetchRemoteReplies(for status: Status) async -> [Status] {
-        guard let account = authService.currentAccount,
-              let token = await authService.getAccessToken(for: account) else {
+    /// Fetches and merges the most complete reply context available for a status.
+    func fetchRemoteReplyContext(for status: Status, initialContext: StatusContext? = nil) async -> StatusContext? {
+        guard let session = await authService.activeSessionSnapshot() else {
             Self.logger.warning("No active account for remote reply fetch")
-            return []
+            return initialContext
         }
         
         Self.logger.info("Fetching remote replies for status: \(status.id.prefix(8), privacy: .public)")
         
         do {
-            // Get context with async refresh support
-            let contextWithRefresh = try await client.getStatusContextWithRefresh(
-                instance: account.instance,
-                accessToken: token,
-                id: status.id
-            )
-            
-            let context = contextWithRefresh.context
-            
-            // Check if we need to fetch missing replies
-            let missingReplies = try await fetchMissingReplies(
-                context: context,
-                status: status,
-                instance: account.instance,
-                accessToken: token
-            )
-            
-            // Combine known descendants with newly fetched remote replies
-            var allReplies = context.descendants
-            
-            // Add missing replies that aren't already in descendants
-            let existingIds = Set(context.descendants.map { $0.id })
-            for reply in missingReplies {
-                if !existingIds.contains(reply.id) {
-                    allReplies.append(reply)
-                }
+            let startingContext: StatusContext
+            if let initialContext {
+                startingContext = initialContext
+            } else {
+                let contextWithRefresh = try await client.getStatusContextWithRefreshInBackground(
+                    instance: session.instance,
+                    accessToken: session.accessToken,
+                    id: status.id
+                )
+                startingContext = contextWithRefresh.context
             }
-            
-            // Sort by creation date (oldest first for thread order)
-            allReplies.sort { $0.createdAt < $1.createdAt }
-            
-            Self.logger.info("Fetched \(allReplies.count) total replies (including \(missingReplies.count) remote)")
-            return allReplies
+
+            let updatedContext = try await fetchMissingReplies(
+                context: startingContext,
+                status: status,
+                instance: session.instance,
+                accessToken: session.accessToken
+            )
+
+            Self.logger.info("Resolved reply context with \(updatedContext.descendants.count) replies")
+            return updatedContext
             
         } catch {
             Self.logger.error("Error fetching remote replies: \(error.localizedDescription)")
-            return []
+            return initialContext
         }
     }
     
-    /// Fetches missing replies by comparing expected count with known descendants.
-    ///
-    /// We intentionally return `[]` because the API does not expose specific missing reply URIs.
-    /// **Missing replies are handled via async refresh**: when the server returns
-    /// `Mastodon-Async-Refresh`, we poll `GET /api/v1_alpha/async_refreshes/:id`, then re-GET
-    /// context. That flow (in TimelineService) is what fills in newly fetched replies—not this helper.
+    /// Re-fetches context when the server hints that additional remote replies exist.
     func fetchMissingReplies(
         context: StatusContext,
         status: Status,
         instance: String,
         accessToken: String
-    ) async throws -> [Status] {
-        let expectedCount = status.repliesCount
-        let knownCount = context.descendants.count
-        
-        guard expectedCount > knownCount else {
-            Self.logger.debug("No missing replies detected (expected: \(expectedCount), known: \(knownCount))")
-            return []
+    ) async throws -> StatusContext {
+        guard context.needsRemoteReplyFetch(for: status, localInstance: instance) else {
+            Self.logger.debug("No missing replies detected for status \(status.id.prefix(8), privacy: .public)")
+            return context
         }
-        
-        let missingCount = expectedCount - knownCount
-        Self.logger.info("Detected \(missingCount) missing replies, attempting to fetch")
-        
-        // The /context endpoint may not return all replies (e.g. remote instances, policy filters).
-        // We cannot identify which specific replies are missing. Async refresh + re-GET context
-        // (see TimelineService) handles those cases; this helper remains a no-op.
-        Self.logger.debug("Missing replies: expected \(expectedCount), have \(knownCount). Rely on async refresh + re-GET context.")
-        
-        return []
+
+        var latestContext = context
+        var delaySeconds: TimeInterval = 0
+        let maxAttempts = max(Constants.RemoteReplies.maxRetries + 1, 1)
+
+        for attempt in 0..<maxAttempts {
+            if Task.isCancelled {
+                break
+            }
+
+            if attempt > 0, delaySeconds > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+            }
+
+            do {
+                let contextWithRefresh = try await client.getStatusContextWithRefreshInBackground(
+                    instance: instance,
+                    accessToken: accessToken,
+                    id: status.id
+                )
+
+                latestContext = latestContext.merged(with: contextWithRefresh.context)
+                Self.logger.debug(
+                    "Remote reply fetch attempt \(attempt + 1)/\(maxAttempts) returned \(latestContext.descendants.count) replies"
+                )
+
+                if !latestContext.needsRemoteReplyFetch(for: status, localInstance: instance) {
+                    break
+                }
+
+                delaySeconds = nextDelaySeconds(
+                    from: contextWithRefresh,
+                    currentContext: latestContext
+                )
+            } catch {
+                if attempt == maxAttempts - 1 {
+                    throw error
+                }
+
+                Self.logger.debug("Retrying remote reply fetch after error: \(error.localizedDescription)")
+                delaySeconds = contextRefetchDelaySeconds
+            }
+        }
+
+        return latestContext
     }
     
     /// Resolves a remote status by its URI with comprehensive error handling
@@ -193,6 +211,21 @@ final class RemoteReplyService {
         defer { cacheLock.unlock() }
         resolvedStatusCache.removeAll()
         Self.logger.debug("Cleared remote reply cache")
+    }
+
+    private func nextDelaySeconds(
+        from contextWithRefresh: MastodonClient.StatusContextWithRefresh,
+        currentContext: StatusContext
+    ) -> TimeInterval {
+        if let asyncRefreshHeader = contextWithRefresh.asyncRefreshHeader {
+            return TimeInterval(asyncRefreshHeader.retrySeconds)
+        }
+
+        if currentContext.hasPendingAsyncRefresh {
+            return TimeInterval(Constants.RemoteReplies.asyncRefreshFallbackRetrySeconds)
+        }
+
+        return contextRefetchDelaySeconds
     }
 }
 

--- a/fedi-reader/Services/TimelineService.swift
+++ b/fedi-reader/Services/TimelineService.swift
@@ -456,59 +456,37 @@ final class TimelineService {
     // MARK: - Status Operations
     
     func getStatusContext(for status: Status) async throws -> StatusContext {
-        guard let account = authService.currentAccount,
-              let token = await authService.getAccessToken(for: account) else {
+        guard let session = await authService.activeSessionSnapshot() else {
             throw FediReaderError.noActiveAccount
         }
         
-        let contextWithRefresh = try await client.getStatusContextWithRefresh(
-            instance: account.instance,
-            accessToken: token,
+        let contextWithRefresh = try await client.getStatusContextWithRefreshInBackground(
+            instance: session.instance,
+            accessToken: session.accessToken,
             id: status.id
         )
-        
-        let context = contextWithRefresh.context
-        
-        if let header = buildAsyncRefreshHeader(from: contextWithRefresh) {
-            Self.logger.info("Async refresh available for status \(status.id.prefix(8), privacy: .public), starting polling")
-            startAsyncRefreshPolling(status: status, header: header, instance: account.instance, token: token)
-        } else if shouldFetchRemoteReplies(context: context, status: status) {
-            Self.logger.info("Fetching remote replies for status: \(status.id.prefix(8), privacy: .public)")
-            Task { [context] in
-                let allReplies = await remoteReplyService.fetchRemoteReplies(for: status)
-                let existingIds = Set(context.descendants.map { $0.id })
-                var mergedDescendants = context.descendants
-                for reply in allReplies {
-                    if !existingIds.contains(reply.id) {
-                        mergedDescendants.append(reply)
-                    }
-                }
-                mergedDescendants.sort { $0.createdAt < $1.createdAt }
-                let updatedContext = StatusContext(
-                    ancestors: context.ancestors,
-                    descendants: mergedDescendants,
-                    hasMoreReplies: context.hasMoreReplies,
-                    asyncRefreshId: context.asyncRefreshId
-                )
-                let payload = StatusContextUpdatePayload(statusId: status.id, context: updatedContext)
-                NotificationCenter.default.post(name: .statusContextDidUpdate, object: payload)
-            }
+
+        if shouldFetchRemoteReplies(context: contextWithRefresh.context, status: status) {
+            Self.logger.debug(
+                "Deferring remote reply follow-up for status \(status.id.prefix(8), privacy: .public) until explicit refresh"
+            )
         }
-        
-        return context
+
+        return contextWithRefresh.context
     }
     
     /// Re-GETs context for a status, runs async-refresh polling when metadata is present (header or payload id), then updates UI via notification.
     /// Use for "Fetch Remote" and any explicit refresh.
     func refreshContextForStatus(_ status: Status) async throws {
-        guard let account = authService.currentAccount,
-              let token = await authService.getAccessToken(for: account) else {
+        guard let session = await authService.activeSessionSnapshot() else {
             throw FediReaderError.noActiveAccount
         }
+
+        cancelAsyncRefreshPolling(forStatusId: status.id)
         
-        let contextWithRefresh = try await client.getStatusContextWithRefresh(
-            instance: account.instance,
-            accessToken: token,
+        let contextWithRefresh = try await client.getStatusContextWithRefreshInBackground(
+            instance: session.instance,
+            accessToken: session.accessToken,
             id: status.id
         )
         
@@ -516,7 +494,9 @@ final class TimelineService {
         
         if let header = buildAsyncRefreshHeader(from: contextWithRefresh) {
             Self.logger.info("Async refresh available on refresh for status \(status.id.prefix(8), privacy: .public), starting polling")
-            startAsyncRefreshPolling(status: status, header: header, instance: account.instance, token: token)
+            startAsyncRefreshPolling(status: status, header: header, instance: session.instance, token: session.accessToken)
+        } else if shouldFetchRemoteReplies(context: context, status: status) {
+            startFallbackRemoteReplyFetch(status: status, context: context)
         } else {
             let payload = StatusContextUpdatePayload(statusId: status.id, context: context)
             NotificationCenter.default.post(name: .statusContextDidUpdate, object: payload)
@@ -559,7 +539,11 @@ final class TimelineService {
             
             while !Task.isCancelled, attempts < maxAttempts {
                 do {
-                    let refresh = try await self.client.getAsyncRefresh(instance: instance, accessToken: token, id: header.id)
+                    let refresh = try await self.client.getAsyncRefreshInBackground(
+                        instance: instance,
+                        accessToken: token,
+                        id: header.id
+                    )
                     if refresh.status == "finished" {
                         Self.logger.info("Async refresh finished for status \(status.id.prefix(8), privacy: .public)")
                         break
@@ -582,11 +566,10 @@ final class TimelineService {
             if Task.isCancelled { return }
             
             do {
-                guard let account = self.authService.currentAccount,
-                      let tok = await self.authService.getAccessToken(for: account) else { return }
-                let ctxWithRefresh = try await self.client.getStatusContextWithRefresh(
-                    instance: account.instance,
-                    accessToken: tok,
+                guard let session = await self.authService.activeSessionSnapshot() else { return }
+                let ctxWithRefresh = try await self.client.getStatusContextWithRefreshInBackground(
+                    instance: session.instance,
+                    accessToken: session.accessToken,
                     id: status.id
                 )
                 let payload = StatusContextUpdatePayload(statusId: status.id, context: ctxWithRefresh.context)
@@ -603,27 +586,31 @@ final class TimelineService {
     
     /// Fetches remote replies for a status and returns updated context
     func fetchRemoteReplies(for status: Status) async throws -> [Status] {
-        return await remoteReplyService.fetchRemoteReplies(for: status)
+        let context = await remoteReplyService.fetchRemoteReplyContext(for: status)
+        return context?.descendants ?? []
     }
     
     /// Determines if we should fetch remote replies based on context and status
     private func shouldFetchRemoteReplies(context: StatusContext, status: Status) -> Bool {
-        // Fetch if we have fewer descendants than expected replies
-        if status.repliesCount > context.descendants.count {
-            return true
-        }
-        
-        // Fetch if any descendants appear to be remote (different instance)
-        if let account = authService.currentAccount {
-            let hasRemoteReplies = context.descendants.contains { reply in
-                !reply.uri.contains(account.instance)
+        let localInstance = authService.currentAccount?.instance
+        return context.needsRemoteReplyFetch(for: status, localInstance: localInstance)
+    }
+
+    private func startFallbackRemoteReplyFetch(status: Status, context: StatusContext) {
+        Self.logger.info("Attempting fallback remote reply fetch for status: \(status.id.prefix(8), privacy: .public)")
+
+        Task { [weak self] in
+            guard let self else { return }
+            guard let updatedContext = await self.remoteReplyService.fetchRemoteReplyContext(
+                for: status,
+                initialContext: context
+            ) else {
+                return
             }
-            if hasRemoteReplies {
-                return true
-            }
+
+            let payload = StatusContextUpdatePayload(statusId: status.id, context: updatedContext)
+            NotificationCenter.default.post(name: .statusContextDidUpdate, object: payload)
         }
-        
-        return false
     }
     
     func refreshStatus(id: String) async throws -> Status {

--- a/fedi-reader/Utilities/Constants/Constants.swift
+++ b/fedi-reader/Utilities/Constants/Constants.swift
@@ -40,7 +40,7 @@ enum Constants {
         static let conversationRead = "/api/v1/conversations" // Use with /:id/read
         
         static let statuses = "/api/v1/statuses"
-        static let asyncRefreshes = "/api/v1_alpha/async_refreshes"
+        nonisolated static let asyncRefreshes = "/api/v1_alpha/async_refreshes"
         static let accounts = "/api/v1/accounts"
         static let search = "/api/v2/search"
         
@@ -155,17 +155,16 @@ enum Constants {
     // MARK: - Remote Replies
     
     enum RemoteReplies {
-        static let asyncRefreshHeader = "Mastodon-Async-Refresh"
-        static let fetchTimeout: TimeInterval = 10
-        static let maxConcurrentFetches = 5
-        static let maxRetries = 2
+        static nonisolated let asyncRefreshHeader = "Mastodon-Async-Refresh"
+        static nonisolated let fetchTimeout: TimeInterval = 10
+        static nonisolated let maxConcurrentFetches = 5
+        static nonisolated let maxRetries = 2
+        static nonisolated let contextRefetchDelaySeconds: TimeInterval = 2
         /// Fallback retry interval when server provides only async_refresh_id without header metadata.
-        static let asyncRefreshFallbackRetrySeconds = 5
+        static nonisolated let asyncRefreshFallbackRetrySeconds = 5
         /// Max polling attempts for async refresh before giving up (~2 min at typical retry=5–10s).
-        static let asyncRefreshMaxPollAttempts = 15
+        static nonisolated let asyncRefreshMaxPollAttempts = 15
     }
 }
 
 // MARK: - Notification Names
-
-

--- a/fedi-reader/Views/Actions/StatusActions/StatusActionsBar.swift
+++ b/fedi-reader/Views/Actions/StatusActions/StatusActionsBar.swift
@@ -17,6 +17,7 @@ struct StatusActionsBar: View {
     @State private var localBookmarked: Bool?
     @State private var localFavoriteCount: Int?
     @State private var localReblogCount: Int?
+    @State private var localReplyCount: Int?
     
     private var displayStatus: Status {
         status.displayStatus
@@ -36,6 +37,10 @@ struct StatusActionsBar: View {
     
     private var reblogCount: Int {
         localReblogCount ?? displayStatus.reblogsCount
+    }
+
+    private var replyCount: Int {
+        localReplyCount ?? displayStatus.repliesCount
     }
     
     private var isBookmarked: Bool {
@@ -67,6 +72,11 @@ struct StatusActionsBar: View {
                 guard let updated = notification.object as? Status else { return }
                 applyUpdatedStatus(updated)
             }
+            .onReceive(NotificationCenter.default.publisher(for: .statusContextDidUpdate)) { notification in
+                guard let payload = notification.object as? StatusContextUpdatePayload,
+                      payload.statusId == displayStatus.id else { return }
+                localReplyCount = payload.context.resolvedReplyCount(for: displayStatus)
+            }
     }
     
     @ViewBuilder
@@ -89,17 +99,19 @@ struct StatusActionsBar: View {
                     .font(iconFont)
                     .foregroundStyle(isActive ? activeColor : .secondary)
 
-                Text(formatCount(count ?? 0))
-                    .font(countFont)
-                    .foregroundStyle(isActive ? activeColor : .secondary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-                    .layoutPriority(1)
+                if let countText = formattedCountLabel(for: count) {
+                    Text(countText)
+                        .font(countFont)
+                        .foregroundStyle(isActive ? activeColor : .secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .layoutPriority(1)
+                }
             }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)
-        .accessibilityValue(isActive ? "Active, \(formatCount(count ?? 0))" : formatCount(count ?? 0))
+        .accessibilityValue(accessibilityValue(for: count, isActive: isActive))
         .accessibilityHint("Double tap to \(accessibilityLabel.lowercased())")
     }
     
@@ -140,7 +152,7 @@ struct StatusActionsBar: View {
             // Reply
             actionButton(
                 icon: "arrowshape.turn.up.left",
-                count: displayStatus.repliesCount,
+                count: replyCount,
                 isActive: false,
                 activeColor: .accentColor,
                 accessibilityLabel: "Reply"
@@ -324,6 +336,19 @@ struct StatusActionsBar: View {
         }
         return "\(count)"
     }
+
+    func formattedCountLabel(for count: Int?) -> String? {
+        guard let count else { return nil }
+        return formatCount(count)
+    }
+
+    func accessibilityValue(for count: Int?, isActive: Bool) -> String {
+        guard let count else {
+            return isActive ? "Active" : "Inactive"
+        }
+        let formattedCount = formatCount(count)
+        return isActive ? "Active, \(formattedCount)" : formattedCount
+    }
     
     private func toggleFavorite() async {
         guard let service = timelineWrapper.service else { return }
@@ -412,9 +437,8 @@ struct StatusActionsBar: View {
         localBookmarked = resolvedStatus.bookmarked
         localFavoriteCount = resolvedStatus.favouritesCount
         localReblogCount = resolvedStatus.reblogsCount
+        localReplyCount = resolvedStatus.repliesCount
     }
 }
 
 // MARK: - Expanded Actions Toolbar (for Web View)
-
-

--- a/fedi-reader/Views/Feed/StatusDetailView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailView.swift
@@ -47,6 +47,7 @@ struct StatusDetailView: View {
                 if let context = context {
                     // Build thread tree from descendants only (exclude parent/current post)
                     let replyTrees = threadingService.buildThreadTree(from: context.descendants)
+                    let shouldFetchMoreReplies = shouldFetchRemoteReplies(context: context)
                     
                     if !context.descendants.isEmpty {
                         // Single card containing reply thread (without parent)
@@ -69,10 +70,14 @@ struct StatusDetailView: View {
                                     Text("\(context.descendants.count) of \(threadStatus.repliesCount)")
                                         .font(.roundedCaption)
                                         .foregroundStyle(.secondary)
+                                } else if context.hasMoreReplies == true {
+                                    Text("More available")
+                                        .font(.roundedCaption)
+                                        .foregroundStyle(.secondary)
                                 }
                                 
                                 // Button to fetch remote replies
-                                if threadStatus.repliesCount > context.descendants.count && !isLoadingRemoteReplies {
+                                if shouldFetchMoreReplies && !isLoadingRemoteReplies {
                                     Button {
                                         Task {
                                             await refreshReplies()
@@ -97,7 +102,7 @@ struct StatusDetailView: View {
                         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Constants.UI.cardCornerRadius))
                         .padding(.horizontal)
                         .padding(.vertical, 5)
-                    } else if threadStatus.repliesCount > 0 {
+                    } else if shouldFetchMoreReplies || threadStatus.repliesCount > 0 {
                         // Show message if we expect replies but don't have any yet
                         VStack(alignment: .leading, spacing: 0) {
                             HStack {
@@ -177,13 +182,7 @@ struct StatusDetailView: View {
             let loadedContext = try await service.getStatusContext(for: threadStatus)
             context = loadedContext
             isLoading = false
-            
-            // Check if we need to fetch remote replies
-            // Note: getStatusContext already triggers remote reply fetching in background
-            // We just need to show loading state
-            if shouldFetchRemoteReplies(context: loadedContext) {
-                isLoadingRemoteReplies = true
-            }
+            isLoadingRemoteReplies = false
         } catch {
             isLoading = false
             isLoadingRemoteReplies = false
@@ -191,17 +190,7 @@ struct StatusDetailView: View {
     }
     
     private func shouldFetchRemoteReplies(context: StatusContext) -> Bool {
-        // Fetch if we have fewer descendants than expected
-        if threadStatus.repliesCount > context.descendants.count {
-            return true
-        }
-        
-        // Fetch if async refresh is indicated
-        if context.asyncRefreshId != nil {
-            return true
-        }
-        
-        return false
+        context.needsRemoteReplyFetch(for: threadStatus)
     }
     
     private func refreshReplies() async {

--- a/fedi-readerTests/AuthServiceTests.swift
+++ b/fedi-readerTests/AuthServiceTests.swift
@@ -43,50 +43,57 @@ struct AuthServiceTests {
 
     @Test("fetchVerifiedProfile throws unauthorized when token is missing")
     func fetchVerifiedProfileThrowsUnauthorizedWhenTokenMissing() async {
-        let auth = AuthService(client: nil, keychain: .shared)
-        let accountID = "example.social:\(UUID().uuidString)"
-        let account = Account(
-            id: accountID,
-            instance: "example.social",
-            username: "tester",
-            displayName: "Tester",
-            acct: "tester@example.social"
-        )
+        await SharedTestResourceGate.withExclusiveAccess {
+            let auth = AuthService(client: nil, keychain: .shared)
+            let accountID = "example.social:\(UUID().uuidString)"
+            let account = Account(
+                id: accountID,
+                instance: "example.social",
+                username: "tester",
+                displayName: "Tester",
+                acct: "tester@example.social"
+            )
 
-        try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+            try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
 
-        do {
-            _ = try await auth.fetchVerifiedProfile(for: account)
-            Issue.record("Expected fetchVerifiedProfile to throw unauthorized")
-        } catch let error as FediReaderError {
-            #expect(error == .unauthorized)
-        } catch {
-            Issue.record("Expected FediReaderError.unauthorized, got \(error)")
+            do {
+                _ = try await auth.fetchVerifiedProfile(for: account)
+                Issue.record("Expected fetchVerifiedProfile to throw unauthorized")
+            } catch let error as FediReaderError {
+                #expect(error == .unauthorized)
+            } catch {
+                Issue.record("Expected FediReaderError.unauthorized, got \(error)")
+            }
         }
     }
 
     @Test("refreshClientAuthenticationState updates the client snapshot")
     func refreshClientAuthenticationStateUpdatesClientSnapshot() async throws {
-        let client = MastodonClient()
-        let auth = AuthService(client: client, keychain: .shared)
-        let accountID = "mastodon.social:\(UUID().uuidString)"
-        let account = Account(
-            id: accountID,
-            instance: "mastodon.social",
-            username: "tester",
-            displayName: "Tester",
-            acct: "tester@mastodon.social",
-            isActive: true
-        )
+        try await SharedTestResourceGate.withExclusiveAccess {
+            let client = MastodonClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let accountID = "mastodon.social:\(UUID().uuidString)"
+            let account = Account(
+                id: accountID,
+                instance: "mastodon.social",
+                username: "tester",
+                displayName: "Tester",
+                acct: "tester@mastodon.social",
+                isActive: true
+            )
 
-        try await KeychainHelper.shared.saveToken("secret-token", forAccount: accountID)
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: accountID)
+            defer {
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: accountID)
+                }
+            }
 
-        auth.currentAccount = account
-        await auth.refreshClientAuthenticationState()
+            auth.currentAccount = account
+            await auth.refreshClientAuthenticationState()
 
-        #expect(client.currentInstance == "mastodon.social")
-        #expect(client.currentAccessToken == "secret-token")
-
-        try? await KeychainHelper.shared.deleteToken(forAccount: accountID)
+            #expect(client.currentInstance == "mastodon.social")
+            #expect(client.currentAccessToken == "secret-token")
+        }
     }
 }

--- a/fedi-readerTests/MastodonClientTests.swift
+++ b/fedi-readerTests/MastodonClientTests.swift
@@ -2,50 +2,60 @@ import Testing
 import Foundation
 @testable import fedi_reader
 
-@Suite("Mastodon Client Tests")
+@Suite("Mastodon Client Tests", .serialized)
 @MainActor
 struct MastodonClientTests {
     @Test("lookupAccount uses configured session and auth snapshot")
     func lookupAccountUsesConfiguredSession() async throws {
-        let account = makeAccount(acct: "alice-lookup@example.com", username: "alice")
-        MockURLProtocol.setMockResponse(
-            for: lookupAccountURL(instance: "mastodon.social", acct: "alice-lookup@example.com"),
-            data: try makeEncoder().encode(account)
-        )
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+            defer { MockURLProtocol.reset() }
 
-        let client = makeClient()
-        client.currentInstance = "mastodon.social"
-        client.currentAccessToken = "secret-token"
+            let account = makeAccount(acct: "alice-lookup@example.com", username: "alice")
+            MockURLProtocol.setMockResponse(
+                for: lookupAccountURL(instance: "mastodon.social", acct: "alice-lookup@example.com"),
+                data: try makeEncoder().encode(account)
+            )
 
-        let resolved = try await client.lookupAccount(acct: "alice-lookup@example.com")
+            let client = makeClient()
+            client.currentInstance = "mastodon.social"
+            client.currentAccessToken = "secret-token"
 
-        #expect(resolved.acct == "alice-lookup@example.com")
-        #expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret-token")
+            let resolved = try await client.lookupAccount(acct: "alice-lookup@example.com")
+
+            #expect(resolved.acct == "alice-lookup@example.com")
+            #expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret-token")
+        }
     }
 
     @Test("resolveProfileAccount falls back to search when lookup fails")
     func resolveProfileAccountFallsBackToSearch() async throws {
-        let account = makeAccount(acct: "alice-resolve@example.com", username: "alice")
-        MockURLProtocol.setMockResponse(
-            for: lookupAccountURL(instance: "mastodon.social", acct: "alice-resolve@example.com"),
-            data: Data("not found".utf8),
-            statusCode: 404
-        )
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+            defer { MockURLProtocol.reset() }
 
-        let searchResults = SearchResults(accounts: [account], statuses: [], hashtags: [])
-        MockURLProtocol.setMockResponse(
-            for: searchURL(instance: "mastodon.social", query: "alice-resolve@example.com", type: "accounts", limit: 5),
-            data: try makeEncoder().encode(searchResults)
-        )
+            let account = makeAccount(acct: "alice-resolve@example.com", username: "alice")
+            MockURLProtocol.setMockResponse(
+                for: lookupAccountURL(instance: "mastodon.social", acct: "alice-resolve@example.com"),
+                data: Data("not found".utf8),
+                statusCode: 404
+            )
 
-        let client = makeClient()
-        client.currentInstance = "mastodon.social"
-        client.currentAccessToken = "secret-token"
+            let searchResults = SearchResults(accounts: [account], statuses: [], hashtags: [])
+            MockURLProtocol.setMockResponse(
+                for: searchURL(instance: "mastodon.social", query: "alice-resolve@example.com", type: "accounts", limit: 5),
+                data: try makeEncoder().encode(searchResults)
+            )
 
-        let resolved = await client.resolveProfileAccount(handle: "@alice-resolve@example.com")
+            let client = makeClient()
+            client.currentInstance = "mastodon.social"
+            client.currentAccessToken = "secret-token"
 
-        #expect(resolved?.id == account.id)
-        #expect(resolved?.preferredDisplayName == account.displayName)
+            let resolved = await client.resolveProfileAccount(handle: "@alice-resolve@example.com")
+
+            #expect(resolved?.id == account.id)
+            #expect(resolved?.preferredDisplayName == account.displayName)
+        }
     }
 
     private func makeClient() -> MastodonClient {

--- a/fedi-readerTests/MastodonTypesTests.swift
+++ b/fedi-readerTests/MastodonTypesTests.swift
@@ -75,6 +75,57 @@ struct MastodonTypesTests {
 
         #expect(context.parentStatus(for: current) == nil)
     }
+
+    @Test("StatusContext requests more replies when server reports more replies are available")
+    func statusContextRequestsMoreRepliesWhenHasMoreRepliesIsTrue() {
+        let status = MockStatusFactory.makeStatus(id: "root", repliesCount: 1)
+        let reply = MockStatusFactory.makeStatus(id: "reply-1", inReplyToId: status.id)
+        let context = StatusContext(
+            ancestors: [],
+            descendants: [reply],
+            hasMoreReplies: true
+        )
+
+        #expect(context.needsRemoteReplyFetch(for: status) == true)
+    }
+
+    @Test("StatusContext requests remote fetch when async refresh is pending")
+    func statusContextRequestsRemoteFetchWhenAsyncRefreshIsPending() {
+        let status = MockStatusFactory.makeStatus(id: "root", repliesCount: 1)
+        let reply = MockStatusFactory.makeStatus(id: "reply-1", inReplyToId: status.id, repliesCount: 0)
+        let context = StatusContext(
+            ancestors: [],
+            descendants: [reply],
+            asyncRefreshId: "refresh-123"
+        )
+
+        #expect(context.needsRemoteReplyFetch(for: status) == true)
+    }
+
+    @Test("StatusContext resolvedReplyCount prefers discovered replies when context is complete")
+    func statusContextResolvedReplyCountUsesDiscoveredRepliesWhenComplete() {
+        let status = MockStatusFactory.makeStatus(id: "root", repliesCount: 1)
+        let replies = [
+            MockStatusFactory.makeStatus(id: "reply-1", inReplyToId: status.id, repliesCount: 0),
+            MockStatusFactory.makeStatus(id: "reply-2", inReplyToId: status.id, repliesCount: 0),
+            MockStatusFactory.makeStatus(id: "reply-3", inReplyToId: status.id, repliesCount: 0)
+        ]
+        let context = StatusContext(ancestors: [], descendants: replies, hasMoreReplies: false)
+
+        #expect(context.resolvedReplyCount(for: status) == 3)
+    }
+
+    @Test("StatusContext resolvedReplyCount preserves higher server count while replies are still pending")
+    func statusContextResolvedReplyCountPreservesHigherServerCountWhenPending() {
+        let status = MockStatusFactory.makeStatus(id: "root", repliesCount: 5)
+        let replies = [
+            MockStatusFactory.makeStatus(id: "reply-1", inReplyToId: status.id, repliesCount: 0),
+            MockStatusFactory.makeStatus(id: "reply-2", inReplyToId: status.id, repliesCount: 0)
+        ]
+        let context = StatusContext(ancestors: [], descendants: replies, hasMoreReplies: true)
+
+        #expect(context.resolvedReplyCount(for: status) == 5)
+    }
     
     // MARK: - Visibility Tests
     

--- a/fedi-readerTests/MockStatusFactory.swift
+++ b/fedi-readerTests/MockStatusFactory.swift
@@ -8,6 +8,8 @@ enum MockStatusFactory {
         hasCard: Bool = false,
         cardURL: String? = nil,
         cardTitle: String? = nil,
+        uri: String? = nil,
+        url: String? = nil,
         tags: [Tag] = [],
         account: MastodonAccount? = nil,
         isReblog: Bool = false,
@@ -15,7 +17,8 @@ enum MockStatusFactory {
         favourited: Bool = false,
         reblogged: Bool = false,
         visibility: Visibility = .public,
-        inReplyToId: String? = nil
+        inReplyToId: String? = nil,
+        repliesCount: Int = 2
     ) -> Status {
         let account = account ?? makeAccount()
         
@@ -41,8 +44,8 @@ enum MockStatusFactory {
         
         return Status(
             id: id,
-            uri: "https://mastodon.social/statuses/\(id)",
-            url: "https://mastodon.social/@testuser/\(id)",
+            uri: uri ?? "https://mastodon.social/statuses/\(id)",
+            url: url ?? "https://mastodon.social/@testuser/\(id)",
             createdAt: Date(),
             account: account,
             content: content,
@@ -55,7 +58,7 @@ enum MockStatusFactory {
             emojis: [],
             reblogsCount: 5,
             favouritesCount: 10,
-            repliesCount: 2,
+            repliesCount: repliesCount,
             application: nil,
             language: "en",
             reblog: nil,
@@ -179,7 +182,9 @@ enum MockStatusFactory {
 
 class MockURLProtocol: URLProtocol {
     static var mockResponses: [String: (Data, HTTPURLResponse)] = [:]
+    static var queuedResponses: [String: [(Data, HTTPURLResponse)]] = [:]
     static var mockErrors: [String: Error] = [:]
+    static var requestCounts: [String: Int] = [:]
     static var lastRequest: URLRequest?
     private static let lock = NSLock()
     
@@ -194,21 +199,32 @@ class MockURLProtocol: URLProtocol {
     override func startLoading() {
         Self.lock.lock()
         Self.lastRequest = request
-        let mockErrors = Self.mockErrors
-        let mockResponses = Self.mockResponses
-        Self.lock.unlock()
-        
         guard let url = request.url?.absoluteString else {
+            Self.lock.unlock()
             client?.urlProtocolDidFinishLoading(self)
             return
         }
+        Self.requestCounts[url, default: 0] += 1
+
+        let error = Self.mockErrors[url]
+        var queuedResponse: (Data, HTTPURLResponse)?
+        if var responses = Self.queuedResponses[url], !responses.isEmpty {
+            queuedResponse = responses.removeFirst()
+            if responses.isEmpty {
+                Self.queuedResponses.removeValue(forKey: url)
+            } else {
+                Self.queuedResponses[url] = responses
+            }
+        }
+        let mockResponse = queuedResponse ?? Self.mockResponses[url]
+        Self.lock.unlock()
         
-        if let error = mockErrors[url] {
+        if let error {
             client?.urlProtocol(self, didFailWithError: error)
             return
         }
         
-        if let (data, response) = mockResponses[url] {
+        if let (data, response) = mockResponse {
             client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             client?.urlProtocol(self, didLoad: data)
         }
@@ -222,20 +238,48 @@ class MockURLProtocol: URLProtocol {
         lock.lock()
         defer { lock.unlock() }
         mockResponses.removeAll()
+        queuedResponses.removeAll()
         mockErrors.removeAll()
+        requestCounts.removeAll()
         lastRequest = nil
     }
     
-    static func setMockResponse(for url: String, data: Data, statusCode: Int = 200) {
+    static func setMockResponse(
+        for url: String,
+        data: Data,
+        statusCode: Int = 200,
+        headerFields: [String: String]? = nil
+    ) {
         let response = HTTPURLResponse(
             url: URL(string: url)!,
             statusCode: statusCode,
             httpVersion: nil,
-            headerFields: nil
+            headerFields: headerFields
         )!
         lock.lock()
         defer { lock.unlock() }
         mockResponses[url] = (data, response)
+    }
+
+    static func setQueuedResponses(
+        for url: String,
+        responses: [(data: Data, statusCode: Int, headerFields: [String: String]?)]
+    ) {
+        let queued = responses.map { response in
+            (
+                response.data,
+                HTTPURLResponse(
+                    url: URL(string: url)!,
+                    statusCode: response.statusCode,
+                    httpVersion: nil,
+                    headerFields: response.headerFields
+                )!
+            )
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+        queuedResponses[url] = queued
     }
     
     static func setMockError(for url: String, error: Error) {
@@ -243,7 +287,12 @@ class MockURLProtocol: URLProtocol {
         defer { lock.unlock() }
         mockErrors[url] = error
     }
+
+    static func requestCount(for url: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return requestCounts[url, default: 0]
+    }
 }
 
 // MARK: - Mock Keychain Helper
-

--- a/fedi-readerTests/RemoteReplyServiceTests.swift
+++ b/fedi-readerTests/RemoteReplyServiceTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Remote Reply Service Tests", .serialized)
+@MainActor
+struct RemoteReplyServiceTests {
+    @Test("Remote reply fetch retries context requests until replies stabilize")
+    func remoteReplyFetchRetriesContextRequestsUntilRepliesStabilize() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let account = Account(
+                id: "mastodon.social:\(UUID().uuidString)",
+                instance: "mastodon.social",
+                username: "tester",
+                displayName: "Tester",
+                acct: "tester@mastodon.social",
+                isActive: true
+            )
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let rootStatus = MockStatusFactory.makeStatus(id: "root-status", repliesCount: 2)
+            let firstReply = MockStatusFactory.makeStatus(
+                id: "reply-1",
+                inReplyToId: rootStatus.id,
+                repliesCount: 0
+            )
+            let secondReply = MockStatusFactory.makeStatus(
+                id: "reply-2",
+                inReplyToId: rootStatus.id,
+                repliesCount: 0
+            )
+
+            let initialContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply],
+                hasMoreReplies: true
+            )
+            let refreshedContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply],
+                hasMoreReplies: true
+            )
+            let completedContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply, secondReply],
+                hasMoreReplies: false
+            )
+
+            let encoder = makeEncoder()
+            MockURLProtocol.setQueuedResponses(
+                for: statusContextURL(instance: account.instance, id: rootStatus.id),
+                responses: [
+                    (data: try encoder.encode(refreshedContext), statusCode: 200, headerFields: nil),
+                    (data: try encoder.encode(completedContext), statusCode: 200, headerFields: nil)
+                ]
+            )
+
+            let service = RemoteReplyService(
+                client: client,
+                authService: auth,
+                contextRefetchDelaySeconds: 0
+            )
+
+            guard let updatedContext = await service.fetchRemoteReplyContext(
+                for: rootStatus,
+                initialContext: initialContext
+            ) else {
+                Issue.record("Expected an updated context")
+                return
+            }
+
+            #expect(updatedContext.descendants.map(\.id) == ["reply-1", "reply-2"])
+            #expect(updatedContext.hasMoreReplies == false)
+        }
+    }
+
+    private func makeClient() -> MastodonClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return MastodonClient(configuration: configuration)
+    }
+
+    private func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private func statusContextURL(instance: String, id: String) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/statuses/\(id)/context"
+        return components.url!.absoluteString
+    }
+}

--- a/fedi-readerTests/StatusActionsBarTests.swift
+++ b/fedi-readerTests/StatusActionsBarTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import fedi_reader
+
+@Suite("Status Actions Bar Tests")
+@MainActor
+struct StatusActionsBarTests {
+    private func makeBar() -> StatusActionsBar {
+        StatusActionsBar(
+            status: MockStatusFactory.makeStatus(),
+            size: .standard
+        )
+    }
+
+    @Test("StatusActionsBar omits count label when count is nil")
+    func formattedCountLabelOmitsNilCount() {
+        let bar = makeBar()
+
+        #expect(bar.formattedCountLabel(for: nil) == nil)
+    }
+
+    @Test("StatusActionsBar reports active state without a numeric accessibility value when count is nil")
+    func accessibilityValueOmitsNumericCountWhenNil() {
+        let bar = makeBar()
+
+        #expect(bar.accessibilityValue(for: nil, isActive: false) == "Inactive")
+        #expect(bar.accessibilityValue(for: nil, isActive: true) == "Active")
+    }
+
+    @Test("StatusActionsBar still formats visible counts when present")
+    func formattedCountLabelFormatsPresentCount() {
+        let bar = makeBar()
+
+        #expect(bar.formattedCountLabel(for: 1_200) == "1.2K")
+        #expect(bar.accessibilityValue(for: 42, isActive: true) == "Active, 42")
+    }
+}

--- a/fedi-readerTests/Support/SharedTestResourceGate.swift
+++ b/fedi-readerTests/Support/SharedTestResourceGate.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+actor SharedTestResourceGate {
+    static let shared = SharedTestResourceGate()
+
+    private var isLocked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    static func withExclusiveAccess<T>(
+        _ operation: () async throws -> T
+    ) async rethrows -> T {
+        let gate = SharedTestResourceGate.shared
+        await gate.acquire()
+
+        do {
+            let result = try await operation()
+            await gate.release()
+            return result
+        } catch {
+            await gate.release()
+            throw error
+        }
+    }
+
+    private func acquire() async {
+        guard isLocked else {
+            isLocked = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        guard let nextWaiter = waiters.first else {
+            isLocked = false
+            return
+        }
+
+        waiters.removeFirst()
+        nextWaiter.resume()
+    }
+}

--- a/fedi-readerTests/TimelineServiceContextTests.swift
+++ b/fedi-readerTests/TimelineServiceContextTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Timeline Service Context Tests", .serialized)
+@MainActor
+struct TimelineServiceContextTests {
+    @Test("Initial status context load does not auto-fetch remote replies")
+    func initialContextLoadDoesNotAutoFetchRemoteReplies() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = Account(
+                id: "mastodon.social:\(UUID().uuidString)",
+                instance: "mastodon.social",
+                username: "tester",
+                displayName: "Tester",
+                acct: "tester@mastodon.social",
+                isActive: true
+            )
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let rootStatus = MockStatusFactory.makeStatus(id: "root-status", repliesCount: 3)
+            let partialReply = MockStatusFactory.makeStatus(
+                id: "reply-1",
+                inReplyToId: rootStatus.id,
+                repliesCount: 0
+            )
+            let partialContext = StatusContext(
+                ancestors: [],
+                descendants: [partialReply],
+                hasMoreReplies: true
+            )
+
+            let url = statusContextURL(instance: account.instance, id: rootStatus.id)
+            let encoder = makeEncoder()
+            MockURLProtocol.setMockResponse(
+                for: url,
+                data: try encoder.encode(partialContext)
+            )
+
+            let loadedContext = try await service.getStatusContext(for: rootStatus)
+            try? await Task.sleep(nanoseconds: 50_000_000)
+
+            #expect(loadedContext.descendants.map(\.id) == ["reply-1"])
+            #expect(MockURLProtocol.requestCount(for: url) == 1)
+        }
+    }
+
+    private func makeClient() -> MastodonClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return MastodonClient(configuration: configuration)
+    }
+
+    private func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private func statusContextURL(instance: String, id: String) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/statuses/\(id)/context"
+        return components.url!.absoluteString
+    }
+}


### PR DESCRIPTION
Summary
- stabilize reply fetching for Mastodon and Lemmy posts while preventing the expensive reply refresh from running on the main timeline
- ensure reply counts shown in action bars match server data and drop the bookmark count display entirely
- update constants, services, and tests to cover the refreshed reply handling and UI behavior

Testing
- Not run (not requested)