### PR TITLE
FEDI-19 Exclude Bluesky/BridgyFed links from link feed

### DIFF
--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -83,14 +83,17 @@ final class LinkFilterService {
                 return false
             }
             
-            // Check for link card
-            if targetStatus.hasLinkCard {
+            // Check for link card (exclude social post URLs: Threads, Instagram, Bluesky)
+            if targetStatus.hasLinkCard,
+               let cardURL = targetStatus.card?.linkURL,
+               !Self.isSocialPostURL(cardURL) {
                 return true
             }
             
-            // Check for links in content
+            // Check for links in content (exclude social post URLs)
             let links = Self.extractExternalLinks(from: targetStatus)
-            return !links.isEmpty
+            let validLinks = links.filter { !Self.isSocialPostURL($0) }
+            return !validLinks.isEmpty
         }
         Self.logger.debug("Filtered to \(filtered.count) link statuses (\(filtered.count * 100 / max(statuses.count, 1))%)")
         return filtered
@@ -247,17 +250,20 @@ final class LinkFilterService {
     
     // MARK: - Link Extraction
     
-    /// Returns true if the URL points to Threads or Instagram (social posts, not articles).
-    private func isThreadsOrInstagramURL(_ url: URL) -> Bool {
-        Self.isThreadsOrInstagramURL(url)
+    /// Returns true if the URL points to Threads, Instagram, or Bluesky (social posts, not articles).
+    private func isSocialPostURL(_ url: URL) -> Bool {
+        Self.isSocialPostURL(url)
     }
     
-    /// Returns true if the URL points to Threads or Instagram (social posts, not articles).
-    private nonisolated static func isThreadsOrInstagramURL(_ url: URL) -> Bool {
+    /// Returns true if the URL points to Threads, Instagram, or Bluesky (social posts, not articles).
+    private nonisolated static func isSocialPostURL(_ url: URL) -> Bool {
         guard let host = url.host?.lowercased() else { return false }
+        // Threads / Instagram
         if host == "threads.net" || host == "www.threads.net" || host.hasSuffix(".threads.net") { return true }
         if host == "threads.com" || host == "www.threads.com" || host.hasSuffix(".threads.com") { return true }
         if host == "instagram.com" || host == "www.instagram.com" || host.hasSuffix(".instagram.com") { return true }
+        // Bluesky / BridgyFed – replies to bridged posts often have cards/links pointing to bsky.app
+        if host.contains("bsky.app") || host.contains("bsky.social") { return true }
         return false
     }
     
@@ -332,7 +338,7 @@ final class LinkFilterService {
             if let card = targetStatus.card,
                card.type == .link,
                let cardURL = card.linkURL {
-                guard !isThreadsOrInstagramURL(cardURL) else { continue }
+                guard !isSocialPostURL(cardURL) else { continue }
                 
                 linkStatuses.append(
                     LinkStatus(
@@ -352,8 +358,7 @@ final class LinkFilterService {
             }
             
             let links = extractExternalLinks(from: targetStatus)
-            guard let primaryURL = links.first else { continue }
-            guard !isThreadsOrInstagramURL(primaryURL) else { continue }
+            guard let primaryURL = links.first(where: { !isSocialPostURL($0) }) else { continue }
             
             linkStatuses.append(
                 LinkStatus(

--- a/fedi-readerTests/LinkFilterServiceTests.swift
+++ b/fedi-readerTests/LinkFilterServiceTests.swift
@@ -308,6 +308,70 @@ struct LinkFilterServiceTests {
         #expect(linkStatuses.first?.primaryURL.absoluteString == "https://example.com/article")
     }
     
+    @Test("Includes replies that have article links in content")
+    func includesRepliesWithArticleLinks() async {
+        let statuses = [
+            MockStatusFactory.makeStatus(
+                id: "reply-with-article",
+                content: "<p>Great point! Here's more: <a href=\"https://example.com/deep-dive\">read this</a></p>",
+                inReplyToId: "parent-status-id"
+            ),
+            MockStatusFactory.makeStatus(
+                id: "reply-with-article-card",
+                hasCard: true,
+                cardURL: "https://news.site/article",
+                inReplyToId: "bridged-bluesky-parent"
+            ),
+            MockStatusFactory.makeStatus(
+                id: "reply-mixed-links",
+                content: """
+                <p>Replying to <a href="https://bsky.app/post/abc">thread</a> —
+                also see <a href="https://example.com/related">this article</a></p>
+                """,
+                inReplyToId: "bluesky-parent"
+            )
+        ]
+
+        let linkStatuses = await service.processStatuses(statuses)
+
+        #expect(linkStatuses.count == 3)
+        #expect(linkStatuses.contains { $0.id == "reply-with-article" && $0.primaryURL.absoluteString == "https://example.com/deep-dive" })
+        #expect(linkStatuses.contains { $0.id == "reply-with-article-card" && $0.primaryURL.absoluteString == "https://news.site/article" })
+        #expect(linkStatuses.contains { $0.id == "reply-mixed-links" && $0.primaryURL.absoluteString == "https://example.com/related" })
+    }
+
+    @Test("Excludes Bluesky and BridgyFed links from processed results")
+    func excludesBlueskyLinks() async {
+        let statuses = [
+            MockStatusFactory.makeStatus(
+                id: "bluesky-card",
+                hasCard: true,
+                cardURL: "https://bsky.app/profile/user.bsky.social/post/abc123"
+            ),
+            MockStatusFactory.makeStatus(
+                id: "bluesky-content",
+                content: "<p>Reply <a href=\"https://bsky.app/post/xyz\">to thread</a></p>"
+            ),
+            MockStatusFactory.makeStatus(
+                id: "bridgy-reply",
+                hasCard: true,
+                cardURL: "https://bsky.social/xrpc/app.bsky.feed.getPost",
+                inReplyToId: "parent-id"
+            ),
+            MockStatusFactory.makeStatus(
+                id: "article",
+                hasCard: true,
+                cardURL: "https://example.com/article"
+            )
+        ]
+
+        let linkStatuses = await service.processStatuses(statuses)
+
+        #expect(linkStatuses.count == 1)
+        #expect(linkStatuses.first?.id == "article")
+        #expect(linkStatuses.first?.primaryURL.absoluteString == "https://example.com/article")
+    }
+
     @Test("Excludes Threads and Instagram subdomains and bare domains")
     func excludesThreadsAndInstagramSubdomainsAndBareDomains() async {
         let statuses = [


### PR DESCRIPTION
## Summary

Replies to bridged Bluesky posts sometimes show up in the link feed without having a meaningful link—they only contain cards or content links pointing to bsky.app/bsky.social. This PR treats Bluesky URLs as social post URLs (like Threads and Instagram) and excludes them from the link feed.

## Changes

- **LinkFilterService**: Renamed `isThreadsOrInstagramURL` to `isSocialPostURL` and extended it to include Bluesky (bsky.app, bsky.social)
- Exclude Bluesky URLs from both link card and content link filtering
- Replies that have actual article links still appear—we use the first non-social link as the primary URL when content has mixed links

## Tests

- `excludesBlueskyLinks`: Bluesky card and content links are excluded
- `includesRepliesWithArticleLinks`: Replies with article links (in content or as cards) are still included, including replies that mix Bluesky and article links

Made with [Cursor](https://cursor.com)