### PR TITLE
Unread PM dot indicator, theme-colored badges, Linear workflow docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,15 @@ fedi-reader/
 
 ## Linear workflow
 
-- **When starting work on an issue**: Mark it **In Progress** in Linear (use Linear MCP `save_issue` with `state: "In Progress"`).
-- **Do not mark issues Done**: Let the Linear–GitHub integration set Done when the PR is merged. Manually setting Done bypasses that flow.
+Branches are linked to Linear issues via the branch name (e.g. `FED-123-feature-name`, `sam/FED-456-fix`). Follow this workflow:
+
+1. **Check for linked issue**: When starting work, parse the current branch name for a Linear issue ID (e.g. `FED-123`, `PROJ-456`). Use Linear MCP `get_issue` or `list_issues` to confirm the issue exists.
+
+2. **Set In Progress**: If the issue exists, update it to **In Progress** via `save_issue` with `state: "In Progress"` (or equivalent state name in your workspace).
+
+3. **Add comments as you work**: Use `create_comment` to describe the work being done—what was implemented, key decisions, or blockers. This keeps the issue history useful for PR review and future reference.
+
+4. **Do not mark Done**: Let the Linear–GitHub integration set Done when the PR is merged. Manually setting Done bypasses that flow. PRs opened in GitHub will drive status updates from here.
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,15 @@ fedi-reader/
 
 ## Linear workflow
 
-- **When starting work on an issue**: Mark it **In Progress** in Linear (use Linear MCP `save_issue` with `state: "In Progress"`).
-- **Do not mark issues Done**: Let the Linear–GitHub integration set Done when the PR is merged. Manually setting Done bypasses that flow.
+Branches are linked to Linear issues via the branch name (e.g. `FED-123-feature-name`, `sam/FED-456-fix`). Follow this workflow:
+
+1. **Check for linked issue**: When starting work, parse the current branch name for a Linear issue ID (e.g. `FED-123`, `PROJ-456`). Use Linear MCP `get_issue` or `list_issues` to confirm the issue exists.
+
+2. **Set In Progress**: If the issue exists, update it to **In Progress** via `save_issue` with `state: "In Progress"` (or equivalent state name in your workspace).
+
+3. **Add comments as you work**: Use `create_comment` to describe the work being done—what was implemented, key decisions, or blockers. This keeps the issue history useful for PR review and future reference.
+
+4. **Do not mark Done**: Let the Linear–GitHub integration set Done when the PR is merged. Manually setting Done bypasses that flow. PRs opened in GitHub will drive status updates from here.
 
 ## Configuration
 

--- a/fedi-reader/App/FediReaderApp.swift
+++ b/fedi-reader/App/FediReaderApp.swift
@@ -8,6 +8,9 @@
 import SwiftUI
 import SwiftData
 import AppIntents
