### PR TITLE
Messages UI: theme color, iPad/macOS layout, thread grouping

### DIFF
--- a/fedi-reader/Utilities/ConversationSearch/ConversationGroupingHelper.swift
+++ b/fedi-reader/Utilities/ConversationSearch/ConversationGroupingHelper.swift
@@ -11,9 +11,11 @@ enum ConversationGroupingHelper {
         for conversation in conversations {
             let otherParticipants = conversation.accounts.filter { $0.id != currentAccountId }
 
+            guard !otherParticipants.isEmpty else { continue }
+
             if otherParticipants.count > 1 {
-                let participantIds = otherParticipants.map { $0.id }.sorted().joined(separator: "-")
-                let groupId = "group-\(participantIds)"
+                let participantKeys = Set(otherParticipants.map { canonicalParticipantKey(for: $0) }).sorted().joined(separator: "-")
+                let groupId = "group-\(participantKeys)"
 
                 if var existing = groupChats[groupId] {
                     existing.conversations.append(conversation)
@@ -21,12 +23,13 @@ enum ConversationGroupingHelper {
                 } else {
                     groupChats[groupId] = (participants: otherParticipants, conversations: [conversation])
                 }
-            } else if let otherAccount = otherParticipants.first ?? conversation.accounts.first {
-                if var existing = oneOnOneGrouped[otherAccount.id] {
+            } else if let otherAccount = otherParticipants.first {
+                let key = canonicalParticipantKey(for: otherAccount)
+                if var existing = oneOnOneGrouped[key] {
                     existing.conversations.append(conversation)
-                    oneOnOneGrouped[otherAccount.id] = existing
+                    oneOnOneGrouped[key] = existing
                 } else {
-                    oneOnOneGrouped[otherAccount.id] = (account: otherAccount, conversations: [conversation])
+                    oneOnOneGrouped[key] = (account: otherAccount, conversations: [conversation])
                 }
             }
         }
@@ -101,6 +104,10 @@ enum ConversationGroupingHelper {
         }
 
         return candidates.sorted().first
+    }
+
+    private static func canonicalParticipantKey(for account: MastodonAccount) -> String {
+        canonicalNormalizedHandle(for: account) ?? account.id
     }
 }
 

--- a/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
+++ b/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
@@ -6,6 +6,7 @@ struct ChatBubble: View {
     let account: MastodonAccount
     let isSent: Bool
     @Environment(AppState.self) private var appState
+    @AppStorage("themeColor") private var themeColorName = "blue"
     
     var status: Status? {
         message.status
@@ -59,7 +60,7 @@ struct ChatBubble: View {
                 .padding(.vertical, 10)
                 .background(
                     RoundedRectangle(cornerRadius: 18)
-                        .fill(isSent ? Color.accentColor.opacity(0.2) : Color(.secondarySystemBackground))
+                        .fill(isSent ? ThemeColor.resolved(from: themeColorName).color.opacity(0.2) : Color(.secondarySystemBackground))
                 )
                 .overlay(alignment: isSent ? .bottomLeading : .bottomTrailing) {
                     // Tapback-style favorite indicator

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
@@ -5,6 +5,7 @@ struct GroupedConversationDetailView: View {
     let groupedConversation: GroupedConversation
     @Environment(AppState.self) private var appState
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+    @Environment(\.layoutMode) private var layoutMode
     
     @State private var messageText = ""
     @State private var isSending = false
@@ -122,10 +123,12 @@ struct GroupedConversationDetailView: View {
             
             // Compose bar
             composeBar
+                .padding(.horizontal, 16)
+                .padding(.bottom, 12)
         }
         .navigationTitle(currentGroupedConversation.displayName)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .tabBar)
+        .toolbar(layoutMode.isCompact ? .hidden : .visible, for: .tabBar)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 if isGroupChat {

--- a/fedi-reader/Views/Feed/Mentions/MentionsTwoColumnView.swift
+++ b/fedi-reader/Views/Feed/Mentions/MentionsTwoColumnView.swift
@@ -39,6 +39,15 @@ struct MentionsTwoColumnView: View {
             HStack(spacing: 0) {
                 // Column 1: Conversations list
                 VStack(spacing: 0) {
+                    HStack {
+                        Text("Messages")
+                            .font(.roundedTitle2.bold())
+                        Spacer()
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 16)
+                    .background(Color(.systemBackground))
+
                     if !conversations.isEmpty {
                         ConversationsListView(conversations: conversations, selection: $selectedConversation)
                     } else if timelineService?.isLoadingConversations == true {

--- a/fedi-readerTests/ConversationSearchHelpersTests.swift
+++ b/fedi-readerTests/ConversationSearchHelpersTests.swift
@@ -84,6 +84,23 @@ struct ConversationSearchHelpersTests {
         #expect(Set(matches[0].participants.map(\.id)) == Set(["alice", "bob"]))
     }
 
+    @Test("Same id but different acct produces separate grouped conversations")
+    func sameIdDifferentAcctProducesSeparateGroups() {
+        let me = makeAccount(id: "me", username: "me", acct: "me@local.social", host: "local.social")
+        let aliceAlpha = makeAccount(id: "123", username: "alice", acct: "alice@alpha.social", host: "alpha.social")
+        let aliceBeta = makeAccount(id: "123", username: "alice", acct: "alice@beta.social", host: "beta.social")
+
+        let conversations = [
+            makeConversation(id: "conv-alpha", accounts: [me, aliceAlpha]),
+            makeConversation(id: "conv-beta", accounts: [me, aliceBeta])
+        ]
+
+        let grouped = ConversationGroupingHelper.groupedConversations(from: conversations, currentAccountId: me.id)
+
+        #expect(grouped.count == 2)
+        #expect(Set(grouped.map { $0.participants.first?.acct ?? "" }) == Set(["alice@alpha.social", "alice@beta.social"]))
+    }
+
     @Test("Superset and subset participant sets do not match")
     func doesNotMatchSupersetOrSubset() {
         let me = makeAccount(id: "me", username: "me", acct: "me@local.social", host: "local.social")


### PR DESCRIPTION
- ChatBubble: use theme color for sent message bubbles (fixes FEDI-60)
- GroupedConversationDetailView: keep tab bar visible on iPad/macOS sidebar
  layout; add padding around compose bar pill
- MentionsTwoColumnView: add Messages heading in sidebar; full title2 style
- ConversationGroupingHelper: group threads by canonical handle (acct) instead
  of id to prevent similar users blending; skip empty otherParticipants
- Add test: same id different acct produces separate grouped conversations

Made-with: Cursor