### PR TITLE
Load link feeds from app launch

### DIFF
--- a/fedi-reader/App/FediReaderApp.swift
+++ b/fedi-reader/App/FediReaderApp.swift
@@ -16,6 +16,8 @@ private enum AppIntentsDependency {
 
 @main
 struct FediReaderApp: App {
+    @Environment(\.scenePhase) private var scenePhase
+
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Account.self,
@@ -37,19 +39,187 @@ struct FediReaderApp: App {
     }()
     
     @AppStorage("themeColor") private var themeColorName = "blue"
+    @AppStorage("defaultListId") private var defaultListId = ""
+    @State private var appState = AppState()
+    @State private var timelineWrapper = TimelineServiceWrapper()
+    @State private var linkFilterService = LinkFilterService()
+    @State private var readLaterManager = ReadLaterManager()
+
+    private var modelContext: ModelContext {
+        sharedModelContainer.mainContext
+    }
     
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(appState)
+                .environment(linkFilterService)
+                .environment(readLaterManager)
+                .environment(timelineWrapper)
                 .tint(ThemeColor.resolved(from: themeColorName).color)
+                .onAppear {
+                    setupServices()
+                    updateInboxAutoRefresh(for: scenePhase)
+                    startInitialLinkFeedLoadIfNeeded()
+                }
+                .task {
+                    await appState.authService.migrateOAuthClientSecretsToKeychain(modelContext: modelContext)
+                }
+                .onOpenURL { url in
+                    handleOpenURL(url)
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    updateInboxAutoRefresh(for: newPhase)
+                }
+                .onChange(of: appState.currentAccount?.id) { _, _ in
+                    updateInboxAutoRefresh(for: scenePhase)
+                    timelineWrapper.resetStartupLinkFeedLoad(for: appState.currentAccount?.id)
+                    startInitialLinkFeedLoadIfNeeded()
+                    Task {
+                        await appState.authService.refreshClientAuthenticationState()
+                    }
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .readLaterDidSave)) { notification in
+                    guard let result = notification.object as? ReadLaterSaveResult else { return }
+                    handleReadLaterSaveResult(result)
+                }
         }
         .modelContainer(sharedModelContainer)
         
         #if os(macOS)
         Settings {
             SettingsView()
-                .environment(AppState())
+                .environment(appState)
+                .environment(timelineWrapper)
+                .environment(readLaterManager)
         }
         #endif
