### PR TITLE
FEDI-35 implement separate tab for lists and enhance navigation

### DIFF
--- a/.agents/skills/linear-workflow/SKILL.md
+++ b/.agents/skills/linear-workflow/SKILL.md
@@ -17,7 +17,7 @@ description: ALWAYS check for linked Linear issue and follow conventions before 
 
 ## Instructions
 
-1. **Parse branch name** for a Linear issue ID (e.g. `FED-123`, `PROJ-456`). Valid patterns: `FED-123-feature-name`, `sam/FED-456-fix`, `feature/FED-789-thing`.
+1. **Check GitHub issue** for a comment from Linear that has the Linear ticket ID (e.g. `FED-123`, `PROJ-456`). Valid patterns: `FED-123-feature-name`, `sam/FED-456-fix`, `feature/FED-789-thing`.
 
 2. **Confirm issue exists** via Linear MCP `get_issue` or `list_issues`.
 

--- a/fedi-reader/App/FediReaderApp.swift
+++ b/fedi-reader/App/FediReaderApp.swift
@@ -43,6 +43,7 @@ struct FediReaderApp: App {
     
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("defaultListId") private var defaultListId = ""
+    @AppStorage(AppState.listsInSeparateTabStorageKey) private var listsInSeparateTab = false
     @State private var appState = AppState()
     @State private var timelineWrapper = TimelineServiceWrapper()
     @State private var linkFilterService = LinkFilterService()
@@ -218,7 +219,8 @@ struct FediReaderApp: App {
             UserDefaults.standard.string(forKey: AppState.defaultListIdStorageKey) ?? defaultListId
         return appState.applyDefaultLinkFeed(
             defaultListId: persistedDefaultListID,
-            availableListIDs: resolution.visibleListIDs
+            availableListIDs: resolution.visibleListIDs,
+            listsInSeparateTab: listsInSeparateTab
         )
     }
 

--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -15,6 +15,7 @@ final class AppState {
     private static let logger = Logger(subsystem: "app.fedi-reader", category: "AppState")
     static let homeFeedID = "home"
     static let defaultListIdStorageKey = "defaultListId"
+    static let listsInSeparateTabStorageKey = "listsInSeparateTab"
     private static let listDisplayPreferencesStorageKeyPrefix = "listDisplayPreferences."
     private static let listDisplayPreferencesEncoder = JSONEncoder()
     private static let listDisplayPreferencesDecoder = JSONDecoder()
@@ -32,6 +33,7 @@ final class AppState {
     
     // List and filter state
     var selectedListId: String? = nil  // nil = Home timeline
+    var pendingListNavigationListID: String? = nil
     var isUserFilterOpen = false
     var userFilterPerFeedId: [String: String] = [:]  // feedId -> accountId
     var linksLastVisibleStatusIdPerFeed: [String: String] = [:]
@@ -39,6 +41,7 @@ final class AppState {
     
     // Navigation state (per-tab so switching tabs shows correct root)
     var linksNavigationPath: [NavigationDestination] = []
+    var listsNavigationPath: [NavigationDestination] = []
     var exploreNavigationPath: [NavigationDestination] = []
     var profileNavigationPath: [NavigationDestination] = []
     var mentionsNavigationPath: [NavigationDestination] = []
@@ -162,6 +165,25 @@ final class AppState {
         [FeedTabItem.home] + visibleLists(from: rawLists).map {
             FeedTabItem(id: $0.id, title: $0.title)
         }
+    }
+
+    func homeFeedTabs(from rawLists: [MastodonList], listsInSeparateTab: Bool) -> [FeedTabItem] {
+        listsInSeparateTab ? [.home] : feedTabs(from: rawLists)
+    }
+
+    func listFeedTabs(from rawLists: [MastodonList]) -> [FeedTabItem] {
+        visibleLists(from: rawLists).map {
+            FeedTabItem(id: $0.id, title: $0.title)
+        }
+    }
+
+    func appTabs(listsInSeparateTab: Bool) -> [AppTab] {
+        var tabs: [AppTab] = [.links]
+        if listsInSeparateTab {
+            tabs.append(.lists)
+        }
+        tabs.append(contentsOf: [.explore, .mentions, .profile])
+        return tabs
     }
 
     func updateListDisplaySortOrder(
@@ -294,6 +316,12 @@ final class AppState {
             } else {
                 linksNavigationPath.append(destination)
             }
+        case .lists:
+            if shouldReplaceArticle(path: listsNavigationPath) {
+                listsNavigationPath[listsNavigationPath.count - 1] = destination
+            } else {
+                listsNavigationPath.append(destination)
+            }
         case .explore:
             if shouldReplaceArticle(path: exploreNavigationPath) {
                 exploreNavigationPath[exploreNavigationPath.count - 1] = destination
@@ -324,6 +352,14 @@ final class AppState {
                 Self.logger.info("Navigating back from: \(String(describing: previous), privacy: .public)")
             } else {
                 Self.logger.debug("Navigate back called but navigation path is empty")
+            }
+        case .lists:
+            if !listsNavigationPath.isEmpty {
+                let previous = listsNavigationPath.last
+                listsNavigationPath.removeLast()
+                Self.logger.info("Navigating back from: \(String(describing: previous), privacy: .public)")
+            } else {
+                Self.logger.debug("Navigate back called but lists navigation path is empty")
             }
         case .explore:
             if !exploreNavigationPath.isEmpty {
@@ -358,6 +394,10 @@ final class AppState {
             let count = linksNavigationPath.count
             linksNavigationPath.removeAll()
             Self.logger.info("Navigating to root, cleared \(count) destinations")
+        case .lists:
+            let count = listsNavigationPath.count
+            listsNavigationPath.removeAll()
+            Self.logger.info("Navigating to root, cleared \(count) list destinations")
         case .explore:
             let count = exploreNavigationPath.count
             exploreNavigationPath.removeAll()
@@ -398,12 +438,21 @@ final class AppState {
     }
 
     @discardableResult
-    func applyDefaultLinkFeed(defaultListId: String, availableListIDs: [String]) -> String {
+    func applyDefaultLinkFeed(
+        defaultListId: String,
+        availableListIDs: [String],
+        listsInSeparateTab: Bool = false
+    ) -> String {
         let feedID = resolvedDefaultLinkFeedID(
             defaultListId: defaultListId,
             availableListIDs: availableListIDs
         )
         selectedListId = feedID == Self.homeFeedID ? nil : feedID
+        selectedTab = feedID == Self.homeFeedID || !listsInSeparateTab ? .links : .lists
+        pendingListNavigationListID = selectedTab == .lists ? feedID : nil
+        if pendingListNavigationListID == Self.homeFeedID {
+            pendingListNavigationListID = nil
+        }
         return feedID
     }
 }
@@ -412,6 +461,7 @@ final class AppState {
 
 enum AppTab: String, CaseIterable, Identifiable {
     case links
+    case lists
     case explore
     case mentions
     case profile
@@ -421,6 +471,7 @@ enum AppTab: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .links: return "Home"
+        case .lists: return "Lists"
         case .explore: return "Explore"
         case .mentions: return "Messages"
         case .profile: return "Profile"
@@ -430,6 +481,7 @@ enum AppTab: String, CaseIterable, Identifiable {
     var systemImage: String {
         switch self {
         case .links: return "house"
+        case .lists: return "list.bullet"
         case .explore: return "globe"
         case .mentions: return "at"
         case .profile: return "person"
@@ -443,6 +495,7 @@ enum NavigationDestination: Hashable {
     case status(Status)
     case conversation(GroupedConversation)
     case profile(MastodonAccount)
+    case listFeed(MastodonList)
     case article(url: URL, status: Status?)
     case thread(statusId: String)
     case hashtag(String)

--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -8,6 +8,28 @@
 import Foundation
 import os
 
+enum FeedScopedLinkData {
+    static func statuses(in service: LinkFilterService, feedId: String) -> [LinkStatus] {
+        service.getCachedContent(for: feedId)
+    }
+
+    static func filteredStatuses(
+        in service: LinkFilterService,
+        feedId: String,
+        userFilterAccountId: String?
+    ) -> [LinkStatus] {
+        service.filter(linkStatuses: statuses(in: service, feedId: feedId), byAccountId: userFilterAccountId)
+    }
+
+    static func accounts(in service: LinkFilterService, feedId: String) -> [MastodonAccount] {
+        service.uniqueAccounts(in: statuses(in: service, feedId: feedId))
+    }
+
+    static func isLoading(in service: LinkFilterService, feedId: String) -> Bool {
+        service.isLoadingFeed(feedId)
+    }
+}
+
 @Observable
 @MainActor
 final class LinkFilterService {

--- a/fedi-reader/Views/Feed/LinkFeedView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView.swift
@@ -1,8 +1,35 @@
 import SwiftUI
 
 struct LinkFeedView: View {
+    let feedTabsOverride: [FeedTabItem]?
+    let showsFeedPicker: Bool
+    let allowsSwipeNavigation: Bool
+    let titleOverride: String?
+    let userFilterToolbarPlacement: UserFilterToolbarPlacement
+
+    init(
+        feedTabsOverride: [FeedTabItem]? = nil,
+        showsFeedPicker: Bool = true,
+        allowsSwipeNavigation: Bool = true,
+        titleOverride: String? = nil,
+        userFilterToolbarPlacement: UserFilterToolbarPlacement = .leading
+    ) {
+        self.feedTabsOverride = feedTabsOverride
+        self.showsFeedPicker = showsFeedPicker
+        self.allowsSwipeNavigation = allowsSwipeNavigation
+        self.titleOverride = titleOverride
+        self.userFilterToolbarPlacement = userFilterToolbarPlacement
+    }
+
     var body: some View {
-        LinkFeedContentView(onArticleSelect: nil)
+        LinkFeedContentView(
+            onArticleSelect: nil,
+            feedTabsOverride: feedTabsOverride,
+            showsFeedPicker: showsFeedPicker,
+            allowsSwipeNavigation: allowsSwipeNavigation,
+            titleOverride: titleOverride,
+            userFilterToolbarPlacement: userFilterToolbarPlacement
+        )
     }
 }
 

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -23,6 +23,22 @@ enum HorizontalListPickerGestureFilter {
     }
 }
 
+enum UserFilterToolbarPlacement: Equatable {
+    case leading
+    case trailing
+
+    static let listsDetail: Self = .trailing
+
+    var toolbarItemPlacement: ToolbarItemPlacement {
+        switch self {
+        case .leading:
+            .topBarLeading
+        case .trailing:
+            .topBarTrailing
+        }
+    }
+}
+
 #if os(iOS)
 private struct HorizontalListPickerScrollProtector: UIViewRepresentable {
     typealias UIViewType = UIView
@@ -107,6 +123,11 @@ struct LinkFeedContentView: View {
     private static let pickerHeight: CGFloat = 44
 
     var onArticleSelect: ((URL, Status) -> Void)?
+    var feedTabsOverride: [FeedTabItem]? = nil
+    var showsFeedPicker = true
+    var allowsSwipeNavigation = true
+    var titleOverride: String? = nil
+    var userFilterToolbarPlacement: UserFilterToolbarPlacement = .leading
 
     @Environment(AppState.self) private var appState
     @Environment(LinkFilterService.self) private var linkFilterService
@@ -150,7 +171,8 @@ struct LinkFeedContentView: View {
     }
 
     private var feedTabs: [FeedTabItem] {
-        appState.feedTabs(from: rawLists)
+        let tabs = feedTabsOverride ?? appState.feedTabs(from: rawLists)
+        return tabs.isEmpty ? [.home] : tabs
     }
 
     private var currentTab: FeedTabItem {
@@ -161,7 +183,7 @@ struct LinkFeedContentView: View {
     }
 
     private var currentAccounts: [MastodonAccount] {
-        linkFilterService.uniqueAccounts()
+        FeedScopedLinkData.accounts(in: linkFilterService, feedId: currentTab.id)
     }
 
     private var currentUserFilter: String? {
@@ -169,9 +191,11 @@ struct LinkFeedContentView: View {
     }
 
     private var filteredStatuses: [LinkStatus] {
-        var statuses = linkFilterService.linkStatuses
-        statuses = linkFilterService.filter(linkStatuses: statuses, byAccountId: currentUserFilter)
-        return statuses
+        FeedScopedLinkData.filteredStatuses(
+            in: linkFilterService,
+            feedId: currentTab.id,
+            userFilterAccountId: currentUserFilter
+        )
     }
 
     private func shouldShowPaginationLoadingRow(for statuses: [LinkStatus]) -> Bool {
@@ -188,12 +212,13 @@ struct LinkFeedContentView: View {
 
         feedStack(statuses: statuses)
         .background(Color(.systemBackground))
+        .navigationTitle(showsFeedPicker ? "" : (titleOverride ?? currentTab.title))
         .navigationBarTitleDisplayMode(.inline)
         .onChange(of: appState.linksScrollToTopRequestID) { _, _ in
             scrollToTop()
         }
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
+            ToolbarItem(placement: userFilterToolbarPlacement.toolbarItemPlacement) {
                 Button {
                     appState.isUserFilterOpen = true
                 } label: {
@@ -202,8 +227,10 @@ struct LinkFeedContentView: View {
                 .accessibilityLabel(currentUserFilter != nil ? "User filter active" : "Filter by user")
                 .accessibilityHint("Opens user filter pane")
             }
-            ToolbarItem(placement: .principal) {
-                listPickerHeader
+            if showsFeedPicker {
+                ToolbarItem(placement: .principal) {
+                    listPickerHeader
+                }
             }
         }
         .sheet(isPresented: $state.isUserFilterOpen) {
@@ -228,6 +255,7 @@ struct LinkFeedContentView: View {
             handleTabChange(to: newIndex)
         }
         .onChange(of: appState.selectedListId) { _, newListId in
+            guard feedTabsOverride == nil else { return }
             let targetId = newListId ?? AppState.homeFeedID
             if let index = feedTabs.firstIndex(where: { $0.id == targetId }), selectedTabIndex != index {
                 selectedTabIndex = index
@@ -238,9 +266,9 @@ struct LinkFeedContentView: View {
                 selectedTabIndex = 0
                 return
             }
-            let targetTabID = tabIds.contains(appState.selectedLinkFeedID)
+            let targetTabID = feedTabsOverride == nil && tabIds.contains(appState.selectedLinkFeedID)
                 ? appState.selectedLinkFeedID
-                : AppState.homeFeedID
+                : feedTabs.first?.id ?? AppState.homeFeedID
             if let index = feedTabs.firstIndex(where: { $0.id == targetTabID }) {
                 selectedTabIndex = index
             } else {
@@ -278,8 +306,8 @@ struct LinkFeedContentView: View {
 
     @ViewBuilder
     private func feedStack(statuses: [LinkStatus]) -> some View {
-        Group {
-            if statuses.isEmpty, !linkFilterService.isLoading {
+        let baseStack = Group {
+            if statuses.isEmpty, !FeedScopedLinkData.isLoading(in: linkFilterService, feedId: currentTab.id) {
                 emptyStateView
             } else {
                 linkList(statuses: statuses)
@@ -287,34 +315,40 @@ struct LinkFeedContentView: View {
         }
         .frame(minHeight: 0, maxHeight: .infinity)
         .id(currentTab.id)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: FeedSwipeGestureEvaluator.horizontalIntentDistance)
-                .onChanged { value in
-                    guard !isHorizontalSwipeIntentActive else { return }
-                    if FeedSwipeGestureEvaluator.isHorizontalIntent(translation: value.translation) {
-                        isHorizontalSwipeIntentActive = true
-                    }
-                }
-                .onEnded { value in
-                    defer { isHorizontalSwipeIntentActive = false }
-                    let direction = FeedSwipeGestureEvaluator.shouldCommit(
-                        translation: value.translation,
-                        predictedEndTranslation: value.predictedEndTranslation
-                    )
-                    switch direction {
-                    case .previous:
-                        selectTab(at: selectedTabIndex - 1)
-                    case .next:
-                        selectTab(at: selectedTabIndex + 1)
-                    case .none:
-                        break
-                    }
-                    if isHorizontalSwipeIntentActive || direction != .none || FeedSwipeGestureEvaluator.shouldSuppressTapAfterGesture(translation: value.translation) {
-                        suppressPostSwipeTaps()
-                    }
-                }
-        )
         .background(Color(.systemBackground))
+
+        if allowsSwipeNavigation {
+            baseStack
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: FeedSwipeGestureEvaluator.horizontalIntentDistance)
+                        .onChanged { value in
+                            guard !isHorizontalSwipeIntentActive else { return }
+                            if FeedSwipeGestureEvaluator.isHorizontalIntent(translation: value.translation) {
+                                isHorizontalSwipeIntentActive = true
+                            }
+                        }
+                        .onEnded { value in
+                            defer { isHorizontalSwipeIntentActive = false }
+                            let direction = FeedSwipeGestureEvaluator.shouldCommit(
+                                translation: value.translation,
+                                predictedEndTranslation: value.predictedEndTranslation
+                            )
+                            switch direction {
+                            case .previous:
+                                selectTab(at: selectedTabIndex - 1)
+                            case .next:
+                                selectTab(at: selectedTabIndex + 1)
+                            case .none:
+                                break
+                            }
+                            if isHorizontalSwipeIntentActive || direction != .none || FeedSwipeGestureEvaluator.shouldSuppressTapAfterGesture(translation: value.translation) {
+                                suppressPostSwipeTaps()
+                            }
+                        }
+                )
+        } else {
+            baseStack
+        }
     }
 
     private func linkList(statuses: [LinkStatus]) -> some View {
@@ -323,7 +357,7 @@ struct LinkFeedContentView: View {
             : (timelineService?.canLoadMoreListTimeline() ?? false)
         return LinkFeedPostList(
             statuses: statuses,
-            isLoading: linkFilterService.isLoading,
+            isLoading: FeedScopedLinkData.isLoading(in: linkFilterService, feedId: currentTab.id),
             shouldShowPaginationLoading: shouldShowPaginationLoadingRow(for: statuses),
             canLoadMore: canLoadMore,
             deferPostNavigation: { action in
@@ -531,10 +565,12 @@ struct LinkFeedContentView: View {
         await service.loadLists(forceRefresh: liveLists.isEmpty)
         syncRetainedLists(with: service.lists, allowEmpty: service.error == nil)
 
-        if let index = feedTabs.firstIndex(where: { $0.id == appState.selectedLinkFeedID }) {
+        if feedTabsOverride == nil,
+           let index = feedTabs.firstIndex(where: { $0.id == appState.selectedLinkFeedID }) {
             selectedTabIndex = index
         }
 
+        syncAppStateSelectionToCurrentTab()
         linkFilterService.switchToFeed(currentTab.id)
 
         if linkFilterService.hasCachedContent(for: currentTab.id) {
@@ -566,6 +602,13 @@ struct LinkFeedContentView: View {
     private func loadContentForTabIfNeeded(_ tab: FeedTabItem) async {
         guard !linkFilterService.hasCachedContent(for: tab.id) else { return }
         await loadContentForTab(tab)
+    }
+
+    private func syncAppStateSelectionToCurrentTab() {
+        let listId = currentTab.isHome ? nil : currentTab.id
+        if appState.selectedListId != listId {
+            appState.selectedListId = listId
+        }
     }
 
     private func refreshCurrentFeed() async {

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -82,7 +82,7 @@ struct LinkFeedThreeColumnView: View {
     }
 
     private var currentAccounts: [MastodonAccount] {
-        linkFilterService.uniqueAccounts()
+        FeedScopedLinkData.accounts(in: linkFilterService, feedId: currentTab.id)
     }
 
     private var currentUserFilter: String? {
@@ -90,9 +90,11 @@ struct LinkFeedThreeColumnView: View {
     }
 
     private var filteredStatuses: [LinkStatus] {
-        var statuses = linkFilterService.linkStatuses
-        statuses = linkFilterService.filter(linkStatuses: statuses, byAccountId: currentUserFilter)
-        return statuses
+        FeedScopedLinkData.filteredStatuses(
+            in: linkFilterService,
+            feedId: currentTab.id,
+            userFilterAccountId: currentUserFilter
+        )
     }
 
     private func shouldShowPaginationLoadingRow(for statuses: [LinkStatus]) -> Bool {
@@ -326,7 +328,7 @@ struct LinkFeedThreeColumnView: View {
 
     private func postsColumnContent(statuses: [LinkStatus]) -> some View {
         Group {
-            if statuses.isEmpty, !linkFilterService.isLoading {
+            if statuses.isEmpty, !FeedScopedLinkData.isLoading(in: linkFilterService, feedId: currentTab.id) {
                 emptyStateView
             } else {
                 let canLoadMore = currentTab.isHome
@@ -334,7 +336,7 @@ struct LinkFeedThreeColumnView: View {
                     : (timelineService?.canLoadMoreListTimeline() ?? false)
                 LinkFeedPostList(
                     statuses: statuses,
-                    isLoading: linkFilterService.isLoading,
+                    isLoading: FeedScopedLinkData.isLoading(in: linkFilterService, feedId: currentTab.id),
                     shouldShowPaginationLoading: shouldShowPaginationLoadingRow(for: statuses),
                     canLoadMore: canLoadMore,
                     deferPostNavigation: { action in action() },

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedTwoColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedTwoColumnView.swift
@@ -13,6 +13,12 @@ struct LinkFeedTwoColumnView: View {
     @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
 
+    let feedTabsOverride: [FeedTabItem]?
+    let showsFeedPicker: Bool
+    let allowsSwipeNavigation: Bool
+    let titleOverride: String?
+    let userFilterToolbarPlacement: UserFilterToolbarPlacement
+
     @State private var selectedArticle: (url: URL, status: Status)?
     @AppStorage("linkFeedTwoColumnPostsWidth") private var persistedPostsWidth: Double = 350
     @State private var postsWidth: Double = 350
@@ -20,6 +26,20 @@ struct LinkFeedTwoColumnView: View {
     private static let minPostsWidth: CGFloat = 280
     private static let minArticleWidth: CGFloat = 400
     private static let dividerWidth: CGFloat = 4
+
+    init(
+        feedTabsOverride: [FeedTabItem]? = nil,
+        showsFeedPicker: Bool = true,
+        allowsSwipeNavigation: Bool = true,
+        titleOverride: String? = nil,
+        userFilterToolbarPlacement: UserFilterToolbarPlacement = .leading
+    ) {
+        self.feedTabsOverride = feedTabsOverride
+        self.showsFeedPicker = showsFeedPicker
+        self.allowsSwipeNavigation = allowsSwipeNavigation
+        self.titleOverride = titleOverride
+        self.userFilterToolbarPlacement = userFilterToolbarPlacement
+    }
 
     private struct TwoColumnLayout {
         let postsWidth: CGFloat
@@ -75,7 +95,7 @@ struct LinkFeedTwoColumnView: View {
             HStack(spacing: 0) {
                 LinkFeedContentView(onArticleSelect: { url, status in
                     selectedArticle = (url, status)
-                })
+                }, feedTabsOverride: feedTabsOverride, showsFeedPicker: showsFeedPicker, allowsSwipeNavigation: allowsSwipeNavigation, titleOverride: titleOverride, userFilterToolbarPlacement: userFilterToolbarPlacement)
                 .frame(width: layout.postsWidth)
                 .background(Color(.systemBackground))
 

--- a/fedi-reader/Views/Feed/ListsTabRootView.swift
+++ b/fedi-reader/Views/Feed/ListsTabRootView.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+enum ListsTabEditingFeatures {
+    static func shouldShowEditor(editMode: EditMode) -> Bool {
+        editMode.isEditing
+    }
+
+    static func visibleListsSectionTitle(editMode: EditMode) -> String? {
+        shouldShowEditor(editMode: editMode) ? "Visible" : nil
+    }
+}
+
+struct ListsTabRootView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+
+    @State private var isLoading = false
+    @State private var editMode: EditMode = .inactive
+
+    private var timelineService: TimelineService? {
+        timelineWrapper.service
+    }
+
+    private var accountID: String? {
+        appState.currentAccount?.id
+    }
+
+    private var liveLists: [MastodonList] {
+        timelineService?.lists ?? []
+    }
+
+    private var cachedLists: [MastodonList] {
+        timelineWrapper.cachedLists(for: accountID)
+    }
+
+    private var rawLists: [MastodonList] {
+        if !liveLists.isEmpty {
+            return liveLists
+        }
+        return cachedLists
+    }
+
+    private var resolution: AccountListDisplayResolution {
+        appState.resolvedListDisplay(for: rawLists)
+    }
+
+    private var shouldShowEditor: Bool {
+        ListsTabEditingFeatures.shouldShowEditor(editMode: editMode)
+    }
+
+    private var visibleListsSectionTitle: String? {
+        ListsTabEditingFeatures.visibleListsSectionTitle(editMode: editMode)
+    }
+
+    var body: some View {
+        List {
+            if let visibleListsSectionTitle {
+                Section(visibleListsSectionTitle) {
+                    visibleListsContent(editable: true)
+                }
+            } else {
+                Section {
+                    visibleListsContent(editable: false)
+                }
+            }
+
+            if shouldShowEditor {
+                ListDisplayEditorSections(
+                    rawLists: rawLists,
+                    resolution: resolution,
+                    isLoading: isLoading,
+                    showHomeNote: false,
+                    showsVisibleSection: false
+                )
+            }
+        }
+        .navigationTitle("Lists")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                EditButton()
+            }
+        }
+        .environment(\.editMode, $editMode)
+        .task {
+            await loadLists()
+        }
+        .onAppear {
+            if !rawLists.isEmpty {
+                appState.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
+            }
+            navigateToPendingListIfNeeded()
+        }
+        .onChange(of: liveLists) { _, newLists in
+            appState.synchronizeCurrentAccountListDisplayPreferences(with: newLists)
+            navigateToPendingListIfNeeded()
+        }
+    }
+
+    private func loadLists() async {
+        guard let timelineService else { return }
+        isLoading = true
+        await timelineService.loadLists(forceRefresh: rawLists.isEmpty)
+        if !timelineService.lists.isEmpty {
+            timelineWrapper.updateCachedLists(timelineService.lists, for: accountID)
+        }
+        appState.synchronizeCurrentAccountListDisplayPreferences(
+            with: timelineService.lists,
+            allowEmptyListSet: true
+        )
+        isLoading = false
+        navigateToPendingListIfNeeded()
+    }
+
+    private func navigateToPendingListIfNeeded() {
+        guard appState.selectedTab == .lists else { return }
+        guard appState.listsNavigationPath.isEmpty else { return }
+        guard let pendingListID = appState.pendingListNavigationListID else { return }
+        guard let list = resolution.visibleLists.first(where: { $0.id == pendingListID }) else { return }
+
+        appState.listsNavigationPath = [.listFeed(list)]
+        appState.pendingListNavigationListID = nil
+    }
+
+    @ViewBuilder
+    private func visibleListsContent(editable: Bool) -> some View {
+        if isLoading && rawLists.isEmpty {
+            HStack {
+                Spacer()
+                ProgressView()
+                Spacer()
+            }
+        } else if resolution.visibleLists.isEmpty {
+            Text("No visible lists.")
+                .foregroundStyle(.secondary)
+        } else if editable {
+            if resolution.normalizedPreferences.sortOrder == .custom {
+                ForEach(resolution.visibleLists) { list in
+                    editableVisibleListRow(for: list)
+                }
+                .onMove(perform: moveVisibleLists)
+            } else {
+                ForEach(resolution.visibleLists) { list in
+                    editableVisibleListRow(for: list)
+                }
+            }
+        } else {
+            ForEach(resolution.visibleLists) { list in
+                NavigationLink(value: NavigationDestination.listFeed(list)) {
+                    Label(list.title, systemImage: "list.bullet")
+                }
+            }
+        }
+    }
+
+    private func editableVisibleListRow(for list: MastodonList) -> some View {
+        HStack(spacing: 12) {
+            Text(list.title)
+
+            Spacer(minLength: 0)
+
+            Button {
+                appState.setListVisibility(
+                    listID: list.id,
+                    isVisible: false,
+                    rawLists: rawLists
+                )
+            } label: {
+                Image(systemName: "minus.circle")
+                    .foregroundStyle(Color.red)
+                    .font(.title3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Hide \(list.title)")
+        }
+    }
+
+    private func moveVisibleLists(fromOffsets: IndexSet, toOffset: Int) {
+        appState.moveVisibleLists(
+            fromOffsets: fromOffsets,
+            toOffset: toOffset,
+            rawLists: rawLists
+        )
+    }
+}
+
+struct ListFeedDetailView: View {
+    @Environment(\.layoutMode) private var layoutMode
+
+    let list: MastodonList
+
+    private var listFeedTab: FeedTabItem {
+        FeedTabItem(id: list.id, title: list.title)
+    }
+
+    var body: some View {
+        Group {
+            switch layoutMode {
+            case .wide, .medium:
+                LinkFeedTwoColumnView(
+                    feedTabsOverride: [listFeedTab],
+                    showsFeedPicker: false,
+                    allowsSwipeNavigation: false,
+                    titleOverride: list.title,
+                    userFilterToolbarPlacement: .listsDetail
+                )
+            case .compact:
+                LinkFeedView(
+                    feedTabsOverride: [listFeedTab],
+                    showsFeedPicker: false,
+                    allowsSwipeNavigation: false,
+                    titleOverride: list.title,
+                    userFilterToolbarPlacement: .listsDetail
+                )
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ListsTabRootView()
+    }
+    .environment(AppState())
+    .environment(TimelineServiceWrapper())
+}

--- a/fedi-reader/Views/Profile/ListDisplayEditorSections.swift
+++ b/fedi-reader/Views/Profile/ListDisplayEditorSections.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+struct ListDisplayEditorSections: View {
+    @Environment(AppState.self) private var appState
+
+    let rawLists: [MastodonList]
+    let resolution: AccountListDisplayResolution
+    let isLoading: Bool
+    let showHomeNote: Bool
+    let showsVisibleSection: Bool
+
+    var body: some View {
+        Section("Order") {
+            Picker("Sort Order", selection: sortOrderBinding) {
+                ForEach(ListDisplaySortOrder.allCases) { sortOrder in
+                    Text(sortOrder.title).tag(sortOrder)
+                }
+            }
+            .pickerStyle(.menu)
+        }
+
+        if showHomeNote {
+            Section {
+                Label("Home always stays first and visible.", systemImage: "house.fill")
+                    .foregroundStyle(.secondary)
+            }
+        }
+
+        if showsVisibleSection {
+            Section("Visible") {
+                if isLoading && rawLists.isEmpty {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                        Spacer()
+                    }
+                } else if resolution.visibleLists.isEmpty {
+                    Text("No visible lists.")
+                        .foregroundStyle(.secondary)
+                } else if resolution.normalizedPreferences.sortOrder == .custom {
+                    ForEach(resolution.visibleLists) { list in
+                        listVisibilityRow(for: list, isVisible: true)
+                    }
+                    .onMove(perform: moveVisibleLists)
+                } else {
+                    ForEach(resolution.visibleLists) { list in
+                        listVisibilityRow(for: list, isVisible: true)
+                    }
+                }
+            }
+        }
+
+        Section("Hidden") {
+            if resolution.hiddenLists.isEmpty {
+                Text("No hidden lists.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(resolution.hiddenLists) { list in
+                    listVisibilityRow(for: list, isVisible: false)
+                }
+            }
+        }
+    }
+
+    private var sortOrderBinding: Binding<ListDisplaySortOrder> {
+        Binding(
+            get: { appState.currentAccountListDisplayPreferences.sortOrder },
+            set: { newSortOrder in
+                appState.updateListDisplaySortOrder(newSortOrder, rawLists: rawLists)
+            }
+        )
+    }
+
+    private func listVisibilityRow(for list: MastodonList, isVisible: Bool) -> some View {
+        HStack(spacing: 12) {
+            Text(list.title)
+
+            Spacer(minLength: 0)
+
+            Button {
+                setVisibility(for: list, isVisible: !isVisible)
+            } label: {
+                Image(systemName: isVisible ? "minus.circle" : "plus.circle")
+                    .foregroundStyle(isVisible ? Color.red : Color.accentColor)
+                    .font(.title3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isVisible ? "Hide \(list.title)" : "Show \(list.title)")
+        }
+    }
+
+    private func setVisibility(for list: MastodonList, isVisible: Bool) {
+        appState.setListVisibility(
+            listID: list.id,
+            isVisible: isVisible,
+            rawLists: rawLists
+        )
+    }
+
+    private func moveVisibleLists(fromOffsets: IndexSet, toOffset: Int) {
+        appState.moveVisibleLists(
+            fromOffsets: fromOffsets,
+            toOffset: toOffset,
+            rawLists: rawLists
+        )
+    }
+}

--- a/fedi-reader/Views/Profile/ListDisplaySettingsView.swift
+++ b/fedi-reader/Views/Profile/ListDisplaySettingsView.swift
@@ -39,52 +39,13 @@ struct ListDisplaySettingsView: View {
 
     var body: some View {
         List {
-            Section("Order") {
-                Picker("Sort Order", selection: sortOrderBinding) {
-                    ForEach(ListDisplaySortOrder.allCases) { sortOrder in
-                        Text(sortOrder.title).tag(sortOrder)
-                    }
-                }
-                .pickerStyle(.menu)
-            }
-
-            Section {
-                Label("Home always stays first and visible.", systemImage: "house.fill")
-                    .foregroundStyle(.secondary)
-            }
-
-            Section("Visible") {
-                if isLoading && rawLists.isEmpty {
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                        Spacer()
-                    }
-                } else if resolution.visibleLists.isEmpty {
-                    Text("No visible lists.")
-                        .foregroundStyle(.secondary)
-                } else if resolution.normalizedPreferences.sortOrder == .custom {
-                    ForEach(resolution.visibleLists) { list in
-                        listVisibilityRow(for: list, isVisible: true)
-                    }
-                    .onMove(perform: moveVisibleLists)
-                } else {
-                    ForEach(resolution.visibleLists) { list in
-                        listVisibilityRow(for: list, isVisible: true)
-                    }
-                }
-            }
-
-            Section("Hidden") {
-                if resolution.hiddenLists.isEmpty {
-                    Text("No hidden lists.")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(resolution.hiddenLists) { list in
-                        listVisibilityRow(for: list, isVisible: false)
-                    }
-                }
-            }
+            ListDisplayEditorSections(
+                rawLists: rawLists,
+                resolution: resolution,
+                isLoading: isLoading,
+                showHomeNote: true,
+                showsVisibleSection: true
+            )
         }
         .navigationTitle("List Display")
         .environment(\.editMode, .constant(isCustomSortOrder ? .active : .inactive))
@@ -99,49 +60,6 @@ struct ListDisplaySettingsView: View {
         .onChange(of: liveLists) { _, newLists in
             appState.synchronizeCurrentAccountListDisplayPreferences(with: newLists)
         }
-    }
-
-    private var sortOrderBinding: Binding<ListDisplaySortOrder> {
-        Binding(
-            get: { appState.currentAccountListDisplayPreferences.sortOrder },
-            set: { newSortOrder in
-                appState.updateListDisplaySortOrder(newSortOrder, rawLists: rawLists)
-            }
-        )
-    }
-
-    private func listVisibilityRow(for list: MastodonList, isVisible: Bool) -> some View {
-        HStack(spacing: 12) {
-            Text(list.title)
-
-            Spacer(minLength: 0)
-
-            Button {
-                setVisibility(for: list, isVisible: !isVisible)
-            } label: {
-                Image(systemName: isVisible ? "minus.circle" : "plus.circle")
-                    .foregroundStyle(isVisible ? Color.red : Color.accentColor)
-                    .font(.title3)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(isVisible ? "Hide \(list.title)" : "Show \(list.title)")
-        }
-    }
-
-    private func setVisibility(for list: MastodonList, isVisible: Bool) {
-        appState.setListVisibility(
-            listID: list.id,
-            isVisible: isVisible,
-            rawLists: rawLists
-        )
-    }
-
-    private func moveVisibleLists(fromOffsets: IndexSet, toOffset: Int) {
-        appState.moveVisibleLists(
-            fromOffsets: fromOffsets,
-            toOffset: toOffset,
-            rawLists: rawLists
-        )
     }
 
     private func loadLists() async {

--- a/fedi-reader/Views/Root/MainTabView.swift
+++ b/fedi-reader/Views/Root/MainTabView.swift
@@ -12,6 +12,7 @@ struct MainTabView: View {
     @State private var tabTracker = TabSelectionTracker()
     @AppStorage("hapticFeedback") private var hapticFeedback = true
     @AppStorage("hideTabBarLabels") private var hideTabBarLabels = false
+    @AppStorage(AppState.listsInSeparateTabStorageKey) private var listsInSeparateTab = false
     @AppStorage("themeColor") private var themeColorName = "blue"
 
     private var unreadMentionsCount: Int {
@@ -32,6 +33,9 @@ struct MainTabView: View {
             if oldValue == .profile {
                 state.profileNavigationPath.removeAll()
             }
+            if oldValue == .lists {
+                state.listsNavigationPath.removeAll()
+            }
             if oldValue == .mentions {
                 state.mentionsNavigationPath.removeAll()
             }
@@ -43,6 +47,11 @@ struct MainTabView: View {
                 tabTracker.reset()
             } else if newValue != .links {
                 tabTracker.reset()
+            }
+        }
+        .onChange(of: listsInSeparateTab) { _, isEnabled in
+            if !isEnabled, state.selectedTab == .lists {
+                state.selectedTab = .links
             }
         }
         .onChange(of: useSidebarLayout) { _, _ in
@@ -64,6 +73,17 @@ struct MainTabView: View {
         ) {
             Tab(useSidebarLayout ? "Home" : (hideTabBarLabels ? "" : "Home"), systemImage: "house", value: .links) {
                 linksTabContent()
+            }
+
+            if listsInSeparateTab {
+                Tab(useSidebarLayout ? "Lists" : (hideTabBarLabels ? "" : "Lists"), systemImage: "list.bullet", value: .lists) {
+                    NavigationStack(path: $state.listsNavigationPath) {
+                        ListsTabRootView()
+                        .navigationDestination(for: NavigationDestination.self) { destination in
+                            destinationView(for: destination)
+                        }
+                    }
+                }
             }
 
             Tab(useSidebarLayout ? "Explore" : (hideTabBarLabels ? "" : "Explore"), systemImage: "globe", value: .explore) {
@@ -122,21 +142,42 @@ struct MainTabView: View {
             switch layoutMode {
             case .wide:
                 NavigationStack(path: $state.linksNavigationPath) {
-                    LinkFeedThreeColumnView()
+                    Group {
+                        if listsInSeparateTab {
+                            LinkFeedTwoColumnView(
+                                feedTabsOverride: [.home],
+                                showsFeedPicker: false,
+                                allowsSwipeNavigation: false,
+                                titleOverride: "Home"
+                            )
+                        } else {
+                            LinkFeedThreeColumnView()
+                        }
+                    }
                         .navigationDestination(for: NavigationDestination.self) { destination in
                             splitLayoutDestinationView(for: destination)
                         }
                 }
             case .medium:
                 NavigationStack(path: $state.linksNavigationPath) {
-                    LinkFeedTwoColumnView()
+                    LinkFeedTwoColumnView(
+                        feedTabsOverride: listsInSeparateTab ? [.home] : nil,
+                        showsFeedPicker: !listsInSeparateTab,
+                        allowsSwipeNavigation: !listsInSeparateTab,
+                        titleOverride: listsInSeparateTab ? "Home" : nil
+                    )
                         .navigationDestination(for: NavigationDestination.self) { destination in
                             splitLayoutDestinationView(for: destination)
                         }
                 }
             case .compact:
                 NavigationStack(path: $state.linksNavigationPath) {
-                    LinkFeedView()
+                    LinkFeedView(
+                        feedTabsOverride: listsInSeparateTab ? [.home] : nil,
+                        showsFeedPicker: !listsInSeparateTab,
+                        allowsSwipeNavigation: !listsInSeparateTab,
+                        titleOverride: listsInSeparateTab ? "Home" : nil
+                    )
                         .navigationDestination(for: NavigationDestination.self) { destination in
                             destinationView(for: destination)
                         }
@@ -210,6 +251,8 @@ struct MainTabView: View {
             GroupedConversationDetailView(groupedConversation: groupedConversation)
         case .profile(let account):
             ProfileDetailView(account: account)
+        case .listFeed(let list):
+            ListFeedDetailView(list: list)
         case .article(let url, let status):
             ArticleWebView(url: url, status: status)
         case .thread(let statusId):

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @AppStorage("hideTabBarLabels") private var hideTabBarLabels = false
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("defaultListId") private var defaultListId = ""
+    @AppStorage(AppState.listsInSeparateTabStorageKey) private var listsInSeparateTab = false
     @AppStorage("showQuoteBoost") private var showQuoteBoost = true
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
 
@@ -58,6 +59,7 @@ struct SettingsView: View {
                     hideTabBarLabels: $hideTabBarLabels,
                     themeColorName: $themeColorName,
                     defaultListId: $defaultListId,
+                    listsInSeparateTab: $listsInSeparateTab,
                     showQuoteBoost: $showQuoteBoost,
                     showHandleInFeed: $showHandleInFeed,
                     lists: lists,
@@ -105,6 +107,8 @@ struct SettingsView: View {
             
             // Timeline
             Section("Timeline") {
+                Toggle("Show Lists in Separate Tab", isOn: $listsInSeparateTab)
+
                 Picker("Default Feed", selection: $defaultListId) {
                     Text("Home").tag("")
                     ForEach(lists) { list in
@@ -199,6 +203,7 @@ private struct SettingsTwoColumnView: View {
     @Binding var hideTabBarLabels: Bool
     @Binding var themeColorName: String
     @Binding var defaultListId: String
+    @Binding var listsInSeparateTab: Bool
     @Binding var showQuoteBoost: Bool
     @Binding var showHandleInFeed: Bool
     let lists: [MastodonList]
@@ -358,6 +363,8 @@ private struct SettingsTwoColumnView: View {
 
             case .timeline:
                 Section {
+                    settingsToggleRow("Show Lists in Separate Tab", isOn: $listsInSeparateTab)
+
                     Picker(selection: $defaultListId) {
                         Text("Home").tag("")
                         ForEach(lists) { list in

--- a/fedi-readerTests/AppStateTests.swift
+++ b/fedi-readerTests/AppStateTests.swift
@@ -256,4 +256,73 @@ struct AppStateTests {
 
         #expect(tabIDs == [AppState.homeFeedID, "list-2"])
     }
+
+    @Test("app tabs include lists when separate tab mode is enabled")
+    func appTabsIncludeListsWhenSeparateTabModeEnabled() async {
+        let state = AppState()
+
+        let tabs = state.appTabs(listsInSeparateTab: true)
+
+        #expect(tabs == [.links, .lists, .explore, .mentions, .profile])
+    }
+
+    @Test("home feed tabs exclude lists when separate tab mode is enabled")
+    func homeFeedTabsExcludeListsWhenSeparateTabModeEnabled() async {
+        let state = AppState()
+        let rawLists = [
+            makeList(id: "list-1", title: "Alpha"),
+            makeList(id: "list-2", title: "Beta")
+        ]
+
+        let tabs = state.homeFeedTabs(from: rawLists, listsInSeparateTab: true)
+
+        #expect(tabs.map(\.id) == [AppState.homeFeedID])
+    }
+
+    @Test("list feed tabs exclude home when separate tab mode is enabled")
+    func listFeedTabsExcludeHomeWhenSeparateTabModeEnabled() async {
+        let state = AppState()
+        let rawLists = [
+            makeList(id: "list-1", title: "Alpha"),
+            makeList(id: "list-2", title: "Beta")
+        ]
+
+        let tabs = state.listFeedTabs(from: rawLists)
+
+        #expect(tabs.map(\.id) == ["list-1", "list-2"])
+    }
+
+    @Test("apply default link feed selects lists tab when separate tab mode is enabled")
+    func applyDefaultLinkFeedSelectsListsTabWhenSeparateTabModeEnabled() async {
+        let state = AppState()
+
+        let feedID = state.applyDefaultLinkFeed(
+            defaultListId: "list-2",
+            availableListIDs: ["list-1", "list-2"],
+            listsInSeparateTab: true
+        )
+
+        #expect(feedID == "list-2")
+        #expect(state.selectedListId == "list-2")
+        #expect(state.selectedTab == .lists)
+        #expect(state.pendingListNavigationListID == "list-2")
+    }
+
+    @Test("apply default link feed keeps home tab when separate tab mode is enabled and list is unavailable")
+    func applyDefaultLinkFeedKeepsHomeTabWhenSeparateTabModeEnabledAndListUnavailable() async {
+        let state = AppState()
+        state.selectedTab = .lists
+        state.selectedListId = "old-list"
+
+        let feedID = state.applyDefaultLinkFeed(
+            defaultListId: "missing-list",
+            availableListIDs: ["list-1", "list-2"],
+            listsInSeparateTab: true
+        )
+
+        #expect(feedID == AppState.homeFeedID)
+        #expect(state.selectedListId == nil)
+        #expect(state.selectedTab == .links)
+        #expect(state.pendingListNavigationListID == nil)
+    }
 }

--- a/fedi-readerTests/LinkFilterServiceTests.swift
+++ b/fedi-readerTests/LinkFilterServiceTests.swift
@@ -464,6 +464,43 @@ struct LinkFilterServiceTests {
 
         #expect(accounts.map(\.id) == ["acct-alice", "acct-charlie"])
     }
+
+    @Test("Feed-scoped data reads from the requested feed even when another feed is active")
+    func feedScopedDataReadsRequestedFeedWhenAnotherFeedIsActive() async {
+        let homeAccount = MockStatusFactory.makeAccount(id: "acct-home", username: "home")
+        let listAccount = MockStatusFactory.makeAccount(id: "acct-list", username: "list")
+
+        let homeStatuses = [
+            MockStatusFactory.makeStatus(
+                id: "home-1",
+                hasCard: true,
+                cardURL: "https://example.com/home",
+                account: homeAccount
+            )
+        ]
+        let listStatuses = [
+            MockStatusFactory.makeStatus(
+                id: "list-1",
+                hasCard: true,
+                cardURL: "https://example.com/list",
+                account: listAccount
+            )
+        ]
+
+        _ = await service.processStatuses(homeStatuses, for: AppState.homeFeedID)
+        _ = await service.processStatuses(listStatuses, for: "list-1")
+        service.switchToFeed(AppState.homeFeedID)
+
+        let scopedStatuses = FeedScopedLinkData.filteredStatuses(
+            in: service,
+            feedId: "list-1",
+            userFilterAccountId: nil
+        )
+        let scopedAccounts = FeedScopedLinkData.accounts(in: service, feedId: "list-1")
+
+        #expect(scopedStatuses.map(\.id) == ["list-1"])
+        #expect(scopedAccounts.map(\.id) == ["acct-list"])
+    }
     
     // MARK: - Filter by Account
     

--- a/fedi-readerTests/ListsTabEditingFeaturesTests.swift
+++ b/fedi-readerTests/ListsTabEditingFeaturesTests.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import Testing
+@testable import fedi_reader
+
+@Suite("Lists Tab Editing Features Tests")
+struct ListsTabEditingFeaturesTests {
+    @Test("list section title is hidden when edit mode is inactive")
+    func listSectionTitleIsHiddenWhenEditModeIsInactive() {
+        #expect(ListsTabEditingFeatures.visibleListsSectionTitle(editMode: .inactive) == nil)
+    }
+
+    @Test("list section title becomes visible when edit mode is active")
+    func listSectionTitleBecomesVisibleWhenEditModeIsActive() {
+        #expect(ListsTabEditingFeatures.visibleListsSectionTitle(editMode: .active) == "Visible")
+    }
+
+    @Test("editing features are hidden when edit mode is inactive")
+    func editingFeaturesAreHiddenWhenEditModeIsInactive() {
+        #expect(!ListsTabEditingFeatures.shouldShowEditor(editMode: .inactive))
+    }
+
+    @Test("editing features are shown when edit mode is active")
+    func editingFeaturesAreShownWhenEditModeIsActive() {
+        #expect(ListsTabEditingFeatures.shouldShowEditor(editMode: .active))
+    }
+}

--- a/fedi-readerTests/UserFilterToolbarPlacementTests.swift
+++ b/fedi-readerTests/UserFilterToolbarPlacementTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import fedi_reader
+
+@Suite("User Filter Toolbar Placement Tests")
+struct UserFilterToolbarPlacementTests {
+    @Test("default placement stays on the leading side")
+    func defaultPlacementStaysOnTheLeadingSide() {
+        #expect(UserFilterToolbarPlacement.leading == .leading)
+    }
+
+    @Test("lists detail placement moves to the trailing side")
+    func listsDetailPlacementMovesToTheTrailingSide() {
+        #expect(UserFilterToolbarPlacement.listsDetail == .trailing)
+    }
+}


### PR DESCRIPTION
- Added functionality to display lists in a separate tab based on user preference.
- Updated AppState to manage navigation paths for lists and handle tab switching.
- Enhanced LinkFeed views to support swipe navigation and customizable feed tab behavior.
- Introduced new user filter toolbar placement options and improved data handling for feed-specific contexts.
- Updated settings to allow users to toggle the separate lists tab feature.

These changes aim to improve user experience by providing more flexible navigation options and better organization of content.