### PR TITLE
Fix HTML entity decoding in remote text (FEDI-63)

### DIFF
--- a/fedi-reader/Models/CachedStatus/CachedStatus.swift
+++ b/fedi-reader/Models/CachedStatus/CachedStatus.swift
@@ -61,9 +61,9 @@ final class CachedStatus {
             timelineType: timelineType,
             hasLinkCard: status.hasLinkCard,
             cardURL: status.card?.url,
-            cardTitle: status.card?.title,
+            cardTitle: status.card.flatMap { $0.decodedTitle.isEmpty ? nil : $0.decodedTitle },
             cardImageURL: status.card?.image,
-            authorAttribution: status.card?.authorName
+            authorAttribution: status.card?.decodedAuthorName
         )
     }
 }

--- a/fedi-reader/Models/MastodonTypes/Field.swift
+++ b/fedi-reader/Models/MastodonTypes/Field.swift
@@ -43,6 +43,16 @@ struct Field: Codable, Hashable, Sendable {
         formatter.formatOptions = [.withInternetDateTime]
         verifiedAt = formatter.date(from: decodedDateString)
     }
+
+    /// Field name with HTML entities decoded for display (remote profile metadata).
+    nonisolated var decodedName: String {
+        HTMLParser.decodeHTMLEntities(name).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Field value with HTML entities decoded for display (remote profile metadata).
+    nonisolated var decodedValue: String {
+        HTMLParser.decodeHTMLEntities(value).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }
 
 // MARK: - Media Attachment

--- a/fedi-reader/Models/MastodonTypes/PreviewCard.swift
+++ b/fedi-reader/Models/MastodonTypes/PreviewCard.swift
@@ -33,6 +33,30 @@ struct PreviewCard: Codable, Hashable, Sendable {
     nonisolated var linkURL: URL? {
         URL(string: url)
     }
+
+    /// Author name with HTML entities (e.g. &#x27;, &apos;) decoded for display.
+    nonisolated var decodedAuthorName: String? {
+        guard let authorName, !authorName.isEmpty else { return nil }
+        let decoded = HTMLParser.decodeHTMLEntities(authorName).trimmingCharacters(in: .whitespacesAndNewlines)
+        return decoded.isEmpty ? nil : decoded
+    }
+
+    /// Title with HTML entities decoded for display (remote card metadata).
+    nonisolated var decodedTitle: String {
+        HTMLParser.decodeHTMLEntities(title).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Description with HTML entities decoded for display (remote card metadata).
+    nonisolated var decodedDescription: String {
+        HTMLParser.decodeHTMLEntities(description).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Provider name with HTML entities decoded for display (remote card metadata).
+    nonisolated var decodedProviderName: String? {
+        guard let providerName, !providerName.isEmpty else { return nil }
+        let decoded = HTMLParser.decodeHTMLEntities(providerName).trimmingCharacters(in: .whitespacesAndNewlines)
+        return decoded.isEmpty ? nil : decoded
+    }
 }
 
 

--- a/fedi-reader/Models/MastodonTypes/TrendingLink.swift
+++ b/fedi-reader/Models/MastodonTypes/TrendingLink.swift
@@ -32,6 +32,30 @@ struct TrendingLink: Codable, Hashable, Sendable {
     var linkURL: URL? {
         URL(string: url)
     }
+
+    /// Author name with HTML entities (e.g. &#x27;, &apos;) decoded for display.
+    var decodedAuthorName: String? {
+        guard let authorName, !authorName.isEmpty else { return nil }
+        let decoded = HTMLParser.decodeHTMLEntities(authorName).trimmingCharacters(in: .whitespacesAndNewlines)
+        return decoded.isEmpty ? nil : decoded
+    }
+
+    /// Title with HTML entities decoded for display (remote metadata).
+    var decodedTitle: String {
+        HTMLParser.decodeHTMLEntities(title).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Description with HTML entities decoded for display (remote metadata).
+    var decodedDescription: String {
+        HTMLParser.decodeHTMLEntities(description).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Provider name with HTML entities decoded for display (remote metadata).
+    var decodedProviderName: String? {
+        guard let providerName, !providerName.isEmpty else { return nil }
+        let decoded = HTMLParser.decodeHTMLEntities(providerName).trimmingCharacters(in: .whitespacesAndNewlines)
+        return decoded.isEmpty ? nil : decoded
+    }
 }
 
 

--- a/fedi-reader/Services/AttributionChecker.swift
+++ b/fedi-reader/Services/AttributionChecker.swift
@@ -138,12 +138,14 @@ actor AttributionChecker {
             // Check custom author headers (only if they contain actual author info, not derived)
             if let author = httpResponse.value(forHTTPHeaderField: "X-Author"), !author.isEmpty {
                 Self.logger.debug("Found attribution in X-Author header: \(url.absoluteString, privacy: .public)")
-                return AuthorAttribution(name: author, url: nil, source: .linkHeader)
+                let decoded = HTMLParser.decodeHTMLEntities(author).trimmingCharacters(in: .whitespacesAndNewlines)
+                return AuthorAttribution(name: decoded.isEmpty ? author : decoded, url: nil, source: .linkHeader)
             }
             
             if let author = httpResponse.value(forHTTPHeaderField: "Author"), !author.isEmpty {
                 Self.logger.debug("Found attribution in Author header: \(url.absoluteString, privacy: .public)")
-                return AuthorAttribution(name: author, url: nil, source: .linkHeader)
+                let decoded = HTMLParser.decodeHTMLEntities(author).trimmingCharacters(in: .whitespacesAndNewlines)
+                return AuthorAttribution(name: decoded.isEmpty ? author : decoded, url: nil, source: .linkHeader)
             }
             
             return nil
@@ -348,7 +350,8 @@ actor AttributionChecker {
                 return authorAttribution(fromJSONLD: resolved, identifierIndex: identifierIndex, pageURL: pageURL)
             }
 
-            return makeAuthorAttribution(from: stringValue, source: .jsonLD, relativeTo: pageURL)
+            let decoded = HTMLParser.decodeHTMLEntities(stringValue).trimmingCharacters(in: .whitespacesAndNewlines)
+            return makeAuthorAttribution(from: decoded, source: .jsonLD, relativeTo: pageURL)
         }
 
         if let arrayValue = value as? [Any] {
@@ -370,7 +373,8 @@ actor AttributionChecker {
             return authorAttribution(fromJSONLD: resolved, identifierIndex: identifierIndex, pageURL: pageURL)
         }
 
-        let name = firstTextValue(in: dictionaryValue["name"])?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawName = firstTextValue(in: dictionaryValue["name"])?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = rawName.map { HTMLParser.decodeHTMLEntities($0).trimmingCharacters(in: .whitespacesAndNewlines) }.flatMap { $0.isEmpty ? nil : $0 }
         let urlCandidates = urlValues(in: dictionaryValue["url"]) + urlValues(in: dictionaryValue["sameAs"])
         let absoluteURLs = urlCandidates.compactMap { absoluteURLString(from: $0, relativeTo: pageURL) }
         let mastodonProfileURL = absoluteURLs.first(where: isMastodonProfileURL)

--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -345,11 +345,11 @@ final class LinkFilterService {
                         status: status,
                         primaryURL: cardURL,
                         tags: tags,
-                        title: card.title.isEmpty ? nil : card.title,
-                        description: card.description.isEmpty ? nil : card.description,
+                        title: card.decodedTitle.isEmpty ? nil : card.decodedTitle,
+                        description: card.decodedDescription.isEmpty ? nil : card.decodedDescription,
                         imageURL: card.imageURL,
-                        providerName: card.providerName,
-                        authorAttribution: card.authorName,
+                        providerName: card.decodedProviderName,
+                        authorAttribution: card.decodedAuthorName,
                         authorURL: card.authorUrl
                     )
                 )

--- a/fedi-reader/Views/Actions/StatusActions/StatusActionsBar.swift
+++ b/fedi-reader/Views/Actions/StatusActions/StatusActionsBar.swift
@@ -278,7 +278,7 @@ struct StatusActionsBar: View {
                             Task {
                                 try? await readLaterManager.save(
                                     url: url,
-                                    title: displayStatus.card?.title,
+                                    title: displayStatus.card?.decodedTitle,
                                     to: serviceType
                                 )
                             }
@@ -295,7 +295,7 @@ struct StatusActionsBar: View {
                                     Task {
                                         try? await readLaterManager.save(
                                             url: url,
-                                            title: displayStatus.card?.title,
+                                            title: displayStatus.card?.decodedTitle,
                                             to: serviceType
                                         )
                                     }

--- a/fedi-reader/Views/Actions/StatusActions/StatusActionsToolbar.swift
+++ b/fedi-reader/Views/Actions/StatusActions/StatusActionsToolbar.swift
@@ -79,7 +79,7 @@ struct StatusActionsToolbar: View {
                                 Task {
                                     try? await readLaterManager.save(
                                         url: url,
-                                        title: displayStatus.card?.title,
+                                        title: displayStatus.card?.decodedTitle,
                                         to: serviceType
                                     )
                                 }

--- a/fedi-reader/Views/Components/LinkCardContent.swift
+++ b/fedi-reader/Views/Components/LinkCardContent.swift
@@ -104,22 +104,22 @@ struct LinkCardContent: View {
 
 extension LinkCardContent {
     init(link: TrendingLink) {
-        title = link.title
-        description = link.description
+        title = link.decodedTitle
+        description = link.decodedDescription
         imageURL = link.imageURL
-        providerDisplay = link.providerName ?? link.url
-        authorName = link.authorName
+        providerDisplay = link.decodedProviderName ?? link.url
+        authorName = link.decodedAuthorName
         authorURL = link.authorUrl.flatMap { URL(string: $0) }
         showLinkIcon = false
     }
 
     init(card: PreviewCard, authorAttribution: AuthorAttribution?, authorDisplayName: String? = nil) {
-        title = card.title
-        description = card.description
+        title = card.decodedTitle
+        description = card.decodedDescription
         imageURL = card.imageURL
-        providerDisplay = card.providerName ?? (URL(string: card.url).flatMap { HTMLParser.extractDomain(from: $0) } ?? card.url)
+        providerDisplay = card.decodedProviderName ?? (URL(string: card.url).flatMap { HTMLParser.extractDomain(from: $0) } ?? card.url)
         let cardAuthorURL = card.authorUrl.flatMap { URL(string: $0) }
-        let resolvedAuthorName = authorDisplayName ?? authorAttribution?.preferredName ?? card.authorName
+        let resolvedAuthorName = authorDisplayName ?? authorAttribution?.preferredName ?? card.decodedAuthorName
         let resolvedAuthorURL = authorAttribution?.preferredURL ?? cardAuthorURL
 
         if let resolvedAuthorURL {

--- a/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
+++ b/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
@@ -57,7 +57,7 @@ struct TrendingLinkRow: View {
                             Task {
                                 try? await readLaterManager.save(
                                     url: url,
-                                    title: link.title,
+                                    title: link.decodedTitle,
                                     to: serviceType
                                 )
                             }

--- a/fedi-reader/Views/Feed/StatusRowView.swift
+++ b/fedi-reader/Views/Feed/StatusRowView.swift
@@ -362,12 +362,12 @@ struct StatusRowView: View {
                 
                 // Content
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(card.title)
+                    Text(card.decodedTitle)
                         .font(.roundedTitle3.bold())
                         .lineLimit(3)
                         .multilineTextAlignment(.leading)
                     
-                    let descriptionText = blueskyDescription ?? card.description
+                    let descriptionText = blueskyDescription ?? card.decodedDescription
                     if !descriptionText.isEmpty {
                         Text(descriptionText)
                             .font(.roundedSubheadline)
@@ -379,7 +379,7 @@ struct StatusRowView: View {
                         Image(systemName: "link")
                             .font(.roundedCaption)
                         
-                        Text(card.providerName ?? HTMLParser.extractDomain(from: URL(string: card.url)!) ?? card.url)
+                        Text(card.decodedProviderName ?? HTMLParser.extractDomain(from: URL(string: card.url)!) ?? card.url)
                             .font(.roundedCaption)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -388,7 +388,7 @@ struct StatusRowView: View {
                         let authorLink = authorAttribution?.preferredURL ?? card.authorUrl.flatMap { URL(string: $0) }
                         let authorDisplayName = resolvedAuthorAccount?.preferredDisplayName
                             ?? authorAttribution?.preferredName
-                            ?? card.authorName
+                            ?? card.decodedAuthorName
                             ?? (authorLink != nil ? "Author" : nil)
 
                         if let authorURL = authorLink {
@@ -538,7 +538,7 @@ struct StatusRowView: View {
                     Task {
                         try? await readLaterManager.save(
                             url: url,
-                            title: displayStatus.card?.title,
+                            title: displayStatus.card?.decodedTitle,
                             to: serviceType
                         )
                     }
@@ -554,7 +554,7 @@ struct StatusRowView: View {
                             Task {
                                 try? await readLaterManager.save(
                                     url: url,
-                                    title: displayStatus.card?.title,
+                                    title: displayStatus.card?.decodedTitle,
                                     to: serviceType
                                 )
                             }

--- a/fedi-reader/Views/Profile/FieldCardView.swift
+++ b/fedi-reader/Views/Profile/FieldCardView.swift
@@ -34,7 +34,7 @@ struct FieldCardView: View {
 
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 4) {
-                        Text(field.name)
+                        Text(field.decodedName)
                             .font(.roundedCaption.bold())
                             .foregroundStyle(.secondary)
                             .lineLimit(1)

--- a/fedi-reader/Views/Profile/ProfileLinksListView.swift
+++ b/fedi-reader/Views/Profile/ProfileLinksListView.swift
@@ -50,7 +50,7 @@ struct ProfileLinksListView: View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
-                    Text(field.name)
+                    Text(field.decodedName)
                         .font(.roundedCaption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -62,7 +62,7 @@ struct ProfileLinksListView: View {
                     }
                 }
 
-                Text(field.value.htmlStripped)
+                Text(field.decodedValue.htmlStripped)
                     .font(.roundedSubheadline)
                     .foregroundStyle(destinationURL == nil ? .secondary : .primary)
                     .lineLimit(1)

--- a/fedi-readerTests/HTMLParserTests.swift
+++ b/fedi-readerTests/HTMLParserTests.swift
@@ -226,6 +226,17 @@ struct HTMLParserTests {
         
         #expect(decoded == "A B C")
     }
+
+    @Test("Decodes apostrophe entity in names")
+    func decodesApostropheInNames() {
+        let html = "Terrence O&#x27;Brien"
+        let decoded = HTMLParser.decodeHTMLEntities(html)
+        #expect(decoded == "Terrence O'Brien")
+
+        let withApos = "O&apos;Reilly"
+        let decodedApos = HTMLParser.decodeHTMLEntities(withApos)
+        #expect(decodedApos == "O'Reilly")
+    }
     
     // MARK: - Mention and Hashtag Extraction
     


### PR DESCRIPTION
## Summary

Decode HTML entities (e.g. `&#x27;`, `&apos;`) across all remote-sourced text so names like "Terrence O&#x27;Brien" display correctly as "Terrence O'Brien".

## Changes

- **PreviewCard/TrendingLink**: Added `decodedTitle`, `decodedDescription`, `decodedProviderName`, `decodedAuthorName`
- **Field**: Added `decodedName`, `decodedValue` for profile metadata
- **AttributionChecker**: Decode JSON-LD author names and X-Author/Author headers
- **LinkFilterService**: Use decoded card properties when building LinkStatus
- **LinkCardContent, StatusRowView, StatusActionsBar, StatusActionsToolbar**: Use decoded text for display/share
- **CachedStatus**: Store decoded card title
- Added `decodesApostropheInNames` test

Closes FEDI-63

Made with [Cursor](https://cursor.com)