+#if os(iOS)
+import UIKit
+#endif
 
 @available(iOS 16.0, *)
 private enum AppIntentsDependency {
@@ -61,6 +64,14 @@ struct FediReaderApp: App {
                     setupServices()
                     updateInboxAutoRefresh(for: scenePhase)
                     startInitialLinkFeedLoadIfNeeded()
+                    #if os(iOS)
+                    configureTabBarBadgeColor(themeColorName)
+                    #endif
+                }
+                .onChange(of: themeColorName) { _, newValue in
+                    #if os(iOS)
+                    configureTabBarBadgeColor(newValue)
+                    #endif
                 }
                 .task {
                     await appState.authService.migrateOAuthClientSecretsToKeychain(modelContext: modelContext)
@@ -95,6 +106,18 @@ struct FediReaderApp: App {
         }
         #endif
     }
+
+    #if os(iOS)
+    private func configureTabBarBadgeColor(_ themeColorName: String) {
+        let color = ThemeColor.resolved(from: themeColorName).color
+        let tabBarAppearance = UITabBarAppearance()
+        let itemAppearance = UITabBarItemAppearance()
+        itemAppearance.normal.badgeBackgroundColor = UIColor(color)
+        tabBarAppearance.stackedLayoutAppearance = itemAppearance
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+    }
+    #endif
 
     @MainActor
     private func setupServices() {

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationRow.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationRow.swift
@@ -3,7 +3,8 @@ import os
 
 struct GroupedConversationRow: View {
     let groupedConversation: GroupedConversation
-    
+    @AppStorage("themeColor") private var themeColorName = "blue"
+
     var body: some View {
         HStack(spacing: 12) {
             // Avatar(s)
@@ -57,7 +58,7 @@ struct GroupedConversationRow: View {
     private var unreadIndicator: some View {
         if groupedConversation.unread {
             Circle()
-                .fill(.blue)
+                .fill(ThemeColor.resolved(from: themeColorName).color)
                 .frame(width: 12, height: 12)
                 .overlay(
                     Circle()

--- a/fedi-reader/Views/Root/MainTabView.swift
+++ b/fedi-reader/Views/Root/MainTabView.swift
@@ -12,7 +12,8 @@ struct MainTabView: View {
     @State private var tabTracker = TabSelectionTracker()
     @AppStorage("hapticFeedback") private var hapticFeedback = true
     @AppStorage("hideTabBarLabels") private var hideTabBarLabels = false
-    
+    @AppStorage("themeColor") private var themeColorName = "blue"
+
     private var unreadMentionsCount: Int {
         timelineWrapper.service?.unreadConversationsCount ?? 0
     }
@@ -21,81 +22,12 @@ struct MainTabView: View {
         layoutMode.useSidebarLayout
     }
 
+
     var body: some View {
         @Bindable var state = appState
 
-        TabView(
-            selection: Binding(
-                get: { state.selectedTab },
-                set: { handleTabSelection($0) }
-            )
-        ) {
-            Tab(useSidebarLayout ? "Home" : (hideTabBarLabels ? "" : "Home"), systemImage: "house", value: .links) {
-                Group {
-                    switch layoutMode {
-                    case .wide:
-                        NavigationStack(path: $state.linksNavigationPath) {
-                            LinkFeedThreeColumnView()
-                                .navigationDestination(for: NavigationDestination.self) { destination in
-                                    splitLayoutDestinationView(for: destination)
-                                }
-                        }
-                    case .medium:
-                        NavigationStack(path: $state.linksNavigationPath) {
-                            LinkFeedTwoColumnView()
-                                .navigationDestination(for: NavigationDestination.self) { destination in
-                                    splitLayoutDestinationView(for: destination)
-                                }
-                        }
-                    case .compact:
-                        NavigationStack(path: $state.linksNavigationPath) {
-                            LinkFeedView()
-                                .navigationDestination(for: NavigationDestination.self) { destination in
-                                    destinationView(for: destination)
-                                }
-                        }
-                    }
-                }
-                .id("links-layout-\(layoutMode.id)")
-                .animation(.none, value: layoutMode)
-            }
-
-            Tab(useSidebarLayout ? "Explore" : (hideTabBarLabels ? "" : "Explore"), systemImage: "globe", value: .explore) {
-                NavigationStack(path: $state.exploreNavigationPath) {
-                    ExploreFeedView()
-                        .navigationDestination(for: NavigationDestination.self) { destination in
-                            destinationView(for: destination)
-                        }
-                }
-            }
-
-            Tab(useSidebarLayout ? "Messages" : (hideTabBarLabels ? "" : "Messages"), systemImage: "at", value: .mentions) {
-                Group {
-                    if useSidebarLayout {
-                        MentionsTwoColumnView()
-                    } else {
-                        NavigationStack {
-                            MentionsView()
-                                .navigationDestination(for: NavigationDestination.self) { destination in
-                                    destinationView(for: destination)
-                                }
-                        }
-                    }
-                }
-            }
-            .badge(unreadMentionsCount)
-
-            Tab(useSidebarLayout ? "Profile" : (hideTabBarLabels ? "" : "Profile"), systemImage: "person", value: .profile) {
-                NavigationStack(path: $state.profileNavigationPath) {
-                    ProfileView()
-                        .navigationDestination(for: NavigationDestination.self) { destination in
-                            destinationView(for: destination)
-                        }
-                }
-            }
-        }
-        .modifier(ConditionalTabViewStyle(useSidebarLayout: useSidebarLayout))
-        .onChange(of: state.selectedTab) { oldValue, newValue in
+        mainTabView()
+            .onChange(of: state.selectedTab) { oldValue, newValue in
             HapticFeedback.play(.selection, enabled: hapticFeedback && !useSidebarLayout)
             if oldValue == .profile {
                 state.profileNavigationPath.removeAll()
@@ -113,6 +45,117 @@ struct MainTabView: View {
         .onChange(of: useSidebarLayout) { _, _ in
             Task {
                 await ensureListsAvailableAfterLayoutTransition()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func mainTabView() -> some View {
+        @Bindable var state = appState
+
+        TabView(
+            selection: Binding(
+                get: { state.selectedTab },
+                set: { handleTabSelection($0) }
+            )
+        ) {
+            Tab(useSidebarLayout ? "Home" : (hideTabBarLabels ? "" : "Home"), systemImage: "house", value: .links) {
+                linksTabContent()
+            }
+
+            Tab(useSidebarLayout ? "Explore" : (hideTabBarLabels ? "" : "Explore"), systemImage: "globe", value: .explore) {
+                NavigationStack(path: $state.exploreNavigationPath) {
+                    ExploreFeedView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            destinationView(for: destination)
+                        }
+                }
+            }
+
+            Tab(useSidebarLayout ? "Messages" : (hideTabBarLabels ? "" : "Messages"), systemImage: "at", value: AppTab.mentions) {
+                mentionsTabContent()
+            }
+
+            Tab(useSidebarLayout ? "Profile" : (hideTabBarLabels ? "" : "Profile"), systemImage: "person", value: .profile) {
+                NavigationStack(path: $state.profileNavigationPath) {
+                    ProfileView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            destinationView(for: destination)
+                        }
+                }
+            }
+        }
+        .modifier(ConditionalTabViewStyle(useSidebarLayout: useSidebarLayout))
+        .overlay {
+            unreadDotOverlay
+        }
+    }
+
+    @ViewBuilder
+    private var unreadDotOverlay: some View {
+        if !useSidebarLayout, unreadMentionsCount > 0 {
+            GeometryReader { geometry in
+                Circle()
+                    .fill(ThemeColor.resolved(from: themeColorName).color)
+                    .frame(width: 8, height: 8)
+                    .overlay(
+                        Circle()
+                            .stroke(Color(.systemBackground), lineWidth: 2)
+                    )
+                    .position(
+                        x: geometry.size.width * (2.5 / 4),
+                        y: geometry.size.height - 35
+                    )
+            }
+            .allowsHitTesting(false)
+        }
+    }
+
+    @ViewBuilder
+    private func linksTabContent() -> some View {
+        @Bindable var state = appState
+
+        Group {
+            switch layoutMode {
+            case .wide:
+                NavigationStack(path: $state.linksNavigationPath) {
+                    LinkFeedThreeColumnView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            splitLayoutDestinationView(for: destination)
+                        }
+                }
+            case .medium:
+                NavigationStack(path: $state.linksNavigationPath) {
+                    LinkFeedTwoColumnView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            splitLayoutDestinationView(for: destination)
+                        }
+                }
+            case .compact:
+                NavigationStack(path: $state.linksNavigationPath) {
+                    LinkFeedView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            destinationView(for: destination)
+                        }
+                }
+            }
+        }
+        .id("links-layout-\(layoutMode.id)")
+        .animation(.none, value: layoutMode)
+    }
+
+    @ViewBuilder
+    private func mentionsTabContent() -> some View {
+        Group {
+            if useSidebarLayout {
+                MentionsTwoColumnView()
+            } else {
+                NavigationStack {
+                    MentionsView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            destinationView(for: destination)
+                        }
+                }
             }
         }
     }
@@ -214,3 +257,4 @@ private struct ConditionalTabViewStyle: ViewModifier {
         }
     }
 }
+


### PR DESCRIPTION
## Summary

- **Tab bar**: Replace unread count badge with a small theme-colored dot (matching the conversation view style)
- **Conversation rows**: Unread indicator dot now uses theme color instead of hardcoded blue
- **Linear workflow**: Updated AGENTS.md and CLAUDE.md with branch-linked issue workflow

## Changes

- MainTabView: Overlay a small theme-colored dot over Messages tab when unread
- GroupedConversationRow: Use ThemeColor for unread indicator
- FediReaderApp: UITabBar badge appearance config for theme color (iOS)
- AGENTS.md, CLAUDE.md: Expanded Linear workflow documentation

Made with [Cursor](https://cursor.com)