### PR TITLE
FEDI-11: DM view improvements - keyboard dismiss, remove divider, hide tab bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,11 @@ fedi-reader/
 └── Utilities/              # HTMLParser, KeychainHelper, etc.
 ```
 
+## Linear workflow
+
+- **When starting work on an issue**: Mark it **In Progress** in Linear (use Linear MCP `save_issue` with `state: "In Progress"`).
+- **Do not mark issues Done**: Let the Linear–GitHub integration set Done when the PR is merged. Manually setting Done bypasses that flow.
+
 ## Configuration
 
 - **URL scheme**: `fedi-reader://` for OAuth callbacks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,11 @@ fedi-reader/
 - PascalCase for types, camelCase for properties/methods
 - No external dependencies — all functionality via Apple frameworks
 
+## Linear workflow
+
+- **When starting work on an issue**: Mark it **In Progress** in Linear (use Linear MCP `save_issue` with `state: "In Progress"`).
+- **Do not mark issues Done**: Let the Linear–GitHub integration set Done when the PR is merged. Manually setting Done bypasses that flow.
+
 ## Configuration
 
 - **URL scheme**: `fedi-reader://` (OAuth callbacks, registered in Info.plist)

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
@@ -103,6 +103,7 @@ struct GroupedConversationDetailView: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
                 }
+                .scrollDismissesKeyboard(.interactively)
                 .onAppear {
                     // Scroll to bottom (newest messages) when view appears
                     if let lastGroup = groupedMessages.last {
@@ -119,13 +120,12 @@ struct GroupedConversationDetailView: View {
                 }
             }
             
-            Divider()
-            
             // Compose bar
             composeBar
         }
         .navigationTitle(currentGroupedConversation.displayName)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .tabBar)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 if isGroupChat {


### PR DESCRIPTION
## Summary

Fixes FEDI-11: Cannot Dismiss Keyboard In DM View, plus additional DM UX improvements.

## Changes

- **Keyboard dismiss**: Add `.scrollDismissesKeyboard(.interactively)` so users can swipe the message list to dismiss the keyboard
- **Remove divider**: Remove horizontal bar above the message field
- **Hide tab bar in conversation**: Tab bar now hidden when viewing a conversation, only visible on the main messages list
- **Agent docs**: Document Linear workflow in AGENTS.md and CLAUDE.md (mark In Progress when working, let GitHub set Done on merge)

## Testing

- Verified build succeeds
- Keyboard can be dismissed by swiping the message list
- Tab bar hidden in conversation detail, visible on conversations list

Made with [Cursor](https://cursor.com)