+    }
+
+    @MainActor
+    private func setupServices() {
+        appState.authService.loadAccounts(from: modelContext)
+        Task {
+            await appState.authService.refreshClientAuthenticationState()
+        }
+
+        if timelineWrapper.service == nil {
+            timelineWrapper.service = TimelineService(
+                client: appState.client,
+                authService: appState.authService
+            )
+        }
+
+        if let accountId = appState.currentAccount?.id,
+           let service = timelineWrapper.service,
+           service.lists.isEmpty {
+            let cachedLists = timelineWrapper.cachedLists(for: accountId)
+            if !cachedLists.isEmpty {
+                service.lists = cachedLists
+            }
+        }
+
+        readLaterManager.loadConfigurations(from: modelContext)
+
+        if let instance = appState.getCurrentInstance() {
+            Task {
+                await appState.emojiService.fetchCustomEmojis(for: instance)
+            }
+        }
+
+        updateInboxAutoRefresh(for: scenePhase)
+    }
+
+    @MainActor
+    private func updateInboxAutoRefresh(for phase: ScenePhase) {
+        guard let service = timelineWrapper.service else { return }
+        if appState.hasAccount, phase == .active {
+            service.startInboxAutoRefresh()
+        } else {
+            service.stopInboxAutoRefresh()
+        }
+    }
+
+    @MainActor
+    private func startInitialLinkFeedLoadIfNeeded() {
+        guard let accountId = appState.currentAccount?.id,
+              let service = timelineWrapper.service else { return }
+
+        timelineWrapper.beginStartupLinkFeedLoad(for: accountId) {
+            let initialFeedID = await loadListsAndApplyDefault(using: service)
+            guard self.appState.currentAccount?.id == accountId else { return }
+
+            self.linkFilterService.switchToFeed(initialFeedID)
+
+            if !self.linkFilterService.hasCachedContent(for: initialFeedID) {
+                let statuses = await service.loadLinkFeedStatuses(
+                    feedId: initialFeedID,
+                    forceRefreshHome: true
+                )
+                _ = await self.linkFilterService.processStatuses(statuses, for: initialFeedID)
+            }
+
+            Task {
+                await self.linkFilterService.enrichWithAttributions()
+            }
+
+            let allFeedIDs = [AppState.homeFeedID] + service.lists.map(\.id)
+            await self.linkFilterService.prefetchAdjacentFeeds(
+                currentFeedId: initialFeedID,
+                allFeedIds: allFeedIDs
+            ) { feedId in
+                await service.prefetchLinkFeedStatuses(feedId: feedId)
+            }
+        }
+    }
+
+    @MainActor
+    private func loadListsAndApplyDefault(using service: TimelineService) async -> String {
+        guard appState.hasAccount else { return AppState.homeFeedID }
+
+        await service.loadLists()
+        if !service.lists.isEmpty {
+            timelineWrapper.updateCachedLists(service.lists, for: appState.currentAccount?.id)
+        }
+
+        return appState.applyDefaultLinkFeed(
+            defaultListId: defaultListId,
+            availableListIDs: service.lists.map(\.id)
+        )
+    }
+
+    @MainActor
+    private func handleOpenURL(_ url: URL) {
+        if appState.authService.isValidCallback(url: url) {
+            Task {
+                do {
+                    let account = try await appState.authService.handleCallback(url: url, modelContext: modelContext)
+                    await appState.emojiService.fetchCustomEmojis(for: account.instance)
+                } catch {
+                    appState.handleError(error)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func handleReadLaterSaveResult(_ result: ReadLaterSaveResult) {
+        if result.success {
+            let message = result.url.host ?? result.url.absoluteString
+            appState.presentedAlert = AlertItem(
+                title: "Saved to \(result.serviceType.displayName)",
+                message: message
+            )
+            return
+        }
+
+        if let error = result.error {
+            appState.handleError(error)
+        } else {
+            appState.presentedAlert = AlertItem(
+                title: "Save Failed",
+                message: "Could not save to \(result.serviceType.displayName)"
+            )
+        }
     }
 }

--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -13,6 +13,7 @@ import os
 @MainActor
 final class AppState {
     private static let logger = Logger(subsystem: "app.fedi-reader", category: "AppState")
+    static let homeFeedID = "home"
     
     // Services
     let client: MastodonClient
@@ -53,6 +54,10 @@ final class AppState {
     
     var hasAccount: Bool {
         currentAccount != nil
+    }
+
+    var selectedLinkFeedID: String {
+        selectedListId ?? Self.homeFeedID
     }
     
     func getAccessToken() async -> String? {
@@ -184,6 +189,24 @@ final class AppState {
 
     func requestLinksScrollToTop() {
         linksScrollToTopRequestID &+= 1
+    }
+
+    func resolvedDefaultLinkFeedID(defaultListId: String, availableListIDs: [String]) -> String {
+        guard !defaultListId.isEmpty, availableListIDs.contains(defaultListId) else {
+            return Self.homeFeedID
+        }
+
+        return defaultListId
+    }
+
+    @discardableResult
+    func applyDefaultLinkFeed(defaultListId: String, availableListIDs: [String]) -> String {
+        let feedID = resolvedDefaultLinkFeedID(
+            defaultListId: defaultListId,
+            availableListIDs: availableListIDs
+        )
+        selectedListId = feedID == Self.homeFeedID ? nil : feedID
+        return feedID
     }
 }
 

--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -26,7 +26,7 @@ final class LinkFilterService {
     private var feedCache: [String: [LinkStatus]] = [:]
     
     // Currently active feed ID
-    var activeFeedId: String = "home"
+    var activeFeedId: String = AppState.homeFeedID
     
     // Filtered statuses with link content for the active feed
     var linkStatuses: [LinkStatus] {

--- a/fedi-reader/Services/TimelineService.swift
+++ b/fedi-reader/Services/TimelineService.swift
@@ -173,6 +173,29 @@ final class TimelineService {
         homeMaxId = nil
         await loadHomeTimeline(refresh: true)
     }
+
+    func loadLinkFeedStatuses(feedId: String, forceRefreshHome: Bool = false) async -> [Status] {
+        if feedId == AppState.homeFeedID {
+            if forceRefreshHome || homeTimeline.isEmpty {
+                await refreshHomeTimeline()
+            }
+            return homeTimeline
+        }
+
+        await refreshListTimeline(listId: feedId)
+        return listTimeline
+    }
+
+    func prefetchLinkFeedStatuses(feedId: String) async -> [Status] {
+        if feedId == AppState.homeFeedID {
+            if homeTimeline.isEmpty {
+                await refreshHomeTimeline()
+            }
+            return homeTimeline
+        }
+
+        return await fetchListTimelineStatuses(listId: feedId)
+    }
     
     // MARK: - Explore / Trending
     

--- a/fedi-reader/Services/TimelineServiceWrapper.swift
+++ b/fedi-reader/Services/TimelineServiceWrapper.swift
@@ -12,6 +12,9 @@ import Foundation
 final class TimelineServiceWrapper {
     var service: TimelineService?
     private var cachedListsByAccountId: [String: [MastodonList]] = [:]
+    private var startupLinkFeedLoadTask: Task<Void, Never>?
+    private var startupLinkFeedAccountId: String?
+    private var completedStartupLinkFeedAccountId: String?
 
     init(service: TimelineService? = nil) {
         self.service = service
@@ -31,5 +34,42 @@ final class TimelineServiceWrapper {
     func clearCachedLists(for accountId: String?) {
         guard let accountId else { return }
         cachedListsByAccountId.removeValue(forKey: accountId)
+    }
+
+    func resetStartupLinkFeedLoad(for accountId: String?) {
+        if startupLinkFeedAccountId != accountId {
+            startupLinkFeedLoadTask?.cancel()
+            startupLinkFeedLoadTask = nil
+            startupLinkFeedAccountId = accountId
+        }
+
+        if completedStartupLinkFeedAccountId != accountId {
+            completedStartupLinkFeedAccountId = nil
+        }
+    }
+
+    func beginStartupLinkFeedLoad(
+        for accountId: String?,
+        operation: @escaping @MainActor () async -> Void
+    ) {
+        guard let accountId else { return }
+
+        resetStartupLinkFeedLoad(for: accountId)
+
+        guard completedStartupLinkFeedAccountId != accountId else { return }
+        guard startupLinkFeedLoadTask == nil else { return }
+
+        startupLinkFeedLoadTask = Task { @MainActor [weak self] in
+            await operation()
+
+            guard let self, self.startupLinkFeedAccountId == accountId else { return }
+            self.completedStartupLinkFeedAccountId = accountId
+            self.startupLinkFeedLoadTask = nil
+        }
+    }
+
+    func waitForStartupLinkFeedLoad() async {
+        let task = startupLinkFeedLoadTask
+        await task?.value
     }
 }

--- a/fedi-reader/Views/Feed/FeedTabItem.swift
+++ b/fedi-reader/Views/Feed/FeedTabItem.swift
@@ -11,9 +11,8 @@ struct FeedTabItem: Identifiable, Hashable {
         self.isHome = isHome
     }
     
-    static let home = FeedTabItem(id: "home", title: "Home", isHome: true)
+    static let home = FeedTabItem(id: AppState.homeFeedID, title: "Home", isHome: true)
 }
 
 // MARK: - Link Feed View
-
 

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -230,7 +230,7 @@ struct LinkFeedContentView: View {
             handleTabChange(to: newIndex)
         }
         .onChange(of: appState.selectedListId) { _, newListId in
-            let targetId = newListId ?? "home"
+            let targetId = newListId ?? AppState.homeFeedID
             if let index = feedTabs.firstIndex(where: { $0.id == targetId }), selectedTabIndex != index {
                 selectedTabIndex = index
             }
@@ -453,8 +453,9 @@ struct LinkFeedContentView: View {
 
         Task {
             await loadContentForTabIfNeeded(tab)
-            Task.detached(priority: .background) { [feedTabs] in
-                await prefetchAdjacentFeeds(currentIndex: newIndex, tabs: feedTabs)
+            let allFeedIDs = feedTabs.map(\.id)
+            Task(priority: .background) {
+                await prefetchAdjacentFeeds(currentFeedId: tab.id, allFeedIds: allFeedIDs)
             }
         }
     }
@@ -503,13 +504,13 @@ struct LinkFeedContentView: View {
     }
 
     private func loadInitialContent() async {
+        await timelineWrapper.waitForStartupLinkFeedLoad()
         guard let service = timelineService else { return }
 
         await service.loadLists(forceRefresh: liveLists.isEmpty)
         syncRetainedLists(with: service.lists, allowEmpty: service.error == nil)
 
-        if let listId = appState.selectedListId,
-           let index = feedTabs.firstIndex(where: { $0.id == listId }) {
+        if let index = feedTabs.firstIndex(where: { $0.id == appState.selectedLinkFeedID }) {
             selectedTabIndex = index
         }
 
@@ -523,8 +524,10 @@ struct LinkFeedContentView: View {
             await loadContentForTab(currentTab, forceRefresh: true)
         }
 
-        Task.detached(priority: .background) { [feedTabs, selectedTabIndex] in
-            await prefetchAdjacentFeeds(currentIndex: selectedTabIndex, tabs: feedTabs)
+        let currentFeedID = currentTab.id
+        let allFeedIDs = feedTabs.map(\.id)
+        Task(priority: .background) {
+            await prefetchAdjacentFeeds(currentFeedId: currentFeedID, allFeedIds: allFeedIDs)
         }
     }
 
@@ -532,16 +535,8 @@ struct LinkFeedContentView: View {
         guard let service = timelineService else { return }
 
         linkFilterService.switchToFeed(tab.id)
-
-        if tab.isHome {
-            if forceRefresh || service.homeTimeline.isEmpty {
-                await service.refreshHomeTimeline()
-            }
-            _ = await linkFilterService.processStatuses(service.homeTimeline, for: tab.id)
-        } else {
-            await service.refreshListTimeline(listId: tab.id)
-            _ = await linkFilterService.processStatuses(service.listTimeline, for: tab.id)
-        }
+        let statuses = await service.loadLinkFeedStatuses(feedId: tab.id, forceRefreshHome: forceRefresh)
+        _ = await linkFilterService.processStatuses(statuses, for: tab.id)
         Task {
             await linkFilterService.enrichWithAttributions()
         }
@@ -568,29 +563,13 @@ struct LinkFeedContentView: View {
         }
     }
 
-    private func prefetchAdjacentFeeds(currentIndex: Int, tabs: [FeedTabItem]) async {
+    private func prefetchAdjacentFeeds(currentFeedId: String, allFeedIds: [String]) async {
         guard let service = timelineWrapper.service else { return }
-
-        var indicesToPrefetch: [Int] = []
-        if currentIndex > 0 { indicesToPrefetch.append(currentIndex - 1) }
-        if currentIndex < tabs.count - 1 { indicesToPrefetch.append(currentIndex + 1) }
-
-        for index in indicesToPrefetch {
-            let tab = tabs[index]
-            guard !linkFilterService.hasCachedContent(for: tab.id),
-                  !linkFilterService.isLoadingFeed(tab.id) else { continue }
-
-            if tab.isHome {
-                if service.homeTimeline.isEmpty {
-                    await service.refreshHomeTimeline()
-                }
-                _ = await linkFilterService.processStatuses(service.homeTimeline, for: tab.id)
-            } else {
-                let statuses = await service.fetchListTimelineStatuses(listId: tab.id)
-                if !statuses.isEmpty {
-                    _ = await linkFilterService.processStatuses(statuses, for: tab.id)
-                }
-            }
+        await linkFilterService.prefetchAdjacentFeeds(
+            currentFeedId: currentFeedId,
+            allFeedIds: allFeedIds
+        ) { feedId in
+            await service.prefetchLinkFeedStatuses(feedId: feedId)
         }
     }
 

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -241,7 +241,7 @@ struct LinkFeedThreeColumnView: View {
             handleTabChange(to: newIndex)
         }
         .onChange(of: appState.selectedListId) { _, newListId in
-            let targetId = newListId ?? "home"
+            let targetId = newListId ?? AppState.homeFeedID
             if let index = feedTabs.firstIndex(where: { $0.id == targetId }), selectedTabIndex != index {
                 selectedTabIndex = index
             }
@@ -419,8 +419,9 @@ struct LinkFeedThreeColumnView: View {
 
         Task {
             await loadContentForTabIfNeeded(tab)
-            Task.detached(priority: .background) { [feedTabs] in
-                await prefetchAdjacentFeeds(currentIndex: newIndex, tabs: feedTabs)
+            let allFeedIDs = feedTabs.map(\.id)
+            Task(priority: .background) {
+                await prefetchAdjacentFeeds(currentFeedId: tab.id, allFeedIds: allFeedIDs)
             }
         }
     }
@@ -471,13 +472,13 @@ struct LinkFeedThreeColumnView: View {
     // MARK: - Data Loading
 
     private func loadInitialContent() async {
+        await timelineWrapper.waitForStartupLinkFeedLoad()
         guard let service = timelineService else { return }
 
         await service.loadLists(forceRefresh: liveLists.isEmpty)
         syncRetainedLists(with: service.lists, allowEmpty: service.error == nil)
 
-        if let listId = appState.selectedListId,
-           let index = feedTabs.firstIndex(where: { $0.id == listId }) {
+        if let index = feedTabs.firstIndex(where: { $0.id == appState.selectedLinkFeedID }) {
             selectedTabIndex = index
         }
 
@@ -491,8 +492,10 @@ struct LinkFeedThreeColumnView: View {
             await loadContentForTab(currentTab, forceRefresh: true)
         }
 
-        Task.detached(priority: .background) { [feedTabs, selectedTabIndex] in
-            await prefetchAdjacentFeeds(currentIndex: selectedTabIndex, tabs: feedTabs)
+        let currentFeedID = currentTab.id
+        let allFeedIDs = feedTabs.map(\.id)
+        Task(priority: .background) {
+            await prefetchAdjacentFeeds(currentFeedId: currentFeedID, allFeedIds: allFeedIDs)
         }
     }
 
@@ -500,16 +503,8 @@ struct LinkFeedThreeColumnView: View {
         guard let service = timelineService else { return }
 
         linkFilterService.switchToFeed(tab.id)
-
-        if tab.isHome {
-            if forceRefresh || service.homeTimeline.isEmpty {
-                await service.refreshHomeTimeline()
-            }
-            _ = await linkFilterService.processStatuses(service.homeTimeline, for: tab.id)
-        } else {
-            await service.refreshListTimeline(listId: tab.id)
-            _ = await linkFilterService.processStatuses(service.listTimeline, for: tab.id)
-        }
+        let statuses = await service.loadLinkFeedStatuses(feedId: tab.id, forceRefreshHome: forceRefresh)
+        _ = await linkFilterService.processStatuses(statuses, for: tab.id)
         Task {
             await linkFilterService.enrichWithAttributions()
         }
@@ -536,29 +531,13 @@ struct LinkFeedThreeColumnView: View {
         }
     }
 
-    private func prefetchAdjacentFeeds(currentIndex: Int, tabs: [FeedTabItem]) async {
+    private func prefetchAdjacentFeeds(currentFeedId: String, allFeedIds: [String]) async {
         guard let service = timelineWrapper.service else { return }
-
-        var indicesToPrefetch: [Int] = []
-        if currentIndex > 0 { indicesToPrefetch.append(currentIndex - 1) }
-        if currentIndex < tabs.count - 1 { indicesToPrefetch.append(currentIndex + 1) }
-
-        for index in indicesToPrefetch {
-            let tab = tabs[index]
-            guard !linkFilterService.hasCachedContent(for: tab.id),
-                  !linkFilterService.isLoadingFeed(tab.id) else { continue }
-
-            if tab.isHome {
-                if service.homeTimeline.isEmpty {
-                    await service.refreshHomeTimeline()
-                }
-                _ = await linkFilterService.processStatuses(service.homeTimeline, for: tab.id)
-            } else {
-                let statuses = await service.fetchListTimelineStatuses(listId: tab.id)
-                if !statuses.isEmpty {
-                    _ = await linkFilterService.processStatuses(statuses, for: tab.id)
-                }
-            }
+        await linkFilterService.prefetchAdjacentFeeds(
+            currentFeedId: currentFeedId,
+            allFeedIds: allFeedIds
+        ) { feedId in
+            await service.prefetchLinkFeedStatuses(feedId: feedId)
         }
     }
 

--- a/fedi-reader/Views/Root/ContentView.swift
+++ b/fedi-reader/Views/Root/ContentView.swift
@@ -12,18 +12,15 @@ import UIKit
 #endif
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
-    @Environment(\.scenePhase) private var scenePhase
     @Environment(\.colorScheme) private var colorScheme
-    @AppStorage("defaultListId") private var defaultListId = ""
-    @State private var appState = AppState()
-    @State private var timelineWrapper = TimelineServiceWrapper()
-    @State private var linkFilterService = LinkFilterService()
-    @State private var readLaterManager = ReadLaterManager()
-    @State private var hasAppliedDefaultList = false
+    @Environment(AppState.self) private var appState
+    @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+    @Environment(ReadLaterManager.self) private var readLaterManager
     @State private var stabilizedLayoutMode: LayoutMode = .compact
 
     var body: some View {
+        @Bindable var state = appState
+
         GeometryReader { geometry in
             let topChromePadding = resolvedTopChromePadding(for: geometry.safeAreaInsets.top)
             Group {
@@ -58,137 +55,14 @@ struct ContentView: View {
                 )
             }
         }
-        .environment(appState)
-        .environment(linkFilterService)
-        .environment(readLaterManager)
-        .environment(timelineWrapper)
-        .onAppear {
-            setupServices()
-            updateInboxAutoRefresh(for: scenePhase)
-        }
-        .task {
-            await appState.authService.migrateOAuthClientSecretsToKeychain(modelContext: modelContext)
-            await loadListsAndApplyDefault()
-        }
-        .onOpenURL { url in
-            handleOpenURL(url)
-        }
-        .onChange(of: scenePhase) { _, newPhase in
-            updateInboxAutoRefresh(for: newPhase)
-        }
-        .onChange(of: appState.currentAccount?.id) { _, _ in
-            updateInboxAutoRefresh(for: scenePhase)
-            Task {
-                await appState.authService.refreshClientAuthenticationState()
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .readLaterDidSave)) { notification in
-            guard let result = notification.object as? ReadLaterSaveResult else { return }
-            handleReadLaterSaveResult(result)
-        }
-        .sheet(item: $appState.presentedSheet) { sheet in
+        .sheet(item: $state.presentedSheet) { sheet in
             sheetContent(for: sheet)
         }
-        .alert(item: $appState.presentedAlert) { alert in
+        .alert(item: $state.presentedAlert) { alert in
             Alert(
                 title: Text(alert.title),
                 message: Text(alert.message),
                 dismissButton: .default(Text("OK"))
-            )
-        }
-    }
-
-    private func setupServices() {
-        appState.authService.loadAccounts(from: modelContext)
-        Task {
-            await appState.authService.refreshClientAuthenticationState()
-        }
-
-        if timelineWrapper.service == nil {
-            timelineWrapper.service = TimelineService(
-                client: appState.client,
-                authService: appState.authService
-            )
-        }
-
-        if let accountId = appState.currentAccount?.id,
-           let service = timelineWrapper.service,
-           service.lists.isEmpty {
-            let cachedLists = timelineWrapper.cachedLists(for: accountId)
-            if !cachedLists.isEmpty {
-                service.lists = cachedLists
-            }
-        }
-
-        readLaterManager.loadConfigurations(from: modelContext)
-        
-        // Fetch emoji for current account's instance
-        if let instance = appState.getCurrentInstance() {
-            Task {
-                await appState.emojiService.fetchCustomEmojis(for: instance)
-            }
-        }
-
-        updateInboxAutoRefresh(for: scenePhase)
-    }
-
-    private func updateInboxAutoRefresh(for phase: ScenePhase) {
-        guard let service = timelineWrapper.service else { return }
-        if appState.hasAccount, phase == .active {
-            service.startInboxAutoRefresh()
-        } else {
-            service.stopInboxAutoRefresh()
-        }
-    }
-
-    private func loadListsAndApplyDefault() async {
-        guard appState.hasAccount, !hasAppliedDefaultList else { return }
-
-        if let service = timelineWrapper.service {
-            await service.loadLists()
-            if !service.lists.isEmpty {
-                timelineWrapper.updateCachedLists(service.lists, for: appState.currentAccount?.id)
-            }
-            if !defaultListId.isEmpty {
-                let listExists = service.lists.contains { $0.id == defaultListId }
-                if listExists {
-                    appState.selectedListId = defaultListId
-                }
-            }
-        }
-        hasAppliedDefaultList = true
-    }
-
-    private func handleOpenURL(_ url: URL) {
-        if appState.authService.isValidCallback(url: url) {
-            Task {
-                do {
-                    let account = try await appState.authService.handleCallback(url: url, modelContext: modelContext)
-                    // Fetch custom emoji for the newly logged-in instance
-                    await appState.emojiService.fetchCustomEmojis(for: account.instance)
-                } catch {
-                    appState.handleError(error)
-                }
-            }
-        }
-    }
-    
-    private func handleReadLaterSaveResult(_ result: ReadLaterSaveResult) {
-        if result.success {
-            let message = result.url.host ?? result.url.absoluteString
-            appState.presentedAlert = AlertItem(
-                title: "Saved to \(result.serviceType.displayName)",
-                message: message
-            )
-            return
-        }
-        
-        if let error = result.error {
-            appState.handleError(error)
-        } else {
-            appState.presentedAlert = AlertItem(
-                title: "Save Failed",
-                message: "Could not save to \(result.serviceType.displayName)"
             )
         }
     }
@@ -250,6 +124,13 @@ private struct LeadingSafeAreaForWindowChrome: ViewModifier {
 // MARK: - Preview
 
 #Preview("Content View") {
+    let appState = AppState()
+    let timelineWrapper = TimelineServiceWrapper()
+    let readLaterManager = ReadLaterManager()
+
     ContentView()
+        .environment(appState)
+        .environment(timelineWrapper)
+        .environment(readLaterManager)
         .modelContainer(for: [Account.self, CachedStatus.self, ReadLaterConfig.self], inMemory: true)
 }

--- a/fedi-readerTests/AppStateTests.swift
+++ b/fedi-readerTests/AppStateTests.swift
@@ -122,4 +122,45 @@ struct AppStateTests {
 
         #expect(state.exploreNavigationPath.isEmpty == true)
     }
+
+    @Test("resolved default link feed falls back to home when the configured list is unavailable")
+    func resolvedDefaultLinkFeedFallsBackToHome() async {
+        let state = AppState()
+
+        let feedID = state.resolvedDefaultLinkFeedID(
+            defaultListId: "missing-list",
+            availableListIDs: ["list-1", "list-2"]
+        )
+
+        #expect(feedID == AppState.homeFeedID)
+    }
+
+    @Test("apply default link feed selects the configured list when available")
+    func applyDefaultLinkFeedSelectsConfiguredList() async {
+        let state = AppState()
+
+        let feedID = state.applyDefaultLinkFeed(
+            defaultListId: "list-2",
+            availableListIDs: ["list-1", "list-2"]
+        )
+
+        #expect(feedID == "list-2")
+        #expect(state.selectedListId == "list-2")
+        #expect(state.selectedLinkFeedID == "list-2")
+    }
+
+    @Test("apply default link feed resets selection to home when no default list matches")
+    func applyDefaultLinkFeedResetsSelectionToHome() async {
+        let state = AppState()
+        state.selectedListId = "old-list"
+
+        let feedID = state.applyDefaultLinkFeed(
+            defaultListId: "missing-list",
+            availableListIDs: ["list-1", "list-2"]
+        )
+
+        #expect(feedID == AppState.homeFeedID)
+        #expect(state.selectedListId == nil)
+        #expect(state.selectedLinkFeedID == AppState.homeFeedID)
+    }
 }


### PR DESCRIPTION
Summary
- move service wiring, feed loading, and inbox refresh handling into `FediReaderApp` to run at launch and share between macOS/iOS scenes
- use a shared `TimelineServiceWrapper` to gate initial feed loading, cache lists, and prefetch adjacent feeds while respecting the user’s default feed choice
- unify feed tab selection logic with the new `AppState` helpers and new timeline APIs so home vs. list feeds use the same identifier everywhere

Testing
- Not run (not requested)