### PR TITLE
FEDI-58: add local list display controls

### DIFF
--- a/fedi-reader/App/FediReaderApp.swift
+++ b/fedi-reader/App/FediReaderApp.swift
@@ -84,6 +84,10 @@ struct FediReaderApp: App {
                 }
                 .onChange(of: appState.currentAccount?.id) { _, _ in
                     updateInboxAutoRefresh(for: scenePhase)
+                    appState.loadListDisplayPreferencesForCurrentAccount()
+                    if let service = timelineWrapper.service {
+                        service.lists = timelineWrapper.cachedLists(for: appState.currentAccount?.id)
+                    }
                     timelineWrapper.resetStartupLinkFeedLoad(for: appState.currentAccount?.id)
                     startInitialLinkFeedLoadIfNeeded()
                     Task {
@@ -122,6 +126,7 @@ struct FediReaderApp: App {
     @MainActor
     private func setupServices() {
         appState.authService.loadAccounts(from: modelContext)
+        appState.loadListDisplayPreferencesForCurrentAccount()
         Task {
             await appState.authService.refreshClientAuthenticationState()
         }
@@ -186,7 +191,7 @@ struct FediReaderApp: App {
                 await self.linkFilterService.enrichWithAttributions()
             }
 
-            let allFeedIDs = [AppState.homeFeedID] + service.lists.map(\.id)
+            let allFeedIDs = [AppState.homeFeedID] + self.appState.visibleListIDs(from: service.lists)
             await self.linkFilterService.prefetchAdjacentFeeds(
                 currentFeedId: initialFeedID,
                 allFeedIds: allFeedIDs
@@ -201,13 +206,19 @@ struct FediReaderApp: App {
         guard appState.hasAccount else { return AppState.homeFeedID }
 
         await service.loadLists()
+        let resolution = appState.synchronizeCurrentAccountListDisplayPreferences(
+            with: service.lists,
+            allowEmptyListSet: true
+        )
         if !service.lists.isEmpty {
             timelineWrapper.updateCachedLists(service.lists, for: appState.currentAccount?.id)
         }
 
+        let persistedDefaultListID =
+            UserDefaults.standard.string(forKey: AppState.defaultListIdStorageKey) ?? defaultListId
         return appState.applyDefaultLinkFeed(
-            defaultListId: defaultListId,
-            availableListIDs: service.lists.map(\.id)
+            defaultListId: persistedDefaultListID,
+            availableListIDs: resolution.visibleListIDs
         )
     }
 

--- a/fedi-reader/Models/ListDisplayPreferences.swift
+++ b/fedi-reader/Models/ListDisplayPreferences.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+enum ListDisplaySortOrder: String, Codable, CaseIterable, Identifiable, Sendable {
+    case alphabetical
+    case reverseAlphabetical
+    case custom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .alphabetical:
+            return "Alphabetical"
+        case .reverseAlphabetical:
+            return "Reverse Alphabetical"
+        case .custom:
+            return "Custom"
+        }
+    }
+}
+
+struct AccountListDisplayPreferences: Codable, Equatable, Sendable {
+    var sortOrder: ListDisplaySortOrder = .alphabetical
+    var hiddenListIDs: [String] = []
+    var customVisibleListOrder: [String] = []
+}
+
+struct AccountListDisplayResolution: Equatable, Sendable {
+    let visibleLists: [MastodonList]
+    let hiddenLists: [MastodonList]
+    let normalizedPreferences: AccountListDisplayPreferences
+
+    var visibleListIDs: [String] {
+        visibleLists.map(\.id)
+    }
+}
+
+enum AccountListDisplayResolver {
+    nonisolated static func resolve(
+        lists: [MastodonList],
+        preferences: AccountListDisplayPreferences
+    ) -> AccountListDisplayResolution {
+        let existingListIDs = Set(lists.map(\.id))
+        let hiddenListIDs = orderedUniqueIDs(
+            preferences.hiddenListIDs.filter { existingListIDs.contains($0) }
+        )
+        let hiddenListIDSet = Set(hiddenListIDs)
+
+        let visibleSourceLists = lists.filter { !hiddenListIDSet.contains($0.id) }
+        let hiddenSourceLists = lists.filter { hiddenListIDSet.contains($0.id) }
+
+        let normalizedCustomVisibleListOrder = normalizedCustomOrder(
+            for: visibleSourceLists,
+            preferences: preferences,
+            hiddenListIDSet: hiddenListIDSet,
+            existingListIDs: existingListIDs
+        )
+
+        let visibleLists: [MastodonList]
+        let hiddenLists: [MastodonList]
+        switch preferences.sortOrder {
+        case .alphabetical:
+            visibleLists = visibleSourceLists.sorted(by: ascendingTitleComparator)
+            hiddenLists = hiddenSourceLists.sorted(by: ascendingTitleComparator)
+        case .reverseAlphabetical:
+            visibleLists = visibleSourceLists.sorted(by: descendingTitleComparator)
+            hiddenLists = hiddenSourceLists.sorted(by: descendingTitleComparator)
+        case .custom:
+            let listsByID = Dictionary(uniqueKeysWithValues: visibleSourceLists.map { ($0.id, $0) })
+            let orderedIDs = Set(normalizedCustomVisibleListOrder)
+            let orderedVisibleLists = normalizedCustomVisibleListOrder.compactMap { listsByID[$0] }
+            let unorderedVisibleLists = visibleSourceLists.filter { !orderedIDs.contains($0.id) }
+            visibleLists = orderedVisibleLists + unorderedVisibleLists
+            hiddenLists = hiddenSourceLists.sorted(by: ascendingTitleComparator)
+        }
+
+        return AccountListDisplayResolution(
+            visibleLists: visibleLists,
+            hiddenLists: hiddenLists,
+            normalizedPreferences: AccountListDisplayPreferences(
+                sortOrder: preferences.sortOrder,
+                hiddenListIDs: hiddenListIDs,
+                customVisibleListOrder: normalizedCustomVisibleListOrder
+            )
+        )
+    }
+
+    private nonisolated static func normalizedCustomOrder(
+        for visibleLists: [MastodonList],
+        preferences: AccountListDisplayPreferences,
+        hiddenListIDSet: Set<String>,
+        existingListIDs: Set<String>
+    ) -> [String] {
+        let filteredSavedOrder = orderedUniqueIDs(
+            preferences.customVisibleListOrder.filter {
+                existingListIDs.contains($0) && !hiddenListIDSet.contains($0)
+            }
+        )
+        let savedOrderSet = Set(filteredSavedOrder)
+        let appendedVisibleIDs = visibleLists
+            .map(\.id)
+            .filter { !savedOrderSet.contains($0) }
+        return filteredSavedOrder + appendedVisibleIDs
+    }
+
+    private nonisolated static func orderedUniqueIDs(_ ids: [String]) -> [String] {
+        var seenIDs = Set<String>()
+        return ids.filter { seenIDs.insert($0).inserted }
+    }
+
+    private nonisolated static func ascendingTitleComparator(_ lhs: MastodonList, _ rhs: MastodonList) -> Bool {
+        lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+    }
+
+    private nonisolated static func descendingTitleComparator(_ lhs: MastodonList, _ rhs: MastodonList) -> Bool {
+        lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedDescending
+    }
+}

--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -14,6 +14,10 @@ import os
 final class AppState {
     private static let logger = Logger(subsystem: "app.fedi-reader", category: "AppState")
     static let homeFeedID = "home"
+    static let defaultListIdStorageKey = "defaultListId"
+    private static let listDisplayPreferencesStorageKeyPrefix = "listDisplayPreferences."
+    private static let listDisplayPreferencesEncoder = JSONEncoder()
+    private static let listDisplayPreferencesDecoder = JSONDecoder()
     
     // Services
     let client: MastodonClient
@@ -31,6 +35,7 @@ final class AppState {
     var isUserFilterOpen = false
     var userFilterPerFeedId: [String: String] = [:]  // feedId -> accountId
     var linksLastVisibleStatusIdPerFeed: [String: String] = [:]
+    var currentAccountListDisplayPreferences = AccountListDisplayPreferences()
     
     // Navigation state (per-tab so switching tabs shows correct root)
     var linksNavigationPath: [NavigationDestination] = []
@@ -60,6 +65,11 @@ final class AppState {
     var selectedLinkFeedID: String {
         selectedListId ?? Self.homeFeedID
     }
+
+    private var currentAccountListDisplayPreferencesStorageKey: String? {
+        guard let accountID = currentAccount?.id else { return nil }
+        return Self.listDisplayPreferencesStorageKeyPrefix + accountID
+    }
     
     func getAccessToken() async -> String? {
         guard let account = currentAccount else { return nil }
@@ -68,6 +78,162 @@ final class AppState {
     
     func getCurrentInstance() -> String? {
         currentAccount?.instance
+    }
+
+    // MARK: - List Display
+
+    func loadListDisplayPreferencesForCurrentAccount(defaults: UserDefaults = .standard) {
+        guard let storageKey = currentAccountListDisplayPreferencesStorageKey else {
+            currentAccountListDisplayPreferences = AccountListDisplayPreferences()
+            return
+        }
+
+        guard let data = defaults.data(forKey: storageKey),
+              let preferences = try? Self.listDisplayPreferencesDecoder.decode(
+                  AccountListDisplayPreferences.self,
+                  from: data
+              ) else {
+            currentAccountListDisplayPreferences = AccountListDisplayPreferences()
+            return
+        }
+
+        currentAccountListDisplayPreferences = preferences
+    }
+
+    func persistListDisplayPreferencesForCurrentAccount(defaults: UserDefaults = .standard) {
+        guard let storageKey = currentAccountListDisplayPreferencesStorageKey else { return }
+
+        if currentAccountListDisplayPreferences == AccountListDisplayPreferences() {
+            defaults.removeObject(forKey: storageKey)
+            return
+        }
+
+        guard let data = try? Self.listDisplayPreferencesEncoder.encode(currentAccountListDisplayPreferences) else {
+            Self.logger.error("Failed to encode list display preferences")
+            return
+        }
+
+        defaults.set(data, forKey: storageKey)
+    }
+
+    func resolvedListDisplay(for rawLists: [MastodonList]) -> AccountListDisplayResolution {
+        AccountListDisplayResolver.resolve(
+            lists: rawLists,
+            preferences: currentAccountListDisplayPreferences
+        )
+    }
+
+    @discardableResult
+    func synchronizeCurrentAccountListDisplayPreferences(
+        with rawLists: [MastodonList],
+        allowEmptyListSet: Bool = false,
+        defaults: UserDefaults = .standard
+    ) -> AccountListDisplayResolution {
+        let resolution = resolvedListDisplay(for: rawLists)
+        guard !rawLists.isEmpty || allowEmptyListSet else {
+            return resolution
+        }
+
+        if resolution.normalizedPreferences != currentAccountListDisplayPreferences {
+            currentAccountListDisplayPreferences = resolution.normalizedPreferences
+            persistListDisplayPreferencesForCurrentAccount(defaults: defaults)
+        }
+
+        reconcileVisibleFeedSelection(
+            visibleListIDs: resolution.visibleListIDs,
+            defaults: defaults
+        )
+        return resolution
+    }
+
+    func visibleLists(from rawLists: [MastodonList]) -> [MastodonList] {
+        resolvedListDisplay(for: rawLists).visibleLists
+    }
+
+    func hiddenLists(from rawLists: [MastodonList]) -> [MastodonList] {
+        resolvedListDisplay(for: rawLists).hiddenLists
+    }
+
+    func visibleListIDs(from rawLists: [MastodonList]) -> [String] {
+        resolvedListDisplay(for: rawLists).visibleListIDs
+    }
+
+    func feedTabs(from rawLists: [MastodonList]) -> [FeedTabItem] {
+        [FeedTabItem.home] + visibleLists(from: rawLists).map {
+            FeedTabItem(id: $0.id, title: $0.title)
+        }
+    }
+
+    func updateListDisplaySortOrder(
+        _ sortOrder: ListDisplaySortOrder,
+        rawLists: [MastodonList],
+        defaults: UserDefaults = .standard
+    ) {
+        currentAccountListDisplayPreferences.sortOrder = sortOrder
+        _ = synchronizeCurrentAccountListDisplayPreferences(with: rawLists, defaults: defaults)
+    }
+
+    func setListVisibility(
+        listID: String,
+        isVisible: Bool,
+        rawLists: [MastodonList],
+        defaults: UserDefaults = .standard
+    ) {
+        if isVisible {
+            currentAccountListDisplayPreferences.hiddenListIDs.removeAll { $0 == listID }
+            if currentAccountListDisplayPreferences.sortOrder == .custom,
+               !currentAccountListDisplayPreferences.customVisibleListOrder.contains(listID) {
+                currentAccountListDisplayPreferences.customVisibleListOrder.append(listID)
+            }
+        } else {
+            if !currentAccountListDisplayPreferences.hiddenListIDs.contains(listID) {
+                currentAccountListDisplayPreferences.hiddenListIDs.append(listID)
+            }
+            currentAccountListDisplayPreferences.customVisibleListOrder.removeAll { $0 == listID }
+        }
+
+        _ = synchronizeCurrentAccountListDisplayPreferences(with: rawLists, defaults: defaults)
+    }
+
+    func moveVisibleLists(
+        fromOffsets: IndexSet,
+        toOffset: Int,
+        rawLists: [MastodonList],
+        defaults: UserDefaults = .standard
+    ) {
+        var reorderedVisibleIDs = visibleListIDs(from: rawLists)
+        moveIDs(&reorderedVisibleIDs, fromOffsets: fromOffsets, toOffset: toOffset)
+        currentAccountListDisplayPreferences.sortOrder = .custom
+        currentAccountListDisplayPreferences.customVisibleListOrder = reorderedVisibleIDs
+        _ = synchronizeCurrentAccountListDisplayPreferences(with: rawLists, defaults: defaults)
+    }
+
+    private func reconcileVisibleFeedSelection(
+        visibleListIDs: [String],
+        defaults: UserDefaults
+    ) {
+        if let selectedListId, !visibleListIDs.contains(selectedListId) {
+            self.selectedListId = nil
+        }
+
+        let defaultListID = defaults.string(forKey: Self.defaultListIdStorageKey) ?? ""
+        if !defaultListID.isEmpty, !visibleListIDs.contains(defaultListID) {
+            defaults.set("", forKey: Self.defaultListIdStorageKey)
+        }
+    }
+
+    private func moveIDs(
+        _ ids: inout [String],
+        fromOffsets: IndexSet,
+        toOffset: Int
+    ) {
+        let movingItems = fromOffsets.map { ids[$0] }
+        let removedBeforeDestination = fromOffsets.filter { $0 < toOffset }.count
+        for offset in fromOffsets.sorted(by: >) {
+            ids.remove(at: offset)
+        }
+        let adjustedOffset = max(0, min(ids.count, toOffset - removedBeforeDestination))
+        ids.insert(contentsOf: movingItems, at: adjustedOffset)
     }
     
     // MARK: - Error Handling
@@ -281,6 +447,7 @@ enum NavigationDestination: Hashable {
     case thread(statusId: String)
     case hashtag(String)
     case settings
+    case listDisplay
     case accountSettings
     case readLaterSettings
     case accountPosts(accountId: String, account: MastodonAccount)

--- a/fedi-reader/Services/TimelineService.swift
+++ b/fedi-reader/Services/TimelineService.swift
@@ -1104,7 +1104,6 @@ final class TimelineService {
             let list = try await client.createList(instance: account.instance, accessToken: token, title: title)
             if !lists.contains(list) {
                 lists.append(list)
-                lists.sort { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
             }
             return list
         } catch let err as FediReaderError where err == .unauthorized {

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -139,7 +139,7 @@ struct LinkFeedContentView: View {
         timelineWrapper.cachedLists(for: accountId)
     }
 
-    private var lists: [MastodonList] {
+    private var rawLists: [MastodonList] {
         if !liveLists.isEmpty {
             return liveLists
         }
@@ -150,9 +150,7 @@ struct LinkFeedContentView: View {
     }
 
     private var feedTabs: [FeedTabItem] {
-        var tabs = [FeedTabItem.home]
-        tabs.append(contentsOf: lists.map { FeedTabItem(id: $0.id, title: $0.title) })
-        return tabs
+        appState.feedTabs(from: rawLists)
     }
 
     private var currentTab: FeedTabItem {
@@ -240,7 +238,12 @@ struct LinkFeedContentView: View {
                 selectedTabIndex = 0
                 return
             }
-            if selectedTabIndex >= tabIds.count {
+            let targetTabID = tabIds.contains(appState.selectedLinkFeedID)
+                ? appState.selectedLinkFeedID
+                : AppState.homeFeedID
+            if let index = feedTabs.firstIndex(where: { $0.id == targetTabID }) {
+                selectedTabIndex = index
+            } else {
                 selectedTabIndex = 0
             }
         }
@@ -261,6 +264,7 @@ struct LinkFeedContentView: View {
             if retainedLists.isEmpty, !cachedLists.isEmpty {
                 retainedLists = cachedLists
             }
+            appState.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
             syncRetainedLists(with: liveLists, allowEmpty: false)
             // Attempt to restore scroll to last seen item when returning
             attemptRestoreScrollIfNeeded()
@@ -504,6 +508,10 @@ struct LinkFeedContentView: View {
             if !retainedLists.isEmpty {
                 retainedLists = []
             }
+            appState.synchronizeCurrentAccountListDisplayPreferences(
+                with: [],
+                allowEmptyListSet: true
+            )
             return
         }
 
@@ -513,6 +521,7 @@ struct LinkFeedContentView: View {
         if cachedLists != incomingLists {
             timelineWrapper.updateCachedLists(incomingLists, for: accountId)
         }
+        appState.synchronizeCurrentAccountListDisplayPreferences(with: incomingLists)
     }
 
     private func loadInitialContent() async {

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -60,7 +60,7 @@ struct LinkFeedThreeColumnView: View {
         timelineWrapper.cachedLists(for: accountId)
     }
 
-    private var lists: [MastodonList] {
+    private var rawLists: [MastodonList] {
         if !liveLists.isEmpty {
             return liveLists
         }
@@ -71,9 +71,7 @@ struct LinkFeedThreeColumnView: View {
     }
 
     private var feedTabs: [FeedTabItem] {
-        var tabs = [FeedTabItem.home]
-        tabs.append(contentsOf: lists.map { FeedTabItem(id: $0.id, title: $0.title) })
-        return tabs
+        appState.feedTabs(from: rawLists)
     }
 
     private var currentTab: FeedTabItem {
@@ -246,6 +244,20 @@ struct LinkFeedThreeColumnView: View {
                 selectedTabIndex = index
             }
         }
+        .onChange(of: feedTabs.map(\.id)) { _, tabIDs in
+            guard !tabIDs.isEmpty else {
+                selectedTabIndex = 0
+                return
+            }
+            let targetTabID = tabIDs.contains(appState.selectedLinkFeedID)
+                ? appState.selectedLinkFeedID
+                : AppState.homeFeedID
+            if let index = feedTabs.firstIndex(where: { $0.id == targetTabID }) {
+                selectedTabIndex = index
+            } else {
+                selectedTabIndex = 0
+            }
+        }
         .onChange(of: liveLists) { _, newLists in
             syncRetainedLists(with: newLists, allowEmpty: false)
         }
@@ -263,6 +275,7 @@ struct LinkFeedThreeColumnView: View {
             if retainedLists.isEmpty, !cachedLists.isEmpty {
                 retainedLists = cachedLists
             }
+            appState.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
             syncRetainedLists(with: liveLists, allowEmpty: false)
             attemptRestoreScrollIfNeeded()
         }
@@ -458,6 +471,10 @@ struct LinkFeedThreeColumnView: View {
             if !retainedLists.isEmpty {
                 retainedLists = []
             }
+            appState.synchronizeCurrentAccountListDisplayPreferences(
+                with: [],
+                allowEmptyListSet: true
+            )
             return
         }
 
@@ -467,6 +484,7 @@ struct LinkFeedThreeColumnView: View {
         if cachedLists != incomingLists {
             timelineWrapper.updateCachedLists(incomingLists, for: accountId)
         }
+        appState.synchronizeCurrentAccountListDisplayPreferences(with: incomingLists)
     }
 
     // MARK: - Data Loading

--- a/fedi-reader/Views/Profile/ListDisplaySettingsView.swift
+++ b/fedi-reader/Views/Profile/ListDisplaySettingsView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+struct ListDisplaySettingsView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+
+    @State private var isLoading = false
+
+    private var timelineService: TimelineService? {
+        timelineWrapper.service
+    }
+
+    private var accountID: String? {
+        appState.currentAccount?.id
+    }
+
+    private var liveLists: [MastodonList] {
+        timelineService?.lists ?? []
+    }
+
+    private var cachedLists: [MastodonList] {
+        timelineWrapper.cachedLists(for: accountID)
+    }
+
+    private var rawLists: [MastodonList] {
+        if !liveLists.isEmpty {
+            return liveLists
+        }
+        return cachedLists
+    }
+
+    private var resolution: AccountListDisplayResolution {
+        appState.resolvedListDisplay(for: rawLists)
+    }
+
+    private var isCustomSortOrder: Bool {
+        resolution.normalizedPreferences.sortOrder == .custom
+    }
+
+    var body: some View {
+        List {
+            Section("Order") {
+                Picker("Sort Order", selection: sortOrderBinding) {
+                    ForEach(ListDisplaySortOrder.allCases) { sortOrder in
+                        Text(sortOrder.title).tag(sortOrder)
+                    }
+                }
+                .pickerStyle(.menu)
+            }
+
+            Section {
+                Label("Home always stays first and visible.", systemImage: "house.fill")
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Visible") {
+                if isLoading && rawLists.isEmpty {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                } else if resolution.visibleLists.isEmpty {
+                    Text("No visible lists.")
+                        .foregroundStyle(.secondary)
+                } else if resolution.normalizedPreferences.sortOrder == .custom {
+                    ForEach(resolution.visibleLists) { list in
+                        listVisibilityRow(for: list, isVisible: true)
+                    }
+                    .onMove(perform: moveVisibleLists)
+                } else {
+                    ForEach(resolution.visibleLists) { list in
+                        listVisibilityRow(for: list, isVisible: true)
+                    }
+                }
+            }
+
+            Section("Hidden") {
+                if resolution.hiddenLists.isEmpty {
+                    Text("No hidden lists.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(resolution.hiddenLists) { list in
+                        listVisibilityRow(for: list, isVisible: false)
+                    }
+                }
+            }
+        }
+        .navigationTitle("List Display")
+        .environment(\.editMode, .constant(isCustomSortOrder ? .active : .inactive))
+        .task {
+            await loadLists()
+        }
+        .onAppear {
+            if !rawLists.isEmpty {
+                appState.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
+            }
+        }
+        .onChange(of: liveLists) { _, newLists in
+            appState.synchronizeCurrentAccountListDisplayPreferences(with: newLists)
+        }
+    }
+
+    private var sortOrderBinding: Binding<ListDisplaySortOrder> {
+        Binding(
+            get: { appState.currentAccountListDisplayPreferences.sortOrder },
+            set: { newSortOrder in
+                appState.updateListDisplaySortOrder(newSortOrder, rawLists: rawLists)
+            }
+        )
+    }
+
+    private func listVisibilityRow(for list: MastodonList, isVisible: Bool) -> some View {
+        HStack(spacing: 12) {
+            Text(list.title)
+
+            Spacer(minLength: 0)
+
+            Button {
+                setVisibility(for: list, isVisible: !isVisible)
+            } label: {
+                Image(systemName: isVisible ? "minus.circle" : "plus.circle")
+                    .foregroundStyle(isVisible ? Color.red : Color.accentColor)
+                    .font(.title3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isVisible ? "Hide \(list.title)" : "Show \(list.title)")
+        }
+    }
+
+    private func setVisibility(for list: MastodonList, isVisible: Bool) {
+        appState.setListVisibility(
+            listID: list.id,
+            isVisible: isVisible,
+            rawLists: rawLists
+        )
+    }
+
+    private func moveVisibleLists(fromOffsets: IndexSet, toOffset: Int) {
+        appState.moveVisibleLists(
+            fromOffsets: fromOffsets,
+            toOffset: toOffset,
+            rawLists: rawLists
+        )
+    }
+
+    private func loadLists() async {
+        guard let timelineService else { return }
+        isLoading = true
+        await timelineService.loadLists(forceRefresh: rawLists.isEmpty)
+        appState.synchronizeCurrentAccountListDisplayPreferences(
+            with: timelineService.lists,
+            allowEmptyListSet: true
+        )
+        isLoading = false
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ListDisplaySettingsView()
+    }
+    .environment(AppState())
+    .environment(TimelineServiceWrapper())
+}

--- a/fedi-reader/Views/Profile/ProfileView.swift
+++ b/fedi-reader/Views/Profile/ProfileView.swift
@@ -48,6 +48,14 @@ struct ProfileView: View {
                     Label("Account Settings", systemImage: "person.crop.circle.badge.checkmark")
                 }
             }
+
+            Section("Lists") {
+                Button {
+                    appState.navigate(to: .listDisplay)
+                } label: {
+                    Label("List Display", systemImage: "list.bullet.rectangle")
+                }
+            }
             
             // Read Later
             Section("Read Later") {

--- a/fedi-reader/Views/Root/MainTabView.swift
+++ b/fedi-reader/Views/Root/MainTabView.swift
@@ -218,6 +218,8 @@ struct MainTabView: View {
             HashtagPlaceholderView(tag: tag)
         case .settings:
             SettingsView()
+        case .listDisplay:
+            ListDisplaySettingsView()
         case .accountSettings:
             AccountSettingsView()
         case .readLaterSettings:
@@ -269,4 +271,3 @@ private struct ConditionalTabViewStyle: ViewModifier {
         }
     }
 }
-

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -17,9 +17,21 @@ struct SettingsView: View {
     @AppStorage("defaultListId") private var defaultListId = ""
     @AppStorage("showQuoteBoost") private var showQuoteBoost = true
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+
+    private var accountID: String? {
+        appState.currentAccount?.id
+    }
+
+    private var rawLists: [MastodonList] {
+        let liveLists = timelineWrapper.service?.lists ?? []
+        if !liveLists.isEmpty {
+            return liveLists
+        }
+        return timelineWrapper.cachedLists(for: accountID)
+    }
     
     private var lists: [MastodonList] {
-        timelineWrapper.service?.lists ?? []
+        return appState.visibleLists(from: rawLists)
     }
     
     private var selectedThemeColor: Color {
@@ -58,6 +70,14 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .tint(selectedThemeColor)
         .id("settings-theme-\(themeColorName)")
+        .onAppear {
+            _ = appState.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
+        }
+        .onChange(of: lists.map(\.id)) { _, visibleListIDs in
+            if !defaultListId.isEmpty, !visibleListIDs.contains(defaultListId) {
+                defaultListId = ""
+            }
+        }
     }
 
     private var settingsListContent: some View {
@@ -535,5 +555,3 @@ private struct ThemeColorSelectionView: View {
         .tint(selectedThemeColor)
     }
 }
-
-

--- a/fedi-readerTests/AppStateTests.swift
+++ b/fedi-readerTests/AppStateTests.swift
@@ -15,6 +15,10 @@ private struct GenericTestError: LocalizedError {
     }
 }
 
+private func makeList(id: String, title: String) -> MastodonList {
+    MastodonList(id: id, title: title, repliesPolicy: nil, exclusive: nil)
+}
+
 @Suite("AppState Tests")
 @MainActor
 struct AppStateTests {
@@ -162,5 +166,94 @@ struct AppStateTests {
         #expect(feedID == AppState.homeFeedID)
         #expect(state.selectedListId == nil)
         #expect(state.selectedLinkFeedID == AppState.homeFeedID)
+    }
+
+    @Test("visible list ids exclude hidden lists when resolving default feed selection")
+    func visibleListIDsExcludeHiddenLists() async {
+        let state = AppState()
+        let rawLists = [
+            makeList(id: "list-1", title: "Alpha"),
+            makeList(id: "list-2", title: "Beta")
+        ]
+        state.currentAccountListDisplayPreferences = AccountListDisplayPreferences(
+            sortOrder: .alphabetical,
+            hiddenListIDs: ["list-2"],
+            customVisibleListOrder: []
+        )
+
+        let feedID = state.applyDefaultLinkFeed(
+            defaultListId: "list-2",
+            availableListIDs: state.visibleListIDs(from: rawLists)
+        )
+
+        #expect(feedID == AppState.homeFeedID)
+        #expect(state.selectedLinkFeedID == AppState.homeFeedID)
+    }
+
+    @Test("synchronize clears the selected feed when it becomes hidden")
+    func synchronizeClearsHiddenSelectedFeed() async {
+        let state = AppState()
+        let rawLists = [
+            makeList(id: "list-1", title: "Alpha"),
+            makeList(id: "list-2", title: "Beta")
+        ]
+        state.selectedListId = "list-2"
+        state.currentAccountListDisplayPreferences = AccountListDisplayPreferences(
+            sortOrder: .alphabetical,
+            hiddenListIDs: ["list-2"],
+            customVisibleListOrder: []
+        )
+
+        _ = state.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
+
+        #expect(state.selectedListId == nil)
+        #expect(state.selectedLinkFeedID == AppState.homeFeedID)
+    }
+
+    @Test("synchronize clears the stored default feed when it becomes hidden")
+    func synchronizeClearsHiddenDefaultFeed() async {
+        let state = AppState()
+        let rawLists = [
+            makeList(id: "list-1", title: "Alpha"),
+            makeList(id: "list-2", title: "Beta")
+        ]
+        let defaults = UserDefaults.standard
+        let previousDefaultListID = defaults.string(forKey: AppState.defaultListIdStorageKey)
+        defaults.set("list-2", forKey: AppState.defaultListIdStorageKey)
+        defer {
+            if let previousDefaultListID {
+                defaults.set(previousDefaultListID, forKey: AppState.defaultListIdStorageKey)
+            } else {
+                defaults.removeObject(forKey: AppState.defaultListIdStorageKey)
+            }
+        }
+
+        state.currentAccountListDisplayPreferences = AccountListDisplayPreferences(
+            sortOrder: .alphabetical,
+            hiddenListIDs: ["list-2"],
+            customVisibleListOrder: []
+        )
+
+        _ = state.synchronizeCurrentAccountListDisplayPreferences(with: rawLists, defaults: defaults)
+
+        #expect((defaults.string(forKey: AppState.defaultListIdStorageKey) ?? "") == "")
+    }
+
+    @Test("feed tabs always place home first")
+    func feedTabsAlwaysPlaceHomeFirst() async {
+        let state = AppState()
+        let rawLists = [
+            makeList(id: "list-1", title: "Alpha"),
+            makeList(id: "list-2", title: "Beta")
+        ]
+        state.currentAccountListDisplayPreferences = AccountListDisplayPreferences(
+            sortOrder: .reverseAlphabetical,
+            hiddenListIDs: ["list-1"],
+            customVisibleListOrder: []
+        )
+
+        let tabIDs = state.feedTabs(from: rawLists).map(\.id)
+
+        #expect(tabIDs == [AppState.homeFeedID, "list-2"])
     }
 }

--- a/fedi-readerTests/ListDisplayPreferencesTests.swift
+++ b/fedi-readerTests/ListDisplayPreferencesTests.swift
@@ -1,0 +1,122 @@
+import Testing
+@testable import fedi_reader
+
+@Suite("List Display Preferences Tests")
+struct ListDisplayPreferencesTests {
+    @Test("alphabetical sort orders visible and hidden lists ascending")
+    func alphabeticalSortOrdersListsAscending() {
+        let lists = [
+            makeList(id: "3", title: "Charlie"),
+            makeList(id: "1", title: "alpha"),
+            makeList(id: "2", title: "Beta")
+        ]
+        let preferences = AccountListDisplayPreferences(
+            sortOrder: .alphabetical,
+            hiddenListIDs: ["2"],
+            customVisibleListOrder: []
+        )
+
+        let resolution = AccountListDisplayResolver.resolve(lists: lists, preferences: preferences)
+
+        #expect(resolution.visibleLists.map(\.title) == ["alpha", "Charlie"])
+        #expect(resolution.hiddenLists.map(\.title) == ["Beta"])
+    }
+
+    @Test("reverse alphabetical sort orders visible and hidden lists descending")
+    func reverseAlphabeticalSortOrdersListsDescending() {
+        let lists = [
+            makeList(id: "1", title: "alpha"),
+            makeList(id: "2", title: "Beta"),
+            makeList(id: "3", title: "Charlie")
+        ]
+        let preferences = AccountListDisplayPreferences(
+            sortOrder: .reverseAlphabetical,
+            hiddenListIDs: ["1"],
+            customVisibleListOrder: []
+        )
+
+        let resolution = AccountListDisplayResolver.resolve(lists: lists, preferences: preferences)
+
+        #expect(resolution.visibleLists.map(\.title) == ["Charlie", "Beta"])
+        #expect(resolution.hiddenLists.map(\.title) == ["alpha"])
+    }
+
+    @Test("custom sort respects saved visible order")
+    func customSortUsesSavedVisibleOrder() {
+        let lists = [
+            makeList(id: "1", title: "Alpha"),
+            makeList(id: "2", title: "Beta"),
+            makeList(id: "3", title: "Gamma")
+        ]
+        let preferences = AccountListDisplayPreferences(
+            sortOrder: .custom,
+            hiddenListIDs: [],
+            customVisibleListOrder: ["3", "1", "2"]
+        )
+
+        let resolution = AccountListDisplayResolver.resolve(lists: lists, preferences: preferences)
+
+        #expect(resolution.visibleListIDs == ["3", "1", "2"])
+    }
+
+    @Test("custom sort appends new visible lists after the saved order")
+    func customSortAppendsNewVisibleLists() {
+        let lists = [
+            makeList(id: "1", title: "Alpha"),
+            makeList(id: "2", title: "Beta"),
+            makeList(id: "3", title: "Gamma")
+        ]
+        let preferences = AccountListDisplayPreferences(
+            sortOrder: .custom,
+            hiddenListIDs: [],
+            customVisibleListOrder: ["2", "1"]
+        )
+
+        let resolution = AccountListDisplayResolver.resolve(lists: lists, preferences: preferences)
+
+        #expect(resolution.visibleListIDs == ["2", "1", "3"])
+        #expect(resolution.normalizedPreferences.customVisibleListOrder == ["2", "1", "3"])
+    }
+
+    @Test("hidden lists are excluded from visible results")
+    func hiddenListsAreExcludedFromVisibleResults() {
+        let lists = [
+            makeList(id: "1", title: "Alpha"),
+            makeList(id: "2", title: "Beta"),
+            makeList(id: "3", title: "Gamma")
+        ]
+        let preferences = AccountListDisplayPreferences(
+            sortOrder: .custom,
+            hiddenListIDs: ["2"],
+            customVisibleListOrder: ["2", "3", "1"]
+        )
+
+        let resolution = AccountListDisplayResolver.resolve(lists: lists, preferences: preferences)
+
+        #expect(resolution.visibleListIDs == ["3", "1"])
+        #expect(resolution.hiddenLists.map(\.id) == ["2"])
+        #expect(resolution.normalizedPreferences.customVisibleListOrder == ["3", "1"])
+    }
+
+    @Test("missing list identifiers are pruned during normalization")
+    func missingListIdentifiersArePruned() {
+        let lists = [
+            makeList(id: "1", title: "Alpha"),
+            makeList(id: "2", title: "Beta")
+        ]
+        let preferences = AccountListDisplayPreferences(
+            sortOrder: .custom,
+            hiddenListIDs: ["missing", "2"],
+            customVisibleListOrder: ["missing", "1", "2"]
+        )
+
+        let resolution = AccountListDisplayResolver.resolve(lists: lists, preferences: preferences)
+
+        #expect(resolution.normalizedPreferences.hiddenListIDs == ["2"])
+        #expect(resolution.normalizedPreferences.customVisibleListOrder == ["1"])
+    }
+
+    private func makeList(id: String, title: String) -> MastodonList {
+        MastodonList(id: id, title: title, repliesPolicy: nil, exclusive: nil)
+    }
+}


### PR DESCRIPTION
## What changed
- add per-account local list display preferences in Profile
- support alphabetical, reverse alphabetical, and custom ordering with Home fixed first
- allow visible/hidden list management with explicit add/remove controls and custom drag reordering
- use visible lists for feed tabs and default feed selection
- add resolver and AppState test coverage

## Why
- gives heavy list users control over ordering and visibility without introducing server sync yet

## Implementation notes
- preferences are persisted in UserDefaults per account
- hidden lists are excluded from feed tabs and default feed selection
- TimelineService keeps raw server order; presentation order is resolved in AppState

## Testing
- xcodebuild -scheme "fedi-reader" -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' test

## Risks / migration
- no schema migration; preferences are local-only for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes list-driven navigation (feed tabs, selected feed, and default feed) and introduces per-account UserDefaults persistence/normalization that could cause unexpected feed resets if preferences or cached lists drift.
> 
> **Overview**
> Adds **per-account list display preferences** (sort order, hidden lists, and custom visible ordering) persisted locally in `UserDefaults`, with a new `ListDisplaySettingsView` reachable from Profile via the new navigation destination `listDisplay`.
> 
> Updates the link feed (single- and three-column) and Settings default-feed picker to build tabs/options from **visible lists only**, synchronizes/normalizes preferences when lists load or accounts change, and clears the selected/default list when it becomes hidden. `TimelineService` no longer sorts lists on creation (presentation order is now resolved in `AppState`), and new unit tests cover the resolver and synchronization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 927c5d612894d54f5f022203918c5a4d3cef96c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->