### PR TITLE
FEDI-36 Refactor navigation and settings for Read Later services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,5 +24,5 @@ Project context lives under [.agents/](.agents/):
 ## Configuration
 
 - **URL scheme**: `fedi-reader://` for OAuth callbacks
-- **Read-later**: Configure in-app (Profile → Read Later Services). Credentials in Keychain; no analytics; HTTPS-only.
+- **Read-later**: Configure in-app (Settings → Read Later Services). Credentials in Keychain; no analytics; HTTPS-only.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Each read-later service requires authentication:
 | Readwise | Access token |
 | Raindrop | OAuth or API token |
 
-Configure services in **Profile → Read Later Services**.
+Configure services in **Settings → Read Later Services**.
 
 ### URL Scheme
 

--- a/WARP.md
+++ b/WARP.md
@@ -102,5 +102,5 @@ Data flow (typical)
 ## Configuration & Behavior (from README)
 
 - URL scheme: The app registers the custom scheme `fedi-reader://` for OAuth callbacks.
-- Read-later services: Pocket, Instapaper, Omnivore, Readwise Reader, Raindrop are supported via in-app authentication (Profile → Read Later Services).
+- Read-later services: Pocket, Instapaper, Omnivore, Readwise Reader, Raindrop are supported via in-app authentication (Settings → Read Later Services).
 - Privacy: Credentials are stored in Keychain; no analytics or tracking; HTTPS-only API access.

--- a/fedi-reader/App/FediReaderApp.swift
+++ b/fedi-reader/App/FediReaderApp.swift
@@ -43,7 +43,6 @@ struct FediReaderApp: App {
     
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("defaultListId") private var defaultListId = ""
-    @AppStorage(AppState.listsInSeparateTabStorageKey) private var listsInSeparateTab = false
     @State private var appState = AppState()
     @State private var timelineWrapper = TimelineServiceWrapper()
     @State private var linkFilterService = LinkFilterService()
@@ -219,8 +218,7 @@ struct FediReaderApp: App {
             UserDefaults.standard.string(forKey: AppState.defaultListIdStorageKey) ?? defaultListId
         return appState.applyDefaultLinkFeed(
             defaultListId: persistedDefaultListID,
-            availableListIDs: resolution.visibleListIDs,
-            listsInSeparateTab: listsInSeparateTab
+            availableListIDs: resolution.visibleListIDs
         )
     }
 

--- a/fedi-reader/Models/MastodonTypes/Tag.swift
+++ b/fedi-reader/Models/MastodonTypes/Tag.swift
@@ -1,9 +1,32 @@
 import Foundation
 
 struct Tag: Codable, Hashable, Sendable {
+    let id: String?
     let name: String
     let url: String
     let history: [TagHistory]?
+    let following: Bool?
+
+    init(id: String? = nil, name: String, url: String, history: [TagHistory]? = nil, following: Bool? = nil) {
+        self.id = id
+        self.name = name
+        self.url = url
+        self.history = history
+        self.following = following
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        url = try c.decode(String.self, forKey: .url)
+        history = try c.decodeIfPresent([TagHistory].self, forKey: .history)
+        following = try c.decodeIfPresent(Bool.self, forKey: .following)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, url, history, following
+    }
 }
 
 

--- a/fedi-reader/Models/TabConfiguration.swift
+++ b/fedi-reader/Models/TabConfiguration.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+struct TabConfiguration: Codable, Equatable, Sendable {
+    var visibleTabs: [AppTab]
+    var hiddenTabs: [AppTab]
+
+    private static let permanentlyVisibleTabs: [AppTab] = [.links, .profile]
+    private static let compactTabsBeforeMore = 4
+    private static let compactVisibleTabLimitBeforeMore = 5
+
+    static let defaultConfiguration = TabConfiguration(
+        visibleTabs: [.links, .explore, .mentions, .profile],
+        hiddenTabs: [.lists, .hashtags, .bookmarks]
+    )
+
+    func normalized(allTabs: [AppTab] = AppTab.allCases) -> TabConfiguration {
+        let availableTabs = Set(allTabs)
+
+        var normalizedVisibleTabs = Self.orderedUniqueTabs(
+            visibleTabs.filter { availableTabs.contains($0) }
+        )
+        var normalizedHiddenTabs = Self.orderedUniqueTabs(
+            hiddenTabs.filter { availableTabs.contains($0) }
+        )
+
+        for protectedTab in Self.permanentlyVisibleTabs {
+            normalizedHiddenTabs.removeAll { $0 == protectedTab }
+            if !normalizedVisibleTabs.contains(protectedTab) {
+                normalizedVisibleTabs.append(protectedTab)
+            }
+        }
+
+        let usedTabs = Set(normalizedVisibleTabs).union(normalizedHiddenTabs)
+        let missingTabs = allTabs.filter { !usedTabs.contains($0) }
+        normalizedHiddenTabs.append(contentsOf: missingTabs)
+
+        normalizedVisibleTabs = Self.ensureProtectedTabsNotBehindMore(normalizedVisibleTabs)
+
+        return TabConfiguration(
+            visibleTabs: normalizedVisibleTabs,
+            hiddenTabs: normalizedHiddenTabs
+        )
+    }
+
+    private static func orderedUniqueTabs(_ tabs: [AppTab]) -> [AppTab] {
+        var seenTabs = Set<AppTab>()
+        return tabs.filter { seenTabs.insert($0).inserted }
+    }
+
+    /// Ensures Home and Profile are in the first 4 tabs (not behind More). Preserves user order otherwise.
+    private static func ensureProtectedTabsNotBehindMore(_ tabs: [AppTab]) -> [AppTab] {
+        guard tabs.count > compactVisibleTabLimitBeforeMore else { return tabs }
+
+        let protectedTabs = Set(permanentlyVisibleTabs)
+        let primaryIndices = Array(0..<compactTabsBeforeMore)
+        let overflowIndices = Array(compactTabsBeforeMore..<tabs.count)
+
+        let protectedInOverflow = overflowIndices.filter { protectedTabs.contains(tabs[$0]) }
+        let unprotectedInPrimary = primaryIndices.filter { !protectedTabs.contains(tabs[$0]) }
+        let primaryToSwap = Array(unprotectedInPrimary.suffix(protectedInOverflow.count).reversed())
+
+        guard !protectedInOverflow.isEmpty, protectedInOverflow.count <= primaryToSwap.count else { return tabs }
+
+        var result = tabs
+        let pairs = zip(protectedInOverflow, primaryToSwap).sorted { $0.0 > $1.0 }
+        for (overflowIdx, primaryIdx) in pairs {
+            result.swapAt(overflowIdx, primaryIdx)
+        }
+        return result
+    }
+}

--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -14,11 +14,16 @@ import os
 final class AppState {
     private static let logger = Logger(subsystem: "app.fedi-reader", category: "AppState")
     static let homeFeedID = "home"
+    static let bookmarksFeedID = "bookmarks"
+    static func hashtagFeedID(_ tagName: String) -> String { "hashtag:\(tagName)" }
     static let defaultListIdStorageKey = "defaultListId"
     static let listsInSeparateTabStorageKey = "listsInSeparateTab"
+    private static let tabConfigurationStorageKey = "tabConfiguration"
     private static let listDisplayPreferencesStorageKeyPrefix = "listDisplayPreferences."
     private static let listDisplayPreferencesEncoder = JSONEncoder()
     private static let listDisplayPreferencesDecoder = JSONDecoder()
+    private static let tabConfigurationEncoder = JSONEncoder()
+    private static let tabConfigurationDecoder = JSONDecoder()
     
     // Services
     let client: MastodonClient
@@ -29,6 +34,7 @@ final class AppState {
     var isLoading = false
     var error: Error?
     var selectedTab: AppTab = .links
+    private(set) var tabConfiguration: TabConfiguration
     var linksScrollToTopRequestID: UInt = 0
     
     // List and filter state
@@ -42,9 +48,12 @@ final class AppState {
     // Navigation state (per-tab so switching tabs shows correct root)
     var linksNavigationPath: [NavigationDestination] = []
     var listsNavigationPath: [NavigationDestination] = []
+    var hashtagsNavigationPath: [NavigationDestination] = []
+    var bookmarksNavigationPath: [NavigationDestination] = []
     var exploreNavigationPath: [NavigationDestination] = []
     var profileNavigationPath: [NavigationDestination] = []
     var mentionsNavigationPath: [NavigationDestination] = []
+    var moreTabPath: [NavigationDestination] = []
     var presentedSheet: SheetDestination?
     var presentedAlert: AlertItem?
     
@@ -53,6 +62,7 @@ final class AppState {
         self.client = MastodonClient()
         self.authService = AuthService(client: client)
         self.emojiService = EmojiService(client: client)
+        self.tabConfiguration = Self.loadTabConfiguration()
     }
     
     // MARK: - Account Helpers
@@ -186,6 +196,64 @@ final class AppState {
         return tabs
     }
 
+    func resolvedVisibleTabs() -> [AppTab] {
+        tabConfiguration.normalized().visibleTabs
+    }
+
+    func resolvedHiddenTabs() -> [AppTab] {
+        tabConfiguration.normalized().hiddenTabs
+    }
+
+    var listsInSeparateTab: Bool {
+        resolvedVisibleTabs().contains(.lists)
+    }
+
+    func setTabVisibility(
+        _ tab: AppTab,
+        isVisible: Bool,
+        defaults: UserDefaults = .standard
+    ) {
+        var normalizedConfiguration = tabConfiguration.normalized()
+
+        if isVisible {
+            normalizedConfiguration.hiddenTabs.removeAll { $0 == tab }
+            if !normalizedConfiguration.visibleTabs.contains(tab) {
+                normalizedConfiguration.visibleTabs.append(tab)
+            }
+        } else {
+            guard tab != .links, tab != .profile else {
+                persistTabConfiguration(normalizedConfiguration, defaults: defaults)
+                return
+            }
+
+            normalizedConfiguration.visibleTabs.removeAll { $0 == tab }
+            if !normalizedConfiguration.hiddenTabs.contains(tab) {
+                normalizedConfiguration.hiddenTabs.append(tab)
+            }
+
+            if selectedTab == tab {
+                selectedTab = .links
+            }
+        }
+
+        persistTabConfiguration(normalizedConfiguration, defaults: defaults)
+    }
+
+    func moveTabs(
+        fromOffsets: IndexSet,
+        toOffset: Int,
+        defaults: UserDefaults = .standard
+    ) {
+        var reorderedVisibleTabs = resolvedVisibleTabs()
+        moveAppTabs(&reorderedVisibleTabs, fromOffsets: fromOffsets, toOffset: toOffset)
+
+        let updatedConfiguration = TabConfiguration(
+            visibleTabs: reorderedVisibleTabs,
+            hiddenTabs: resolvedHiddenTabs()
+        )
+        persistTabConfiguration(updatedConfiguration, defaults: defaults)
+    }
+
     func updateListDisplaySortOrder(
         _ sortOrder: ListDisplaySortOrder,
         rawLists: [MastodonList],
@@ -257,6 +325,51 @@ final class AppState {
         let adjustedOffset = max(0, min(ids.count, toOffset - removedBeforeDestination))
         ids.insert(contentsOf: movingItems, at: adjustedOffset)
     }
+
+    private func moveAppTabs(
+        _ tabs: inout [AppTab],
+        fromOffsets: IndexSet,
+        toOffset: Int
+    ) {
+        let movingItems = fromOffsets.map { tabs[$0] }
+        let removedBeforeDestination = fromOffsets.filter { $0 < toOffset }.count
+        for offset in fromOffsets.sorted(by: >) {
+            tabs.remove(at: offset)
+        }
+        let adjustedOffset = max(0, min(tabs.count, toOffset - removedBeforeDestination))
+        tabs.insert(contentsOf: movingItems, at: adjustedOffset)
+    }
+
+    private func persistTabConfiguration(
+        _ configuration: TabConfiguration,
+        defaults: UserDefaults = .standard
+    ) {
+        let normalizedConfiguration = configuration.normalized()
+        tabConfiguration = normalizedConfiguration
+
+        guard let data = try? Self.tabConfigurationEncoder.encode(normalizedConfiguration) else {
+            Self.logger.error("Failed to encode tab configuration")
+            return
+        }
+
+        defaults.set(data, forKey: Self.tabConfigurationStorageKey)
+    }
+
+    private static func loadTabConfiguration(defaults: UserDefaults = .standard) -> TabConfiguration {
+        if let data = defaults.data(forKey: tabConfigurationStorageKey),
+           let configuration = try? tabConfigurationDecoder.decode(TabConfiguration.self, from: data) {
+            return configuration.normalized()
+        }
+
+        var migratedConfiguration = TabConfiguration.defaultConfiguration
+        if defaults.bool(forKey: listsInSeparateTabStorageKey) {
+            migratedConfiguration.hiddenTabs.removeAll { $0 == .lists }
+            if !migratedConfiguration.visibleTabs.contains(.lists) {
+                migratedConfiguration.visibleTabs.insert(.lists, at: 1)
+            }
+        }
+        return migratedConfiguration.normalized()
+    }
     
     // MARK: - Error Handling
     
@@ -322,6 +435,18 @@ final class AppState {
             } else {
                 listsNavigationPath.append(destination)
             }
+        case .hashtags:
+            if shouldReplaceArticle(path: hashtagsNavigationPath) {
+                hashtagsNavigationPath[hashtagsNavigationPath.count - 1] = destination
+            } else {
+                hashtagsNavigationPath.append(destination)
+            }
+        case .bookmarks:
+            if shouldReplaceArticle(path: bookmarksNavigationPath) {
+                bookmarksNavigationPath[bookmarksNavigationPath.count - 1] = destination
+            } else {
+                bookmarksNavigationPath.append(destination)
+            }
         case .explore:
             if shouldReplaceArticle(path: exploreNavigationPath) {
                 exploreNavigationPath[exploreNavigationPath.count - 1] = destination
@@ -361,6 +486,22 @@ final class AppState {
             } else {
                 Self.logger.debug("Navigate back called but lists navigation path is empty")
             }
+        case .bookmarks:
+            if !bookmarksNavigationPath.isEmpty {
+                let previous = bookmarksNavigationPath.last
+                bookmarksNavigationPath.removeLast()
+                Self.logger.info("Navigating back from: \(String(describing: previous), privacy: .public)")
+            } else {
+                Self.logger.debug("Navigate back called but bookmarks navigation path is empty")
+            }
+        case .hashtags:
+            if !hashtagsNavigationPath.isEmpty {
+                let previous = hashtagsNavigationPath.last
+                hashtagsNavigationPath.removeLast()
+                Self.logger.info("Navigating back from: \(String(describing: previous), privacy: .public)")
+            } else {
+                Self.logger.debug("Navigate back called but hashtags navigation path is empty")
+            }
         case .explore:
             if !exploreNavigationPath.isEmpty {
                 let previous = exploreNavigationPath.last
@@ -398,6 +539,14 @@ final class AppState {
             let count = listsNavigationPath.count
             listsNavigationPath.removeAll()
             Self.logger.info("Navigating to root, cleared \(count) list destinations")
+        case .bookmarks:
+            let count = bookmarksNavigationPath.count
+            bookmarksNavigationPath.removeAll()
+            Self.logger.info("Navigating to root, cleared \(count) bookmark destinations")
+        case .hashtags:
+            let count = hashtagsNavigationPath.count
+            hashtagsNavigationPath.removeAll()
+            Self.logger.info("Navigating to root, cleared \(count) hashtag destinations")
         case .explore:
             let count = exploreNavigationPath.count
             exploreNavigationPath.removeAll()
@@ -440,6 +589,18 @@ final class AppState {
     @discardableResult
     func applyDefaultLinkFeed(
         defaultListId: String,
+        availableListIDs: [String]
+    ) -> String {
+        applyDefaultLinkFeed(
+            defaultListId: defaultListId,
+            availableListIDs: availableListIDs,
+            listsInSeparateTab: listsInSeparateTab
+        )
+    }
+
+    @discardableResult
+    func applyDefaultLinkFeed(
+        defaultListId: String,
         availableListIDs: [String],
         listsInSeparateTab: Bool = false
     ) -> String {
@@ -459,12 +620,14 @@ final class AppState {
 
 // MARK: - App Tabs
 
-enum AppTab: String, CaseIterable, Identifiable {
+enum AppTab: String, CaseIterable, Codable, Identifiable, Sendable {
     case links
     case lists
+    case hashtags
     case explore
     case mentions
     case profile
+    case bookmarks
     
     var id: String { rawValue }
     
@@ -472,6 +635,8 @@ enum AppTab: String, CaseIterable, Identifiable {
         switch self {
         case .links: return "Home"
         case .lists: return "Lists"
+        case .hashtags: return "Hashtags"
+        case .bookmarks: return "Bookmarks"
         case .explore: return "Explore"
         case .mentions: return "Messages"
         case .profile: return "Profile"
@@ -482,6 +647,8 @@ enum AppTab: String, CaseIterable, Identifiable {
         switch self {
         case .links: return "house"
         case .lists: return "list.bullet"
+        case .hashtags: return "number"
+        case .bookmarks: return "bookmark.fill"
         case .explore: return "globe"
         case .mentions: return "at"
         case .profile: return "person"
@@ -492,14 +659,17 @@ enum AppTab: String, CaseIterable, Identifiable {
 // MARK: - Navigation Destinations
 
 enum NavigationDestination: Hashable {
+    case moreTab(AppTab)
     case status(Status)
     case conversation(GroupedConversation)
     case profile(MastodonAccount)
     case listFeed(MastodonList)
+    case hashtagFeed(Tag)
     case article(url: URL, status: Status?)
     case thread(statusId: String)
     case hashtag(String)
     case settings
+    case tabOrder
     case listDisplay
     case accountSettings
     case readLaterSettings

--- a/fedi-reader/Services/MastodonClient.swift
+++ b/fedi-reader/Services/MastodonClient.swift
@@ -641,6 +641,23 @@ final class MastodonClient {
         let request = buildRequest(url: url, accessToken: accessToken)
         return try await execute(request)
     }
+
+    func getBookmarks(
+        instance: String,
+        accessToken: String,
+        maxId: String? = nil,
+        limit: Int = Constants.Pagination.defaultLimit
+    ) async throws -> [Status] {
+        Self.logger.info("Fetching bookmarks, limit: \(limit), maxId: \(maxId?.prefix(8) ?? "nil", privacy: .public)")
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let maxId { queryItems.append(URLQueryItem(name: "max_id", value: maxId)) }
+
+        let url = try buildURL(instance: instance, path: Constants.API.bookmarks, queryItems: queryItems)
+        let request = buildRequest(url: url, accessToken: accessToken)
+        let statuses: [Status] = try await execute(request)
+        Self.logger.info("Fetched \(statuses.count) bookmarks")
+        return statuses
+    }
     
     // MARK: - Trending
     
@@ -1007,11 +1024,18 @@ final class MastodonClient {
         return try await getStatus(instance: instance, accessToken: token, id: id)
     }
     
-    func getHashtagTimeline(tag: String, limit: Int = Constants.Pagination.defaultLimit) async throws -> [Status] {
+    func getHashtagTimeline(tag: String, limit: Int = Constants.Pagination.defaultLimit, maxId: String? = nil) async throws -> [Status] {
         guard let instance = currentInstance, let token = currentAccessToken else {
             throw FediReaderError.noActiveAccount
         }
-        return try await getHashtagTimeline(instance: instance, accessToken: token, tag: tag, limit: limit)
+        return try await getHashtagTimeline(instance: instance, accessToken: token, tag: tag, limit: limit, maxId: maxId)
+    }
+
+    func getFollowedTags(limit: Int = Constants.Pagination.defaultLimit, maxId: String? = nil) async throws -> [Tag] {
+        guard let instance = currentInstance, let token = currentAccessToken else {
+            throw FediReaderError.noActiveAccount
+        }
+        return try await getFollowedTags(instance: instance, accessToken: token, limit: limit, maxId: maxId)
     }
     
     nonisolated func searchAccounts(query: String, limit: Int = 10) async throws -> [MastodonAccount] {
@@ -1066,11 +1090,33 @@ final class MastodonClient {
         }
     }
     
-    func getHashtagTimeline(instance: String, accessToken: String, tag: String, limit: Int = Constants.Pagination.defaultLimit) async throws -> [Status] {
+    func getFollowedTags(
+        instance: String,
+        accessToken: String,
+        limit: Int = Constants.Pagination.defaultLimit,
+        maxId: String? = nil
+    ) async throws -> [Tag] {
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let maxId { queryItems.append(URLQueryItem(name: "max_id", value: maxId)) }
+        let url = try buildURL(instance: instance, path: Constants.API.followedTags, queryItems: queryItems)
+        let request = buildRequest(url: url, accessToken: accessToken)
+        return try await execute(request)
+    }
+
+    func getHashtagTimeline(
+        instance: String,
+        accessToken: String,
+        tag: String,
+        limit: Int = Constants.Pagination.defaultLimit,
+        maxId: String? = nil
+    ) async throws -> [Status] {
+        let encodedTag = tag.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? tag
+        var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
+        if let maxId { queryItems.append(URLQueryItem(name: "max_id", value: maxId)) }
         let url = try buildURL(
             instance: instance,
-            path: "/api/v1/timelines/tag/\(tag)",
-            queryItems: [URLQueryItem(name: "limit", value: String(limit))]
+            path: "/api/v1/timelines/tag/\(encodedTag)",
+            queryItems: queryItems
         )
         let request = buildRequest(url: url, accessToken: accessToken)
         return try await execute(request)

--- a/fedi-reader/Services/TimelineService.swift
+++ b/fedi-reader/Services/TimelineService.swift
@@ -20,6 +20,7 @@ final class TimelineService {
     
     // Timeline state
     var homeTimeline: [Status] = []
+    var bookmarks: [Status] = []
     var exploreStatuses: [Status] = []
     var trendingLinks: [TrendingLink] = []
     var mentions: [MastodonNotification] = []
@@ -30,8 +31,15 @@ final class TimelineService {
     var listTimeline: [Status] = []
     var listAccounts: [MastodonAccount] = []
     
+    // Followed tags state
+    var followedTags: [Tag] = []
+    var hashtagTimeline: [Status] = []
+    private var hashtagTimelineMaxId: String?
+    private var hashtagTimelineTag: String?
+    
     // Loading state
     var isLoadingHome = false
+    var isLoadingBookmarks = false
     var isLoadingExplore = false
     var isLoadingMentions = false
     var isLoadingConversations = false
@@ -39,14 +47,18 @@ final class TimelineService {
     var isLoadingLists = false
     var isLoadingListTimeline = false
     var isLoadingListAccounts = false
+    var isLoadingFollowedTags = false
+    var isLoadingHashtagTimeline = false
     
     // Pagination cursors
     private var homeMaxId: String?
     private var homeMinId: String?
+    private var bookmarksMaxId: String?
     private var exploreMaxId: String?
     private var mentionsMaxId: String?
     private var conversationsMaxId: String?
     private var listTimelineMaxId: String?
+    private var followedTagsMaxId: String?
     private var listAccountsMaxId: String?
     private var listsLastRefreshedAt: Date?
     private var listsLastRefreshedForAccountId: String?
@@ -174,12 +186,103 @@ final class TimelineService {
         await loadHomeTimeline(refresh: true)
     }
 
+    // MARK: - Bookmarks
+
+    func loadBookmarks(refresh: Bool = false) async {
+        guard !isLoadingBookmarks else {
+            Self.logger.debug("Bookmarks load already in progress, skipping")
+            return
+        }
+
+        guard let account = authService.currentAccount,
+              let token = await authService.getAccessToken(for: account) else {
+            Self.logger.error("No active account for bookmarks load")
+            error = FediReaderError.noActiveAccount
+            return
+        }
+
+        Self.logger.info("Loading bookmarks, refresh: \(refresh), current count: \(self.bookmarks.count), maxId: \(self.bookmarksMaxId?.prefix(8) ?? "nil", privacy: .public)")
+        isLoadingBookmarks = true
+        error = nil
+
+        do {
+            let statuses = try await client.getBookmarks(
+                instance: account.instance,
+                accessToken: token,
+                maxId: refresh ? nil : bookmarksMaxId,
+                limit: Constants.Pagination.defaultLimit
+            )
+
+            if refresh {
+                bookmarks = statuses
+                Self.logger.info("Bookmarks refreshed: \(statuses.count) statuses")
+            } else {
+                bookmarks.append(contentsOf: statuses)
+                Self.logger.info("Bookmarks loaded more: \(statuses.count) new statuses, total: \(self.bookmarks.count)")
+            }
+
+            if statuses.isEmpty {
+                bookmarksMaxId = nil
+                Self.logger.debug("Bookmarks returned no statuses; reached pagination end")
+            } else if let lastStatus = statuses.last {
+                bookmarksMaxId = lastStatus.id
+                Self.logger.debug("Updated bookmarks maxId: \(lastStatus.id.prefix(8), privacy: .public)")
+            }
+
+            Task {
+                await prefetchFediverseCreators(for: statuses)
+            }
+        } catch let err as FediReaderError where err == .unauthorized {
+            Self.logger.error("Unauthorized error loading bookmarks")
+            self.error = err
+            NotificationCenter.default.post(name: .accountDidChange, object: nil)
+        } catch {
+            Self.logger.error("Error loading bookmarks: \(error.localizedDescription)")
+            self.error = error
+        }
+
+        isLoadingBookmarks = false
+    }
+
+    @discardableResult
+    func loadMoreBookmarks() async -> [Status] {
+        guard !isLoadingMore, bookmarksMaxId != nil else { return [] }
+        let previousCount = bookmarks.count
+
+        isLoadingMore = true
+        await loadBookmarks(refresh: false)
+        isLoadingMore = false
+
+        guard bookmarks.count > previousCount else { return [] }
+        return Array(bookmarks.dropFirst(previousCount))
+    }
+
+    func refreshBookmarks() async {
+        bookmarksMaxId = nil
+        await loadBookmarks(refresh: true)
+    }
+
+    func canLoadMoreBookmarks() -> Bool {
+        bookmarksMaxId != nil
+    }
+
     func loadLinkFeedStatuses(feedId: String, forceRefreshHome: Bool = false) async -> [Status] {
         if feedId == AppState.homeFeedID {
             if forceRefreshHome || homeTimeline.isEmpty {
                 await refreshHomeTimeline()
             }
             return homeTimeline
+        }
+        if feedId == AppState.bookmarksFeedID {
+            if forceRefreshHome || bookmarks.isEmpty {
+                await refreshBookmarks()
+            }
+            return bookmarks
+        }
+        if feedId.hasPrefix("hashtag:") {
+            let tagName = String(feedId.dropFirst("hashtag:".count))
+            await loadHashtagTimeline(tag: tagName, refresh: forceRefreshHome || hashtagTimelineTag != tagName)
+            return hashtagTimelineTag == tagName ? hashtagTimeline : []
         }
 
         await refreshListTimeline(listId: feedId)
@@ -192,6 +295,19 @@ final class TimelineService {
                 await refreshHomeTimeline()
             }
             return homeTimeline
+        }
+        if feedId == AppState.bookmarksFeedID {
+            if bookmarks.isEmpty {
+                await refreshBookmarks()
+            }
+            return bookmarks
+        }
+        if feedId.hasPrefix("hashtag:") {
+            let tagName = String(feedId.dropFirst("hashtag:".count))
+            if hashtagTimelineTag != tagName || hashtagTimeline.isEmpty {
+                await loadHashtagTimeline(tag: tagName, refresh: true)
+            }
+            return hashtagTimelineTag == tagName ? hashtagTimeline : []
         }
 
         return await fetchListTimelineStatuses(listId: feedId)
@@ -908,6 +1024,19 @@ final class TimelineService {
                 exploreStatuses[index] = resolvedStatus
             }
         }
+
+        // Update in bookmarks
+        if let index = bookmarks.firstIndex(where: { $0.displayStatus.id == resolvedStatus.id }) {
+            if resolvedStatus.bookmarked == false {
+                bookmarks.remove(at: index)
+            } else if bookmarks[index].reblog != nil {
+                bookmarks[index] = updatedReblogWrapper(from: bookmarks[index], with: resolvedStatus)
+            } else {
+                bookmarks[index] = resolvedStatus
+            }
+        } else if resolvedStatus.bookmarked == true {
+            bookmarks.insert(resolvedStatus, at: 0)
+        }
         
         // Update in mentions
         if mentions.contains(where: { $0.status?.id == status.id }) {
@@ -968,20 +1097,27 @@ final class TimelineService {
         stopInboxAutoRefresh()
 
         homeTimeline = []
+        bookmarks = []
         exploreStatuses = []
         trendingLinks = []
         mentions = []
         conversations = []
         listTimeline = []
+        followedTags = []
+        hashtagTimeline = []
         listAccounts = []
         
         homeMaxId = nil
         homeMinId = nil
+        bookmarksMaxId = nil
         exploreMaxId = nil
         mentionsMaxId = nil
         conversationsMaxId = nil
         listTimelineMaxId = nil
         listAccountsMaxId = nil
+        hashtagTimelineMaxId = nil
+        hashtagTimelineTag = nil
+        followedTagsMaxId = nil
     }
     
     // MARK: - Lists
@@ -1251,6 +1387,95 @@ final class TimelineService {
     func refreshListTimeline(listId: String) async {
         listTimelineMaxId = nil
         await loadListTimeline(listId: listId, refresh: true)
+    }
+
+    // MARK: - Followed Tags
+
+    func loadFollowedTags(refresh: Bool = false) async {
+        guard !isLoadingFollowedTags else { return }
+        guard let account = authService.currentAccount,
+              let token = await authService.getAccessToken(for: account) else {
+            error = FediReaderError.noActiveAccount
+            return
+        }
+        isLoadingFollowedTags = true
+        error = nil
+        defer { isLoadingFollowedTags = false }
+        do {
+            let tags = try await client.getFollowedTags(
+                instance: account.instance,
+                accessToken: token,
+                limit: 80,
+                maxId: refresh ? nil : followedTagsMaxId
+            )
+            if refresh || followedTagsMaxId == nil {
+                followedTags = tags
+            } else {
+                followedTags.append(contentsOf: tags)
+            }
+            followedTagsMaxId = tags.last?.id ?? tags.last?.name
+            if tags.isEmpty { followedTagsMaxId = nil }
+        } catch {
+            Self.logger.error("Error loading followed tags: \(error.localizedDescription)")
+            self.error = error
+        }
+    }
+
+    func loadHashtagTimeline(tag: String, refresh: Bool = false) async {
+        guard !isLoadingHashtagTimeline else { return }
+        let effectiveRefresh = refresh || hashtagTimelineTag != tag
+        guard let account = authService.currentAccount,
+              let token = await authService.getAccessToken(for: account) else {
+            error = FediReaderError.noActiveAccount
+            return
+        }
+        isLoadingHashtagTimeline = true
+        error = nil
+        if effectiveRefresh {
+            hashtagTimelineMaxId = nil
+            hashtagTimelineTag = tag
+        }
+        defer { isLoadingHashtagTimeline = false }
+        do {
+            let statuses = try await client.getHashtagTimeline(
+                instance: account.instance,
+                accessToken: token,
+                tag: tag,
+                limit: Constants.Pagination.defaultLimit,
+                maxId: effectiveRefresh ? nil : hashtagTimelineMaxId
+            )
+            if effectiveRefresh {
+                hashtagTimeline = statuses
+                hashtagTimelineTag = tag
+            } else {
+                hashtagTimeline.append(contentsOf: statuses)
+            }
+            hashtagTimelineMaxId = statuses.isEmpty ? nil : statuses.last?.id
+            Task { await prefetchFediverseCreators(for: statuses) }
+        } catch {
+            Self.logger.error("Error loading hashtag timeline: \(error.localizedDescription)")
+            self.error = error
+        }
+    }
+
+    func canLoadMoreHashtagTimeline(tag: String) -> Bool {
+        hashtagTimelineTag == tag && hashtagTimelineMaxId != nil
+    }
+
+    @discardableResult
+    func loadMoreHashtagTimeline(tag: String) async -> [Status] {
+        guard !isLoadingMore, canLoadMoreHashtagTimeline(tag: tag) else { return [] }
+        let previousCount = hashtagTimeline.count
+        isLoadingMore = true
+        await loadHashtagTimeline(tag: tag, refresh: false)
+        isLoadingMore = false
+        guard hashtagTimeline.count > previousCount else { return [] }
+        return Array(hashtagTimeline.dropFirst(previousCount))
+    }
+
+    func refreshHashtagTimeline(tag: String) async {
+        hashtagTimelineMaxId = nil
+        await loadHashtagTimeline(tag: tag, refresh: true)
     }
     
     func loadListAccounts(listId: String, refresh: Bool = false) async {

--- a/fedi-reader/Utilities/Constants/Constants.swift
+++ b/fedi-reader/Utilities/Constants/Constants.swift
@@ -35,6 +35,7 @@ enum Constants {
         static let verifyCredentials = "/api/v1/accounts/verify_credentials"
         static let homeTimeline = "/api/v1/timelines/home"
         static let publicTimeline = "/api/v1/timelines/public"
+        static let bookmarks = "/api/v1/bookmarks"
         static let notifications = "/api/v1/notifications"
         static let conversations = "/api/v1/conversations"
         static let conversationRead = "/api/v1/conversations" // Use with /:id/read
@@ -55,6 +56,9 @@ enum Constants {
         // Lists
         static let lists = "/api/v1/lists"
         static let listTimeline = "/api/v1/timelines/list"
+
+        // Followed tags (hashtags)
+        static let followedTags = "/api/v1/followed_tags"
         
         // Rate limiting
         static let defaultRateLimit = 300 // requests per 5 minutes

--- a/fedi-reader/Utilities/Thread/ThreadBuilder.swift
+++ b/fedi-reader/Utilities/Thread/ThreadBuilder.swift
@@ -3,18 +3,17 @@ import Foundation
 enum ThreadBuilder {
     /// Builds a thread tree from a flat array of statuses
     /// Returns root-level threads (statuses that aren't replies, or whose parent isn't in the set)
+    /// Uses O(n) pre-grouping to avoid O(n²) filtering on large reply threads
     static func buildThreadTree(from statuses: [Status]) -> [ThreadNode] {
         guard !statuses.isEmpty else { return [] }
         
-        // Create a lookup map for quick parent finding
         let statusMap = Dictionary(uniqueKeysWithValues: statuses.map { ($0.id, $0) })
+        let repliesByParentId = Dictionary(grouping: statuses) { $0.inReplyToId ?? "" }
         
-        // Find root statuses (those with no parent or parent not in the set)
         let rootStatuses = findRootStatuses(statuses, statusMap: statusMap)
         
-        // Build tree for each root
         return rootStatuses.map { root in
-            buildSubtree(root: root, allStatuses: statuses, statusMap: statusMap)
+            buildSubtree(root: root, repliesByParentId: repliesByParentId)
         }
     }
     
@@ -22,27 +21,16 @@ enum ThreadBuilder {
     static func findRootStatuses(_ statuses: [Status], statusMap: [String: Status]) -> [Status] {
         statuses.filter { status in
             guard let replyToId = status.inReplyToId else {
-                // No parent = root
                 return true
             }
-            // If parent is not in our set, this is effectively a root
             return statusMap[replyToId] == nil
         }
     }
     
-    /// Recursively builds a subtree starting from a root status
-    static func buildSubtree(root: Status, allStatuses: [Status], statusMap: [String: Status]) -> ThreadNode {
-        // Find all direct replies to this status
-        let directReplies = allStatuses.filter { $0.inReplyToId == root.id }
-        
-        // Sort replies chronologically
-        let sortedReplies = directReplies.sorted { $0.createdAt < $1.createdAt }
-        
-        // Recursively build subtrees for each reply
-        let childNodes = sortedReplies.map { reply in
-            buildSubtree(root: reply, allStatuses: allStatuses, statusMap: statusMap)
-        }
-        
+    /// Recursively builds a subtree; uses pre-grouped replies for O(1) child lookup
+    private static func buildSubtree(root: Status, repliesByParentId: [String: [Status]]) -> ThreadNode {
+        let directReplies = (repliesByParentId[root.id] ?? []).sorted { $0.createdAt < $1.createdAt }
+        let childNodes = directReplies.map { buildSubtree(root: $0, repliesByParentId: repliesByParentId) }
         return ThreadNode(status: root, children: childNodes)
     }
     

--- a/fedi-reader/Views/Feed/BookmarksFeedView.swift
+++ b/fedi-reader/Views/Feed/BookmarksFeedView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+struct BookmarksFeedView: View {
+    @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+
+    private var timelineService: TimelineService? {
+        timelineWrapper.service
+    }
+
+    private var bookmarks: [Status] {
+        timelineService?.bookmarks ?? []
+    }
+
+    var body: some View {
+        Group {
+            if !bookmarks.isEmpty {
+                GlassEffectContainer {
+                    List(bookmarks) { status in
+                        StatusRowView(status: status)
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
+                            .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
+                            .onAppear {
+                                checkLoadMore(status)
+                            }
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+#if os(iOS)
+                    .listRowSpacing(8)
+#endif
+                }
+            } else if timelineService?.isLoadingBookmarks == true {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                emptyStateView
+            }
+        }
+        .navigationTitle("Bookmarks")
+        .refreshable {
+            await timelineService?.refreshBookmarks()
+        }
+        .task {
+            await loadBookmarks()
+        }
+    }
+
+    private var emptyStateView: some View {
+        ContentUnavailableView {
+            Label("No Bookmarks", systemImage: "bookmark")
+        } description: {
+            Text("Posts you bookmark will appear here.")
+        } actions: {
+            Button("Refresh") {
+                Task {
+                    await timelineService?.refreshBookmarks()
+                }
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private func loadBookmarks() async {
+        if timelineService?.bookmarks.isEmpty == true {
+            await timelineService?.refreshBookmarks()
+        }
+    }
+
+    private func checkLoadMore(_ status: Status) {
+        guard let bookmarks = timelineService?.bookmarks,
+              let index = bookmarks.firstIndex(of: status) else { return }
+
+        if index >= bookmarks.count - Constants.Pagination.prefetchThreshold {
+            Task {
+                await timelineService?.loadMoreBookmarks()
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        BookmarksFeedView()
+    }
+    .environment(AppState())
+    .environment(TimelineServiceWrapper())
+}

--- a/fedi-reader/Views/Feed/HashtagsTabRootView.swift
+++ b/fedi-reader/Views/Feed/HashtagsTabRootView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct HashtagsTabRootView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+
+    private var timelineService: TimelineService? {
+        timelineWrapper.service
+    }
+
+    private var followedTags: [Tag] {
+        timelineService?.followedTags ?? []
+    }
+
+    private var isLoading: Bool {
+        timelineService?.isLoadingFollowedTags ?? false
+    }
+
+    var body: some View {
+        List {
+            if isLoading && followedTags.isEmpty {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+            } else if followedTags.isEmpty {
+                ContentUnavailableView {
+                    Label("No Followed Hashtags", systemImage: "number")
+                } description: {
+                    Text("Follow hashtags from the Explore tab or by tapping # in posts. They will appear here.")
+                }
+            } else {
+                Section {
+                    ForEach(followedTags, id: \.name) { tag in
+                        NavigationLink(value: NavigationDestination.hashtagFeed(tag)) {
+                            Label("#\(tag.name)", systemImage: "number")
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Hashtags")
+        .refreshable {
+            await timelineService?.loadFollowedTags(refresh: true)
+        }
+        .task {
+            await loadFollowedTags()
+        }
+    }
+
+    private func loadFollowedTags() async {
+        guard let timelineService else { return }
+        if followedTags.isEmpty {
+            await timelineService.loadFollowedTags(refresh: true)
+        }
+    }
+}
+
+struct HashtagFeedDetailView: View {
+    @Environment(\.layoutMode) private var layoutMode
+
+    let tag: Tag
+
+    private var hashtagFeedTab: FeedTabItem {
+        FeedTabItem(id: AppState.hashtagFeedID(tag.name), title: "#\(tag.name)")
+    }
+
+    var body: some View {
+        Group {
+            switch layoutMode {
+            case .wide, .medium:
+                LinkFeedTwoColumnView(
+                    feedTabsOverride: [hashtagFeedTab],
+                    showsFeedPicker: false,
+                    allowsSwipeNavigation: false,
+                    titleOverride: "#\(tag.name)",
+                    userFilterToolbarPlacement: .trailing
+                )
+            case .compact:
+                LinkFeedView(
+                    feedTabsOverride: [hashtagFeedTab],
+                    showsFeedPicker: false,
+                    allowsSwipeNavigation: false,
+                    titleOverride: "#\(tag.name)",
+                    userFilterToolbarPlacement: .trailing
+                )
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HashtagsTabRootView()
+    }
+    .environment(AppState())
+    .environment(TimelineServiceWrapper())
+}

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -352,9 +352,18 @@ struct LinkFeedContentView: View {
     }
 
     private func linkList(statuses: [LinkStatus]) -> some View {
-        let canLoadMore = currentTab.isHome
-            ? (timelineService?.canLoadMoreHomeTimeline() ?? false)
-            : (timelineService?.canLoadMoreListTimeline() ?? false)
+        let canLoadMore: Bool = {
+            if currentTab.id == AppState.bookmarksFeedID {
+                return timelineService?.canLoadMoreBookmarks() ?? false
+            }
+            if currentTab.id.hasPrefix("hashtag:") {
+                let tagName = String(currentTab.id.dropFirst("hashtag:".count))
+                return timelineService?.canLoadMoreHashtagTimeline(tag: tagName) ?? false
+            }
+            return currentTab.isHome
+                ? (timelineService?.canLoadMoreHomeTimeline() ?? false)
+                : (timelineService?.canLoadMoreListTimeline() ?? false)
+        }()
         return LinkFeedPostList(
             statuses: statuses,
             isLoading: FeedScopedLinkData.isLoading(in: linkFilterService, feedId: currentTab.id),
@@ -440,10 +449,19 @@ struct LinkFeedContentView: View {
     }
 
     private var emptyStateView: some View {
-        ContentUnavailableView {
+        let description: String = {
+            if currentTab.id == AppState.bookmarksFeedID {
+                return "Bookmarked posts with links will appear here."
+            }
+            if currentTab.id.hasPrefix("hashtag:") {
+                return "Posts with links from this hashtag will appear here."
+            }
+            return "Posts with links from your \(currentTab.isHome ? "home timeline" : "list") will appear here."
+        }()
+        return ContentUnavailableView {
             Label("No Links Yet", systemImage: "link.badge.plus")
         } description: {
-            Text("Posts with links from your \(currentTab.isHome ? "home timeline" : "list") will appear here.")
+            Text(description)
         } actions: {
             Button("Refresh") {
                 Task {
@@ -527,7 +545,14 @@ struct LinkFeedContentView: View {
         guard !isPaginating, !service.isLoadingMore else { return }
 
         let tab = currentTab
-        let canLoadMore = tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
+        let canLoadMore: Bool = {
+            if tab.id == AppState.bookmarksFeedID { return service.canLoadMoreBookmarks() }
+            if tab.id.hasPrefix("hashtag:") {
+                let tagName = String(tab.id.dropFirst("hashtag:".count))
+                return service.canLoadMoreHashtagTimeline(tag: tagName)
+            }
+            return tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
+        }()
         guard canLoadMore else { return }
 
         isPaginating = true
@@ -605,6 +630,8 @@ struct LinkFeedContentView: View {
     }
 
     private func syncAppStateSelectionToCurrentTab() {
+        guard currentTab.id != AppState.bookmarksFeedID,
+              !currentTab.id.hasPrefix("hashtag:") else { return }
         let listId = currentTab.isHome ? nil : currentTab.id
         if appState.selectedListId != listId {
             appState.selectedListId = listId
@@ -615,7 +642,14 @@ struct LinkFeedContentView: View {
         guard let service = timelineService else { return }
         let tab = currentTab
 
-        if tab.isHome {
+        if tab.id == AppState.bookmarksFeedID {
+            await service.refreshBookmarks()
+            _ = await linkFilterService.processStatuses(service.bookmarks, for: tab.id)
+        } else if tab.id.hasPrefix("hashtag:") {
+            let tagName = String(tab.id.dropFirst("hashtag:".count))
+            await service.refreshHashtagTimeline(tag: tagName)
+            _ = await linkFilterService.processStatuses(service.hashtagTimeline, for: tab.id)
+        } else if tab.isHome {
             await service.refreshHomeTimeline()
             _ = await linkFilterService.processStatuses(service.homeTimeline, for: tab.id)
         } else {
@@ -642,14 +676,25 @@ struct LinkFeedContentView: View {
         defer { isPaginating = false }
 
         let loadMore: () async -> [Status] = {
+            if tab.id == AppState.bookmarksFeedID {
+                return await service.loadMoreBookmarks()
+            }
+            if tab.id.hasPrefix("hashtag:") {
+                let tagName = String(tab.id.dropFirst("hashtag:".count))
+                return await service.loadMoreHashtagTimeline(tag: tagName)
+            }
             if tab.isHome {
                 return await service.loadMoreHomeTimeline()
-            } else {
-                return await service.loadMoreListTimeline(listId: tab.id)
             }
+            return await service.loadMoreListTimeline(listId: tab.id)
         }
         let canLoadMore: () -> Bool = {
-            tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
+            if tab.id == AppState.bookmarksFeedID { return service.canLoadMoreBookmarks() }
+            if tab.id.hasPrefix("hashtag:") {
+                let tagName = String(tab.id.dropFirst("hashtag:".count))
+                return service.canLoadMoreHashtagTimeline(tag: tagName)
+            }
+            return tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
         }
 
         // Keep fetching until we add link posts or exhaust the API (link feed can get batches with 0 links)

--- a/fedi-reader/Views/Feed/Mentions/MentionsTwoColumnView.swift
+++ b/fedi-reader/Views/Feed/Mentions/MentionsTwoColumnView.swift
@@ -85,6 +85,7 @@ struct MentionsTwoColumnView: View {
             }
         }
         .navigationTitle("Messages")
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {

--- a/fedi-reader/Views/Feed/Mentions/MentionsView.swift
+++ b/fedi-reader/Views/Feed/Mentions/MentionsView.swift
@@ -25,6 +25,7 @@ struct MentionsView: View {
             }
         }
         .navigationTitle("Messages")
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {

--- a/fedi-reader/Views/Feed/StatusDetailView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailView.swift
@@ -6,10 +6,9 @@ struct StatusDetailView: View {
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
 
     @State private var context: StatusContext?
+    @State private var replyTrees: [ThreadNode] = []
     @State private var isLoading = true
     @State private var isLoadingRemoteReplies = false
-    
-    private let threadingService = ThreadingService()
 
     private var threadStatus: Status {
         status.displayStatus
@@ -45,8 +44,6 @@ struct StatusDetailView: View {
                 }
 
                 if let context = context {
-                    // Build thread tree from descendants only (exclude parent/current post)
-                    let replyTrees = threadingService.buildThreadTree(from: context.descendants)
                     let shouldFetchMoreReplies = shouldFetchRemoteReplies(context: context)
                     
                     if !context.descendants.isEmpty {
@@ -155,6 +152,9 @@ struct StatusDetailView: View {
         .task {
             await loadContext()
         }
+        .onChange(of: context?.descendants) { _, descendants in
+            buildReplyTrees(descendants: descendants ?? [])
+        }
         .refreshable {
             await refreshReplies()
         }
@@ -162,11 +162,10 @@ struct StatusDetailView: View {
             timelineWrapper.service?.cancelAsyncRefreshPolling(forStatusId: threadStatus.id)
         }
         .onReceive(NotificationCenter.default.publisher(for: .statusContextDidUpdate)) { notification in
-            // Update context when remote replies are fetched
             if let payload = notification.object as? StatusContextUpdatePayload,
                payload.statusId == threadStatus.id {
-                // Replace context with updated one (it already contains all replies)
                 context = payload.context
+                buildReplyTrees(descendants: payload.context.descendants)
                 isLoadingRemoteReplies = false
             }
         }
@@ -181,11 +180,26 @@ struct StatusDetailView: View {
         do {
             let loadedContext = try await service.getStatusContext(for: threadStatus)
             context = loadedContext
+            buildReplyTrees(descendants: loadedContext.descendants)
             isLoading = false
             isLoadingRemoteReplies = false
         } catch {
             isLoading = false
             isLoadingRemoteReplies = false
+        }
+    }
+
+    /// Builds thread tree off main thread to avoid UI hangs with large reply counts
+    private func buildReplyTrees(descendants: [Status]) {
+        if descendants.isEmpty {
+            replyTrees = []
+            return
+        }
+        Task.detached(priority: .userInitiated) { [descendants] in
+            let trees = ThreadBuilder.buildThreadTree(from: descendants)
+            await MainActor.run {
+                replyTrees = trees
+            }
         }
     }
     

--- a/fedi-reader/Views/Profile/ListDisplaySettingsView.swift
+++ b/fedi-reader/Views/Profile/ListDisplaySettingsView.swift
@@ -1,10 +1,17 @@
 import SwiftUI
 
+enum ListDisplaySettingsFeatures {
+    static func editMode(isCustomSortOrder: Bool) -> EditMode {
+        isCustomSortOrder ? .active : .inactive
+    }
+}
+
 struct ListDisplaySettingsView: View {
     @Environment(AppState.self) private var appState
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
 
     @State private var isLoading = false
+    @State private var editMode: EditMode = .inactive
 
     private var timelineService: TimelineService? {
         timelineWrapper.service
@@ -48,14 +55,18 @@ struct ListDisplaySettingsView: View {
             )
         }
         .navigationTitle("List Display")
-        .environment(\.editMode, .constant(isCustomSortOrder ? .active : .inactive))
+        .environment(\.editMode, $editMode)
         .task {
             await loadLists()
         }
         .onAppear {
+            editMode = ListDisplaySettingsFeatures.editMode(isCustomSortOrder: isCustomSortOrder)
             if !rawLists.isEmpty {
                 appState.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
             }
+        }
+        .onChange(of: isCustomSortOrder) { _, newValue in
+            editMode = ListDisplaySettingsFeatures.editMode(isCustomSortOrder: newValue)
         }
         .onChange(of: liveLists) { _, newLists in
             appState.synchronizeCurrentAccountListDisplayPreferences(with: newLists)

--- a/fedi-reader/Views/Profile/ProfileView.swift
+++ b/fedi-reader/Views/Profile/ProfileView.swift
@@ -49,23 +49,6 @@ struct ProfileView: View {
                 }
             }
 
-            Section("Lists") {
-                Button {
-                    appState.navigate(to: .listDisplay)
-                } label: {
-                    Label("List Display", systemImage: "list.bullet.rectangle")
-                }
-            }
-            
-            // Read Later
-            Section("Read Later") {
-                Button {
-                    appState.navigate(to: .readLaterSettings)
-                } label: {
-                    Label("Read Later Services", systemImage: "bookmark")
-                }
-            }
-            
             // App settings
             Section("App") {
                 Button {

--- a/fedi-reader/Views/Root/MainTabView.swift
+++ b/fedi-reader/Views/Root/MainTabView.swift
@@ -12,8 +12,6 @@ struct MainTabView: View {
     @State private var tabTracker = TabSelectionTracker()
     @AppStorage("hapticFeedback") private var hapticFeedback = true
     @AppStorage("hideTabBarLabels") private var hideTabBarLabels = false
-    @AppStorage(AppState.listsInSeparateTabStorageKey) private var listsInSeparateTab = false
-    @AppStorage("themeColor") private var themeColorName = "blue"
 
     private var unreadMentionsCount: Int {
         timelineWrapper.service?.unreadConversationsCount ?? 0
@@ -23,18 +21,36 @@ struct MainTabView: View {
         layoutMode.useSidebarLayout
     }
 
+    private var visibleTabs: [AppTab] {
+        appState.resolvedVisibleTabs()
+    }
+
+    private var listsInSeparateTab: Bool {
+        appState.listsInSeparateTab
+    }
 
     var body: some View {
         @Bindable var state = appState
 
         mainTabView()
+            .animation(.easeInOut(duration: 0.25), value: hideTabBarLabels)
             .onChange(of: state.selectedTab) { oldValue, newValue in
             HapticFeedback.play(.selection, enabled: hapticFeedback && !useSidebarLayout)
+            let primaryTabs = Array(visibleTabs.prefix(4))
+            if primaryTabs.contains(newValue) {
+                state.moreTabPath.removeAll()
+            }
             if oldValue == .profile {
                 state.profileNavigationPath.removeAll()
             }
             if oldValue == .lists {
                 state.listsNavigationPath.removeAll()
+            }
+            if oldValue == .hashtags {
+                state.hashtagsNavigationPath.removeAll()
+            }
+            if oldValue == .bookmarks {
+                state.bookmarksNavigationPath.removeAll()
             }
             if oldValue == .mentions {
                 state.mentionsNavigationPath.removeAll()
@@ -49,9 +65,45 @@ struct MainTabView: View {
                 tabTracker.reset()
             }
         }
-        .onChange(of: listsInSeparateTab) { _, isEnabled in
-            if !isEnabled, state.selectedTab == .lists {
-                state.selectedTab = .links
+        .onChange(of: visibleTabs) { oldVisibleTabs, newVisibleTabs in
+            let wasCompact = oldVisibleTabs.count > 5
+            let isCompact = newVisibleTabs.count > 5
+            let moreTabs = Array(newVisibleTabs.dropFirst(4))
+
+            if wasCompact, !isCompact, case .moreTab(let tab)? = state.moreTabPath.first {
+                let destinations = Array(state.moreTabPath.dropFirst())
+                switch tab {
+                case .mentions: state.mentionsNavigationPath = destinations
+                case .lists: state.listsNavigationPath = destinations
+                case .hashtags: state.hashtagsNavigationPath = destinations
+                case .bookmarks: state.bookmarksNavigationPath = destinations
+                case .explore: state.exploreNavigationPath = destinations
+                case .profile: state.profileNavigationPath = destinations
+                default: break
+                }
+                state.moreTabPath.removeAll()
+            } else if !wasCompact, isCompact, moreTabs.contains(state.selectedTab) {
+                let destinations: [NavigationDestination]
+                switch state.selectedTab {
+                case .mentions: destinations = state.mentionsNavigationPath
+                case .lists: destinations = state.listsNavigationPath
+                case .hashtags: destinations = state.hashtagsNavigationPath
+                case .bookmarks: destinations = state.bookmarksNavigationPath
+                case .explore: destinations = state.exploreNavigationPath
+                case .profile: destinations = state.profileNavigationPath
+                default: destinations = []
+                }
+                if !destinations.isEmpty {
+                    state.moreTabPath = [.moreTab(state.selectedTab)] + destinations
+                }
+            }
+
+            let resolvedSelection = MainTabViewSelectionFeatures.resolvedSelection(
+                selectedTab: state.selectedTab,
+                visibleTabs: newVisibleTabs
+            )
+            if state.selectedTab != resolvedSelection {
+                state.selectedTab = resolvedSelection
             }
         }
         .onChange(of: useSidebarLayout) { _, _ in
@@ -65,72 +117,255 @@ struct MainTabView: View {
     private func mainTabView() -> some View {
         @Bindable var state = appState
 
+        if useSidebarLayout || visibleTabs.count <= 5 {
+            standardTabView()
+        } else {
+            compactTabViewWithMoreList()
+        }
+    }
+
+    @ViewBuilder
+    private func standardTabView() -> some View {
+        @Bindable var state = appState
+
         TabView(
             selection: Binding(
-                get: { state.selectedTab },
-                set: { handleTabSelection($0) }
+                get: {
+                    MainTabViewSelectionFeatures.resolvedSelection(
+                        selectedTab: state.selectedTab,
+                        visibleTabs: visibleTabs
+                    )
+                },
+                set: { newValue in
+                    handleTabSelection(
+                        MainTabViewSelectionFeatures.resolvedSelection(
+                            selectedTab: newValue,
+                            visibleTabs: visibleTabs
+                        )
+                    )
+                }
             )
         ) {
-            Tab(useSidebarLayout ? "Home" : (hideTabBarLabels ? "" : "Home"), systemImage: "house", value: .links) {
-                linksTabContent()
-            }
-
-            if listsInSeparateTab {
-                Tab(useSidebarLayout ? "Lists" : (hideTabBarLabels ? "" : "Lists"), systemImage: "list.bullet", value: .lists) {
-                    NavigationStack(path: $state.listsNavigationPath) {
-                        ListsTabRootView()
-                        .navigationDestination(for: NavigationDestination.self) { destination in
-                            destinationView(for: destination)
+            ForEach(visibleTabs) { tab in
+                if tab == .mentions && unreadMentionsCount > 0 {
+                    tabContent(for: tab)
+                        .tag(tab)
+                        .tabItem {
+                            tabItemLabel(for: tab)
                         }
-                    }
-                }
-            }
-
-            Tab(useSidebarLayout ? "Explore" : (hideTabBarLabels ? "" : "Explore"), systemImage: "globe", value: .explore) {
-                NavigationStack(path: $state.exploreNavigationPath) {
-                    ExploreFeedView()
-                        .navigationDestination(for: NavigationDestination.self) { destination in
-                            destinationView(for: destination)
-                        }
-                }
-            }
-
-            Tab(useSidebarLayout ? "Messages" : (hideTabBarLabels ? "" : "Messages"), systemImage: "at", value: AppTab.mentions) {
-                mentionsTabContent()
-            }
-
-            Tab(useSidebarLayout ? "Profile" : (hideTabBarLabels ? "" : "Profile"), systemImage: "person", value: .profile) {
-                NavigationStack(path: $state.profileNavigationPath) {
-                    ProfileView()
-                        .navigationDestination(for: NavigationDestination.self) { destination in
-                            destinationView(for: destination)
+                        .badge(unreadMentionsCount)
+                } else {
+                    tabContent(for: tab)
+                        .tag(tab)
+                        .tabItem {
+                            tabItemLabel(for: tab)
                         }
                 }
             }
         }
         .modifier(ConditionalTabViewStyle(useSidebarLayout: useSidebarLayout))
-        .overlay {
-            unreadDotOverlay
+        .id(hideTabBarLabels)
+    }
+
+    private enum CompactTabSelection: Hashable {
+        case primary(AppTab)
+        case more
+    }
+
+    @ViewBuilder
+    private func compactTabViewWithMoreList() -> some View {
+        @Bindable var state = appState
+        let primaryTabs = Array(visibleTabs.prefix(4))
+        let moreTabs = Array(visibleTabs.dropFirst(4))
+
+        TabView(
+            selection: Binding(
+                get: {
+                    let resolved = MainTabViewSelectionFeatures.resolvedSelection(
+                        selectedTab: state.selectedTab,
+                        visibleTabs: visibleTabs
+                    )
+                    if primaryTabs.contains(resolved) {
+                        return .primary(resolved)
+                    }
+                    return .more
+                },
+                set: { (newValue: CompactTabSelection) in
+                    switch newValue {
+                    case .primary(let tab):
+                        handleTabSelection(tab)
+                    case .more:
+                        if let first = moreTabs.first {
+                            state.selectedTab = first
+                        }
+                    }
+                }
+            )
+        ) {
+            ForEach(primaryTabs) { tab in
+                if tab == .mentions && unreadMentionsCount > 0 {
+                    tabContent(for: tab)
+                        .tag(CompactTabSelection.primary(tab))
+                        .tabItem {
+                            tabItemLabel(for: tab)
+                        }
+                        .badge(unreadMentionsCount)
+                } else {
+                    tabContent(for: tab)
+                        .tag(CompactTabSelection.primary(tab))
+                        .tabItem {
+                            tabItemLabel(for: tab)
+                        }
+                }
+            }
+
+            moreTabContent(moreTabs: moreTabs)
+                .tag(CompactTabSelection.more)
+                .tabItem {
+                    Group {
+                        if hideTabBarLabels {
+                            Label("More", systemImage: "ellipsis.circle")
+                                .labelStyle(.iconOnly)
+                        } else {
+                            Label("More", systemImage: "ellipsis.circle")
+                        }
+                    }
+                    .accessibilityLabel("More")
+                }
+        }
+        .tabViewStyle(.automatic)
+        .id(hideTabBarLabels)
+    }
+
+    @ViewBuilder
+    private func moreTabContent(moreTabs: [AppTab]) -> some View {
+        @Bindable var state = appState
+
+        NavigationStack(path: $state.moreTabPath) {
+            moreTabList(moreTabs: moreTabs)
+                .navigationDestination(for: NavigationDestination.self) { destination in
+                    destinationView(for: destination)
+                }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func moreTabList(moreTabs: [AppTab]) -> some View {
+        List {
+            ForEach(moreTabs) { tab in
+                NavigationLink(value: NavigationDestination.moreTab(tab)) {
+                    Label {
+                        Text(tab.title)
+                    } icon: {
+                        Image(systemName: tab.systemImage)
+                            .foregroundStyle(.tint)
+                    }
+                }
+            }
+        }
+        .navigationTitle("More")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    private func moreTabRootView(for tab: AppTab) -> some View {
+        switch tab {
+        case .lists:
+            ListsTabRootView()
+        case .hashtags:
+            HashtagsTabRootView()
+        case .bookmarks:
+            LinkFeedView(
+                feedTabsOverride: [FeedTabItem(id: AppState.bookmarksFeedID, title: "Bookmarks")],
+                showsFeedPicker: false,
+                allowsSwipeNavigation: false,
+                titleOverride: "Bookmarks",
+                userFilterToolbarPlacement: .trailing
+            )
+        case .explore:
+            ExploreFeedView()
+        case .mentions:
+            MentionsView()
+        case .profile:
+            ProfileView()
+        default:
+            EmptyView()
         }
     }
 
     @ViewBuilder
-    private var unreadDotOverlay: some View {
-        if !useSidebarLayout, unreadMentionsCount > 0 {
-            GeometryReader { geometry in
-                Circle()
-                    .fill(ThemeColor.resolved(from: themeColorName).color)
-                    .frame(width: 8, height: 8)
-                    .overlay(
-                        Circle()
-                            .stroke(Color(.systemBackground), lineWidth: 2)
-                    )
-                    .position(
-                        x: geometry.size.width * (2.5 / 4),
-                        y: geometry.size.height - 35
-                    )
+    private func tabItemLabel(for tab: AppTab) -> some View {
+        let title = MainTabViewTabItemFeatures.title(
+            for: tab,
+            useSidebarLayout: useSidebarLayout,
+            hideTabBarLabels: hideTabBarLabels
+        )
+        let tabsBehindMore = Set(TabOrderSettingsFeatures.tabsBehindMore(in: visibleTabs))
+        let useIconOnly = MainTabViewTabItemFeatures.usesIconOnlyLabelStyle(
+            useSidebarLayout: useSidebarLayout,
+            hideTabBarLabels: hideTabBarLabels
+        ) && !tabsBehindMore.contains(tab)
+
+        if useIconOnly {
+            Label(title, systemImage: tab.systemImage)
+                .labelStyle(.iconOnly)
+                .accessibilityLabel(title)
+        } else {
+            Label(title, systemImage: tab.systemImage)
+        }
+    }
+
+    @ViewBuilder
+    private func tabContent(for tab: AppTab) -> some View {
+        @Bindable var state = appState
+
+        switch tab {
+        case .links:
+            linksTabContent()
+        case .lists:
+            NavigationStack(path: $state.listsNavigationPath) {
+                ListsTabRootView()
+                    .navigationDestination(for: NavigationDestination.self) { destination in
+                        destinationView(for: destination)
+                    }
             }
-            .allowsHitTesting(false)
+        case .hashtags:
+            NavigationStack(path: $state.hashtagsNavigationPath) {
+                HashtagsTabRootView()
+                    .navigationDestination(for: NavigationDestination.self) { destination in
+                        destinationView(for: destination)
+                    }
+            }
+        case .bookmarks:
+            NavigationStack(path: $state.bookmarksNavigationPath) {
+                LinkFeedView(
+                    feedTabsOverride: [FeedTabItem(id: AppState.bookmarksFeedID, title: "Bookmarks")],
+                    showsFeedPicker: false,
+                    allowsSwipeNavigation: false,
+                    titleOverride: "Bookmarks",
+                    userFilterToolbarPlacement: .trailing
+                )
+                .navigationDestination(for: NavigationDestination.self) { destination in
+                    destinationView(for: destination)
+                }
+            }
+        case .explore:
+            NavigationStack(path: $state.exploreNavigationPath) {
+                ExploreFeedView()
+                    .navigationDestination(for: NavigationDestination.self) { destination in
+                        destinationView(for: destination)
+                    }
+            }
+        case .mentions:
+            mentionsTabContent()
+        case .profile:
+            NavigationStack(path: $state.profileNavigationPath) {
+                ProfileView()
+                    .navigationDestination(for: NavigationDestination.self) { destination in
+                        destinationView(for: destination)
+                    }
+            }
         }
     }
 
@@ -245,6 +480,21 @@ struct MainTabView: View {
     @ViewBuilder
     private func destinationView(for destination: NavigationDestination) -> some View {
         switch destination {
+        case .moreTab(let tab):
+            moreTabRootView(for: tab)
+                .navigationDestination(for: NavigationDestination.self) { dest in
+                    destinationViewContent(for: dest)
+                }
+        default:
+            destinationViewContent(for: destination)
+        }
+    }
+
+    @ViewBuilder
+    private func destinationViewContent(for destination: NavigationDestination) -> some View {
+        switch destination {
+        case .moreTab:
+            EmptyView()
         case .status(let status):
             StatusDetailView(status: status)
         case .conversation(let groupedConversation):
@@ -253,6 +503,8 @@ struct MainTabView: View {
             ProfileDetailView(account: account)
         case .listFeed(let list):
             ListFeedDetailView(list: list)
+        case .hashtagFeed(let tag):
+            HashtagFeedDetailView(tag: tag)
         case .article(let url, let status):
             ArticleWebView(url: url, status: status)
         case .thread(let statusId):
@@ -261,6 +513,8 @@ struct MainTabView: View {
             HashtagPlaceholderView(tag: tag)
         case .settings:
             SettingsView()
+        case .tabOrder:
+            TabOrderSettingsView()
         case .listDisplay:
             ListDisplaySettingsView()
         case .accountSettings:
@@ -285,6 +539,30 @@ struct MainTabView: View {
         if !service.lists.isEmpty {
             timelineWrapper.updateCachedLists(service.lists, for: appState.currentAccount?.id)
         }
+    }
+}
+
+enum MainTabViewTabItemFeatures {
+    static func title(for tab: AppTab, useSidebarLayout: Bool, hideTabBarLabels: Bool) -> String {
+        tab.title
+    }
+
+    static func usesIconOnlyLabelStyle(useSidebarLayout: Bool, hideTabBarLabels: Bool) -> Bool {
+        !useSidebarLayout && hideTabBarLabels
+    }
+}
+
+enum MainTabViewSelectionFeatures {
+    static func resolvedSelection(selectedTab: AppTab, visibleTabs: [AppTab]) -> AppTab {
+        if visibleTabs.contains(selectedTab) {
+            return selectedTab
+        }
+
+        if visibleTabs.contains(.links) {
+            return .links
+        }
+
+        return visibleTabs.first ?? .links
     }
 }
 
@@ -314,3 +592,4 @@ private struct ConditionalTabViewStyle: ViewModifier {
         }
     }
 }
+

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -15,7 +15,6 @@ struct SettingsView: View {
     @AppStorage("hideTabBarLabels") private var hideTabBarLabels = false
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("defaultListId") private var defaultListId = ""
-    @AppStorage(AppState.listsInSeparateTabStorageKey) private var listsInSeparateTab = false
     @AppStorage("showQuoteBoost") private var showQuoteBoost = true
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
 
@@ -59,7 +58,6 @@ struct SettingsView: View {
                     hideTabBarLabels: $hideTabBarLabels,
                     themeColorName: $themeColorName,
                     defaultListId: $defaultListId,
-                    listsInSeparateTab: $listsInSeparateTab,
                     showQuoteBoost: $showQuoteBoost,
                     showHandleInFeed: $showHandleInFeed,
                     lists: lists,
@@ -70,8 +68,8 @@ struct SettingsView: View {
             }
         }
         .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(.inline)
         .tint(selectedThemeColor)
-        .id("settings-theme-\(themeColorName)")
         .onAppear {
             _ = appState.synchronizeCurrentAccountListDisplayPreferences(with: rawLists)
         }
@@ -85,12 +83,16 @@ struct SettingsView: View {
     private var settingsListContent: some View {
         List {
             // Display
-            Section("Display") {
+            Section {
                 Toggle("Show Images", isOn: $showImages)
                 Toggle("Auto-play GIFs", isOn: $autoPlayGifs)
                 Toggle("Hide Tab Bar Labels", isOn: $hideTabBarLabels)
                 Toggle("Show Handle in Feed", isOn: $showHandleInFeed)
-                
+
+                NavigationLink(value: NavigationDestination.tabOrder) {
+                    Label("Tab Order", systemImage: "rectangle.3.group")
+                }
+
                 NavigationLink {
                     ThemeColorSelectionView(selection: $themeColorName)
                 } label: {
@@ -103,12 +105,26 @@ struct SettingsView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            } header: {
+                Text("Display")
             }
             
+            // Lists
+            Section("Lists") {
+                NavigationLink(value: NavigationDestination.listDisplay) {
+                    Label("List Display", systemImage: "list.bullet.rectangle")
+                }
+            }
+
+            // Read Later
+            Section("Read Later") {
+                NavigationLink(value: NavigationDestination.readLaterSettings) {
+                    Label("Read Later Services", systemImage: "bookmark")
+                }
+            }
+
             // Timeline
             Section("Timeline") {
-                Toggle("Show Lists in Separate Tab", isOn: $listsInSeparateTab)
-
                 Picker("Default Feed", selection: $defaultListId) {
                     Text("Home").tag("")
                     ForEach(lists) { list in
@@ -203,7 +219,6 @@ private struct SettingsTwoColumnView: View {
     @Binding var hideTabBarLabels: Bool
     @Binding var themeColorName: String
     @Binding var defaultListId: String
-    @Binding var listsInSeparateTab: Bool
     @Binding var showQuoteBoost: Bool
     @Binding var showHandleInFeed: Bool
     let lists: [MastodonList]
@@ -222,6 +237,8 @@ private struct SettingsTwoColumnView: View {
 
     enum SettingsSection: String, CaseIterable, Identifiable {
         case display
+        case lists
+        case readLater
         case timeline
         case posting
         case accessibility
@@ -233,6 +250,8 @@ private struct SettingsTwoColumnView: View {
         var title: String {
             switch self {
             case .display: return "Display"
+            case .lists: return "Lists"
+            case .readLater: return "Read Later"
             case .timeline: return "Timeline"
             case .posting: return "Posting"
             case .accessibility: return "Accessibility"
@@ -244,6 +263,8 @@ private struct SettingsTwoColumnView: View {
         var systemImage: String {
             switch self {
             case .display: return "photo"
+            case .lists: return "list.bullet.rectangle"
+            case .readLater: return "bookmark"
             case .timeline: return "list.bullet"
             case .posting: return "square.and.pencil"
             case .accessibility: return "accessibility"
@@ -254,7 +275,7 @@ private struct SettingsTwoColumnView: View {
     }
 
     private var visibleSections: [SettingsSection] {
-        var sections: [SettingsSection] = [.display, .timeline, .posting]
+        var sections: [SettingsSection] = [.display, .lists, .readLater, .timeline, .posting]
         if isCompactDevice {
             sections.append(.accessibility)
         }
@@ -343,6 +364,11 @@ private struct SettingsTwoColumnView: View {
                     settingsToggleRow("Auto-play GIFs", isOn: $autoPlayGifs)
                     settingsToggleRow("Hide Tab Bar Labels", isOn: $hideTabBarLabels)
                     settingsToggleRow("Show Handle in Feed", isOn: $showHandleInFeed)
+                    NavigationLink(value: NavigationDestination.tabOrder) {
+                        Label("Tab Order", systemImage: "rectangle.3.group")
+                            .font(.roundedBody)
+                    }
+                    .listRowInsets(Self.detailRowInsets)
                     NavigationLink {
                         ThemeColorSelectionView(selection: $themeColorName)
                     } label: {
@@ -361,10 +387,34 @@ private struct SettingsTwoColumnView: View {
                     Text("Display").font(.roundedTitle3)
                 }
 
+            case .lists:
+                Section {
+                    NavigationLink {
+                        ListDisplaySettingsView()
+                    } label: {
+                        Label("List Display", systemImage: "list.bullet.rectangle")
+                            .font(.roundedBody)
+                    }
+                    .listRowInsets(Self.detailRowInsets)
+                } header: {
+                    Text("Lists").font(.roundedTitle3)
+                }
+
+            case .readLater:
+                Section {
+                    NavigationLink {
+                        ReadLaterSettingsView()
+                    } label: {
+                        Label("Read Later Services", systemImage: "bookmark")
+                            .font(.roundedBody)
+                    }
+                    .listRowInsets(Self.detailRowInsets)
+                } header: {
+                    Text("Read Later").font(.roundedTitle3)
+                }
+
             case .timeline:
                 Section {
-                    settingsToggleRow("Show Lists in Separate Tab", isOn: $listsInSeparateTab)
-
                     Picker(selection: $defaultListId) {
                         Text("Home").tag("")
                         ForEach(lists) { list in

--- a/fedi-reader/Views/Settings/TabOrderSettingsView.swift
+++ b/fedi-reader/Views/Settings/TabOrderSettingsView.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+
+enum TabOrderVisibilityControlStyle: Equatable {
+    case hideEnabled
+    case hideDisabled
+    case showEnabled
+}
+
+enum TabOrderMoveResult: Equatable {
+    case allowed(visibleTabs: [AppTab])
+    case denied(tabs: [AppTab], previewVisibleTabs: [AppTab])
+}
+
+private struct ShakeEffect: GeometryEffect {
+    var amount: CGFloat = 8
+    var shakesPerUnit: CGFloat = 3
+    var animatableData: CGFloat
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        ProjectionTransform(
+            CGAffineTransform(
+                translationX: amount * sin(animatableData * .pi * shakesPerUnit),
+                y: 0
+            )
+        )
+    }
+}
+
+enum TabOrderSettingsFeatures {
+    private static let compactPrimaryTabCountBeforeMore = 4
+    private static let compactVisibleTabLimitBeforeMore = 5
+    private static let protectedTabsBeforeMore: Set<AppTab> = [.links, .profile]
+    static let defaultEditMode: EditMode = .inactive
+    static let deniedMoveFeedbackDelay: TimeInterval = 0.18
+    /// Duration of the shake animation; snap-back runs when this animation completes.
+    static let shakeAnimationDuration: TimeInterval = 0.35
+
+    static func tabsBehindMore(in visibleTabs: [AppTab]) -> [AppTab] {
+        guard visibleTabs.count > compactVisibleTabLimitBeforeMore else { return [] }
+        return Array(visibleTabs.dropFirst(compactPrimaryTabCountBeforeMore))
+    }
+
+    static func visibilityControlStyle(for tab: AppTab, isVisible: Bool) -> TabOrderVisibilityControlStyle {
+        if isVisible {
+            return tab == .links || tab == .profile ? .hideDisabled : .hideEnabled
+        }
+
+        return .showEnabled
+    }
+
+    static func deniedVisibilityChangeTabs(for tab: AppTab, isVisible: Bool) -> [AppTab] {
+        guard !isVisible, protectedTabsBeforeMore.contains(tab) else { return [] }
+        return [tab]
+    }
+
+    static func moveResult(visibleTabs: [AppTab], fromOffsets: IndexSet, toOffset: Int) -> TabOrderMoveResult {
+        let proposedVisibleTabs = movedTabs(
+            visibleTabs,
+            fromOffsets: fromOffsets,
+            toOffset: toOffset
+        )
+        let deniedTabs = tabsBehindMore(in: proposedVisibleTabs).filter { protectedTabsBeforeMore.contains($0) }
+
+        if deniedTabs.isEmpty {
+            return .allowed(visibleTabs: proposedVisibleTabs)
+        }
+
+        return .denied(tabs: deniedTabs, previewVisibleTabs: proposedVisibleTabs)
+    }
+
+    private static func movedTabs(_ tabs: [AppTab], fromOffsets: IndexSet, toOffset: Int) -> [AppTab] {
+        var movedTabs = tabs
+        let movingItems = fromOffsets.map { movedTabs[$0] }
+        let removedBeforeDestination = fromOffsets.filter { $0 < toOffset }.count
+        for offset in fromOffsets.sorted(by: >) {
+            movedTabs.remove(at: offset)
+        }
+        let adjustedOffset = max(0, min(movedTabs.count, toOffset - removedBeforeDestination))
+        movedTabs.insert(contentsOf: movingItems, at: adjustedOffset)
+        return movedTabs
+    }
+}
+
+struct TabOrderSettingsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var editMode: EditMode = TabOrderSettingsFeatures.defaultEditMode
+    @State private var deniedMoveAttempts: [AppTab: Int] = [:]
+    @State private var previewVisibleTabs: [AppTab]? = nil
+    @AppStorage("hapticFeedback") private var hapticFeedback = true
+
+    private var visibleTabs: [AppTab] {
+        previewVisibleTabs ?? appState.resolvedVisibleTabs()
+    }
+
+    private var hiddenTabs: [AppTab] {
+        appState.resolvedHiddenTabs()
+    }
+
+    private var tabsBehindMore: Set<AppTab> {
+        Set(TabOrderSettingsFeatures.tabsBehindMore(in: visibleTabs))
+    }
+
+    var body: some View {
+        List {
+            Section {
+                Label("Home and Profile always stay visible in the main tab bar and never move behind More.", systemImage: "rectangle.3.group.fill")
+                    .foregroundStyle(.secondary)
+            }
+
+            Section("Visible") {
+                ForEach(visibleTabs) { tab in
+                    tabVisibilityRow(for: tab, isVisible: true)
+                }
+                .onMove(perform: moveVisibleTabs)
+            }
+
+            Section("Hidden") {
+                if hiddenTabs.isEmpty {
+                    Text("No hidden tabs.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(hiddenTabs) { tab in
+                        tabVisibilityRow(for: tab, isVisible: false)
+                    }
+                }
+            }
+        }
+        .environment(\.editMode, $editMode)
+        .navigationTitle("Tab Order")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func tabVisibilityRow(for tab: AppTab, isVisible: Bool) -> some View {
+        let controlStyle = TabOrderSettingsFeatures.visibilityControlStyle(for: tab, isVisible: isVisible)
+
+        return HStack(spacing: 12) {
+            Label(tab.title, systemImage: tab.systemImage)
+            Spacer(minLength: 0)
+        }
+        .overlay(alignment: .trailing) {
+            HStack(spacing: 8) {
+                if isVisible, tabsBehindMore.contains(tab) {
+                    Label("In More", systemImage: "ellipsis.circle")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                switch controlStyle {
+                case .hideEnabled, .showEnabled:
+                    Button {
+                        appState.setTabVisibility(tab, isVisible: !isVisible)
+                    } label: {
+                        Image(systemName: controlStyle == .showEnabled ? "plus.circle" : "minus.circle")
+                            .foregroundStyle(controlStyle == .showEnabled ? Color.accentColor : Color.red)
+                            .font(.title3)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(isVisible ? "Hide \(tab.title)" : "Show \(tab.title)")
+                case .hideDisabled:
+                    Button {
+                        triggerDeniedFeedback(for: [tab])
+                    } label: {
+                        Image(systemName: "minus.circle")
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.tertiary)
+                            .font(.title3)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(tab.title) is always visible")
+                }
+            }
+        }
+        .modifier(ShakeEffect(animatableData: CGFloat(deniedMoveAttempts[tab] ?? 0)))
+    }
+
+    private func moveVisibleTabs(fromOffsets: IndexSet, toOffset: Int) {
+        switch TabOrderSettingsFeatures.moveResult(
+            visibleTabs: visibleTabs,
+            fromOffsets: fromOffsets,
+            toOffset: toOffset
+        ) {
+        case .allowed:
+            appState.moveTabs(fromOffsets: fromOffsets, toOffset: toOffset)
+        case .denied(let tabs, let previewVisibleTabs):
+            self.previewVisibleTabs = previewVisibleTabs
+            triggerDeniedFeedback(
+                for: tabs,
+                after: TabOrderSettingsFeatures.deniedMoveFeedbackDelay
+            ) {
+                withAnimation(.default) {
+                    self.previewVisibleTabs = nil
+                }
+            }
+        }
+    }
+
+    private func triggerDeniedFeedback(
+        for tabs: [AppTab],
+        after delay: TimeInterval = 0,
+        onShakeComplete: (() -> Void)? = nil
+    ) {
+        guard !tabs.isEmpty else { return }
+
+        let shakeDuration = TabOrderSettingsFeatures.shakeAnimationDuration
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            HapticFeedback.play(.medium, enabled: hapticFeedback)
+            withAnimation(.easeInOut(duration: shakeDuration)) {
+                for tab in tabs {
+                    deniedMoveAttempts[tab, default: 0] += 1
+                }
+            } completion: {
+                onShakeComplete?()
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TabOrderSettingsView()
+    }
+    .environment(AppState())
+}

--- a/fedi-readerTests/AppStateTests.swift
+++ b/fedi-readerTests/AppStateTests.swift
@@ -19,6 +19,29 @@ private func makeList(id: String, title: String) -> MastodonList {
     MastodonList(id: id, title: title, repliesPolicy: nil, exclusive: nil)
 }
 
+private func withPreservedTabConfiguration(_ operation: () async -> Void) async {
+    let defaults = UserDefaults.standard
+    let tabConfigurationKey = "tabConfiguration"
+    let legacyListsKey = AppState.listsInSeparateTabStorageKey
+    let previousConfiguration = defaults.data(forKey: tabConfigurationKey)
+    let previousLegacyListsValue = defaults.object(forKey: legacyListsKey)
+    defer {
+        if let previousConfiguration {
+            defaults.set(previousConfiguration, forKey: tabConfigurationKey)
+        } else {
+            defaults.removeObject(forKey: tabConfigurationKey)
+        }
+
+        if let previousLegacyListsValue {
+            defaults.set(previousLegacyListsValue, forKey: legacyListsKey)
+        } else {
+            defaults.removeObject(forKey: legacyListsKey)
+        }
+    }
+
+    await operation()
+}
+
 @Suite("AppState Tests")
 @MainActor
 struct AppStateTests {
@@ -101,6 +124,22 @@ struct AppStateTests {
         #expect(state.profileNavigationPath.isEmpty == true)
     }
 
+    @Test("navigate routes bookmarks destinations to the bookmarks navigation path")
+    func navigateRoutesBookmarksDestinationsToBookmarksPath() async {
+        let state = AppState()
+        let destination = NavigationDestination.article(
+            url: URL(string: "https://example.com/bookmarks")!,
+            status: nil
+        )
+
+        state.selectedTab = .bookmarks
+        state.navigate(to: destination)
+
+        #expect(state.bookmarksNavigationPath == [destination])
+        #expect(state.linksNavigationPath.isEmpty == true)
+        #expect(state.exploreNavigationPath.isEmpty == true)
+    }
+
     @Test("navigateBack removes the last explore destination")
     func navigateBackRemovesLastExploreDestination() async {
         let state = AppState()
@@ -125,6 +164,112 @@ struct AppStateTests {
         state.navigateToRoot()
 
         #expect(state.exploreNavigationPath.isEmpty == true)
+    }
+
+    @Test("resolved visible tabs default to home explore messages and profile")
+    func resolvedVisibleTabsUseDefaultConfiguration() async {
+        await withPreservedTabConfiguration {
+            let state = AppState()
+
+            #expect(state.resolvedVisibleTabs() == [.links, .explore, .mentions, .profile])
+        }
+    }
+
+    @Test("setTabVisibility does not hide home")
+    func setTabVisibilityDoesNotHideHome() async {
+        await withPreservedTabConfiguration {
+            let state = AppState()
+
+            state.setTabVisibility(.links, isVisible: false)
+
+            #expect(state.resolvedVisibleTabs().contains(.links))
+            #expect(state.resolvedHiddenTabs().contains(.links) == false)
+        }
+    }
+
+    @Test("setTabVisibility does not hide profile")
+    func setTabVisibilityDoesNotHideProfile() async {
+        await withPreservedTabConfiguration {
+            let state = AppState()
+
+            state.setTabVisibility(.profile, isVisible: false)
+
+            #expect(state.resolvedVisibleTabs().contains(.profile))
+            #expect(state.resolvedHiddenTabs().contains(.profile) == false)
+        }
+    }
+
+    @Test("moveTabs allows home to move away from the first position")
+    func moveTabsAllowsHomeToMoveAwayFromFirstPosition() async {
+        await withPreservedTabConfiguration {
+            let state = AppState()
+
+            state.moveTabs(fromOffsets: IndexSet(integer: 0), toOffset: 2)
+
+            #expect(state.resolvedVisibleTabs() == [.explore, .links, .mentions, .profile])
+        }
+    }
+
+    @Test("moveTabs keeps home and profile ahead of More when all tabs are visible")
+    func moveTabsKeepsHomeAndProfileAheadOfMoreWhenAllTabsAreVisible() async {
+        await withPreservedTabConfiguration {
+            let state = AppState()
+            state.setTabVisibility(.lists, isVisible: true)
+            state.setTabVisibility(.bookmarks, isVisible: true)
+
+            state.moveTabs(fromOffsets: IndexSet(integer: 0), toOffset: 6)
+            state.moveTabs(fromOffsets: IndexSet(integer: 2), toOffset: 6)
+
+            let primaryTabs = Array(state.resolvedVisibleTabs().prefix(4))
+            #expect(primaryTabs.contains(.links))
+            #expect(primaryTabs.contains(.profile))
+        }
+    }
+
+    @Test("moveTabs snaps profile back ahead of More after dragging it to the end")
+    func moveTabsSnapsProfileBackAheadOfMoreAfterDraggingItToTheEnd() async {
+        await withPreservedTabConfiguration {
+            let state = AppState()
+            state.setTabVisibility(.lists, isVisible: true)
+            state.setTabVisibility(.bookmarks, isVisible: true)
+
+            state.moveTabs(fromOffsets: IndexSet(integer: 3), toOffset: 6)
+
+            let primaryTabs = Array(state.resolvedVisibleTabs().prefix(4))
+            #expect(primaryTabs.contains(.profile))
+            #expect(TabOrderSettingsFeatures.tabsBehindMore(in: state.resolvedVisibleTabs()).contains(.profile) == false)
+        }
+    }
+
+    @Test("legacy separate lists setting migrates lists into visible tabs")
+    func legacySeparateListsSettingMigratesIntoVisibleTabs() async {
+        await withPreservedTabConfiguration {
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: "tabConfiguration")
+            defaults.set(true, forKey: AppState.listsInSeparateTabStorageKey)
+
+            let state = AppState()
+
+            #expect(state.resolvedVisibleTabs().contains(.lists))
+            #expect(state.resolvedHiddenTabs().contains(.lists) == false)
+        }
+    }
+
+    @Test("apply default link feed uses the current tab configuration for list tab visibility")
+    func applyDefaultLinkFeedUsesCurrentTabConfigurationForListTabVisibility() async {
+        await withPreservedTabConfiguration {
+            let state = AppState()
+            state.setTabVisibility(.lists, isVisible: true)
+
+            let feedID = state.applyDefaultLinkFeed(
+                defaultListId: "list-2",
+                availableListIDs: ["list-1", "list-2"]
+            )
+
+            #expect(feedID == "list-2")
+            #expect(state.selectedTab == .lists)
+            #expect(state.pendingListNavigationListID == "list-2")
+        }
     }
 
     @Test("resolved default link feed falls back to home when the configured list is unavailable")

--- a/fedi-readerTests/AppTabTests.swift
+++ b/fedi-readerTests/AppTabTests.swift
@@ -24,6 +24,7 @@ struct AppTabTests {
         let tabs = AppTab.allCases
         
         #expect(tabs.contains(.links))
+        #expect(tabs.contains(.bookmarks))
         #expect(tabs.contains(.explore))
         #expect(tabs.contains(.mentions))
         #expect(tabs.contains(.profile))
@@ -32,6 +33,168 @@ struct AppTabTests {
     @Test("Mentions tab uses Messages title")
     func mentionsTabUsesMessagesTitle() {
         #expect(AppTab.mentions.title == "Messages")
+    }
+
+    @Test("Bookmarks tab uses Bookmarks title")
+    func bookmarksTabUsesBookmarksTitle() {
+        #expect(AppTab.bookmarks.title == "Bookmarks")
+    }
+
+    @Test("Bookmarks tab uses bookmark icon")
+    func bookmarksTabUsesBookmarkIcon() {
+        #expect(AppTab.bookmarks.systemImage == "bookmark.fill")
+    }
+
+    @Test("Compact tab items keep their title metadata when labels are hidden")
+    func compactTabItemsKeepTheirTitleMetadataWhenLabelsAreHidden() {
+        #expect(
+            MainTabViewTabItemFeatures.title(for: .profile, useSidebarLayout: false, hideTabBarLabels: true) == "Profile"
+        )
+    }
+
+    @Test("Compact tab items switch to icon-only presentation when labels are hidden")
+    func compactTabItemsSwitchToIconOnlyPresentationWhenLabelsAreHidden() {
+        #expect(
+            MainTabViewTabItemFeatures.usesIconOnlyLabelStyle(useSidebarLayout: false, hideTabBarLabels: true)
+        )
+    }
+
+    @Test("Tab order features marks only overflow tabs as behind More")
+    func tabOrderFeaturesMarksOnlyOverflowTabsAsBehindMore() {
+        let tabsBehindMore = TabOrderSettingsFeatures.tabsBehindMore(
+            in: [.links, .explore, .mentions, .profile, .lists, .bookmarks]
+        )
+
+        #expect(tabsBehindMore == [.lists, .bookmarks])
+    }
+
+    @Test("Tab order features shows no overflow indicator when five or fewer tabs are visible")
+    func tabOrderFeaturesShowsNoOverflowIndicatorWhenFiveOrFewerTabsVisible() {
+        let tabsBehindMore = TabOrderSettingsFeatures.tabsBehindMore(
+            in: [.links, .explore, .mentions, .profile, .lists]
+        )
+
+        #expect(tabsBehindMore.isEmpty)
+    }
+
+    @Test("Tab order features uses disabled hide control for protected visible tabs")
+    func tabOrderFeaturesUsesDisabledHideControlForProtectedVisibleTabs() {
+        #expect(
+            TabOrderSettingsFeatures.visibilityControlStyle(for: .links, isVisible: true) == .hideDisabled
+        )
+        #expect(
+            TabOrderSettingsFeatures.visibilityControlStyle(for: .profile, isVisible: true) == .hideDisabled
+        )
+    }
+
+    @Test("Tab order features uses enabled controls for movable tabs")
+    func tabOrderFeaturesUsesEnabledControlsForMovableTabs() {
+        #expect(
+            TabOrderSettingsFeatures.visibilityControlStyle(for: .explore, isVisible: true) == .hideEnabled
+        )
+        #expect(
+            TabOrderSettingsFeatures.visibilityControlStyle(for: .bookmarks, isVisible: false) == .showEnabled
+        )
+    }
+
+    @Test("Tab order features delays denied move feedback until after the list settles")
+    func tabOrderFeaturesDelaysDeniedMoveFeedbackUntilAfterTheListSettles() {
+        #expect(TabOrderSettingsFeatures.deniedMoveFeedbackDelay > 0)
+    }
+
+    @Test("Tab order features uses shake animation duration for completion-based snap-back")
+    func tabOrderFeaturesUsesShakeAnimationDurationForCompletionBasedSnapBack() {
+        #expect(TabOrderSettingsFeatures.shakeAnimationDuration > 0.2)
+    }
+
+    @Test("Tab order features previews denied moves before snapping back")
+    func tabOrderFeaturesPreviewsDeniedMovesBeforeSnappingBack() {
+        let moveResult = TabOrderSettingsFeatures.moveResult(
+            visibleTabs: [.links, .explore, .mentions, .profile, .lists, .bookmarks],
+            fromOffsets: IndexSet(integer: 3),
+            toOffset: 6
+        )
+
+        #expect(
+            moveResult == .denied(
+                tabs: [.profile],
+                previewVisibleTabs: [.links, .explore, .mentions, .lists, .bookmarks, .profile]
+            )
+        )
+    }
+
+    @Test("Tab order features denies hiding protected tabs")
+    func tabOrderFeaturesDeniesHidingProtectedTabs() {
+        #expect(TabOrderSettingsFeatures.deniedVisibilityChangeTabs(for: .links, isVisible: false) == [.links])
+        #expect(TabOrderSettingsFeatures.deniedVisibilityChangeTabs(for: .profile, isVisible: false) == [.profile])
+    }
+
+    @Test("Tab order features allows hiding non protected tabs")
+    func tabOrderFeaturesAllowsHidingNonProtectedTabs() {
+        #expect(TabOrderSettingsFeatures.deniedVisibilityChangeTabs(for: .explore, isVisible: false).isEmpty)
+    }
+
+    @Test("Tab order features denies moving profile behind More")
+    func tabOrderFeaturesDeniesMovingProfileBehindMore() {
+        let moveResult = TabOrderSettingsFeatures.moveResult(
+            visibleTabs: [.links, .explore, .mentions, .profile, .lists, .bookmarks],
+            fromOffsets: IndexSet(integer: 3),
+            toOffset: 6
+        )
+
+        #expect(
+            moveResult == .denied(
+                tabs: [.profile],
+                previewVisibleTabs: [.links, .explore, .mentions, .lists, .bookmarks, .profile]
+            )
+        )
+    }
+
+    @Test("Tab order features denies moves that would push home behind More")
+    func tabOrderFeaturesDeniesMovesThatWouldPushHomeBehindMore() {
+        let moveResult = TabOrderSettingsFeatures.moveResult(
+            visibleTabs: [.links, .explore, .mentions, .profile, .lists, .bookmarks],
+            fromOffsets: IndexSet(integer: 4),
+            toOffset: 0
+        )
+
+        #expect(
+            moveResult == .denied(
+                tabs: [.profile],
+                previewVisibleTabs: [.lists, .links, .explore, .mentions, .profile, .bookmarks]
+            )
+        )
+    }
+
+    @Test("Tab order features allows protected tabs to move within the primary section")
+    func tabOrderFeaturesAllowsProtectedTabsToMoveWithinThePrimarySection() {
+        let moveResult = TabOrderSettingsFeatures.moveResult(
+            visibleTabs: [.links, .explore, .mentions, .profile, .lists, .bookmarks],
+            fromOffsets: IndexSet(integer: 3),
+            toOffset: 2
+        )
+
+        #expect(moveResult == .allowed(visibleTabs: [.links, .explore, .profile, .mentions, .lists, .bookmarks]))
+    }
+
+    @Test("Main tab selection falls back to home when the selected tab is no longer visible")
+    func mainTabSelectionFallsBackToHomeWhenSelectedTabIsHidden() {
+        let resolvedSelection = MainTabViewSelectionFeatures.resolvedSelection(
+            selectedTab: .bookmarks,
+            visibleTabs: [.links, .explore, .profile]
+        )
+
+        #expect(resolvedSelection == .links)
+    }
+
+    @Test("Main tab selection preserves a still-visible tab when the tab count shrinks")
+    func mainTabSelectionPreservesVisibleSelectionWhenTabCountShrinks() {
+        let resolvedSelection = MainTabViewSelectionFeatures.resolvedSelection(
+            selectedTab: .explore,
+            visibleTabs: [.links, .explore, .profile]
+        )
+
+        #expect(resolvedSelection == .explore)
     }
 }
 

--- a/fedi-readerTests/ListEditorEditModeFeaturesTests.swift
+++ b/fedi-readerTests/ListEditorEditModeFeaturesTests.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import Testing
+@testable import fedi_reader
+
+@Suite("List Editor Edit Mode Features Tests")
+struct ListEditorEditModeFeaturesTests {
+    @Test("tab order editor keeps edit mode active")
+    func tabOrderEditorKeepsEditModeActive() {
+        #expect(TabOrderSettingsFeatures.defaultEditMode == .active)
+    }
+
+    @Test("list display editor uses active edit mode for custom sorting")
+    func listDisplayEditorUsesActiveEditModeForCustomSorting() {
+        #expect(ListDisplaySettingsFeatures.editMode(isCustomSortOrder: true) == .active)
+    }
+
+    @Test("list display editor disables edit mode for non-custom sorting")
+    func listDisplayEditorDisablesEditModeForNonCustomSorting() {
+        #expect(ListDisplaySettingsFeatures.editMode(isCustomSortOrder: false) == .inactive)
+    }
+}

--- a/fedi-readerTests/MastodonClientTests.swift
+++ b/fedi-readerTests/MastodonClientTests.swift
@@ -58,6 +58,37 @@ struct MastodonClientTests {
         }
     }
 
+    @Test("getBookmarks uses the bookmarks endpoint with pagination and auth")
+    func getBookmarksUsesBookmarksEndpointWithPaginationAndAuth() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+            defer { MockURLProtocol.reset() }
+
+            let statuses = [
+                MockStatusFactory.makeStatus(id: "bookmark-1", hasCard: true, cardURL: "https://example.com/1"),
+                MockStatusFactory.makeStatus(id: "bookmark-2", hasCard: true, cardURL: "https://example.com/2")
+            ]
+            let url = bookmarksURL(instance: "mastodon.social", maxId: "bookmark-99", limit: 25)
+            MockURLProtocol.setMockResponse(
+                for: url,
+                data: try makeEncoder().encode(statuses)
+            )
+
+            let client = makeClient()
+
+            let resolved = try await client.getBookmarks(
+                instance: "mastodon.social",
+                accessToken: "secret-token",
+                maxId: "bookmark-99",
+                limit: 25
+            )
+
+            #expect(resolved.map(\.id) == ["bookmark-1", "bookmark-2"])
+            #expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret-token")
+            #expect(MockURLProtocol.lastRequest?.url?.path == "/api/v1/bookmarks")
+        }
+    }
+
     private func makeClient() -> MastodonClient {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
@@ -89,6 +120,18 @@ struct MastodonClientTests {
             URLQueryItem(name: "resolve", value: String(true)),
             URLQueryItem(name: "limit", value: String(limit)),
             URLQueryItem(name: "type", value: type)
+        ]
+        return components.url!.absoluteString
+    }
+
+    private func bookmarksURL(instance: String, maxId: String?, limit: Int) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/bookmarks"
+        components.queryItems = [
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "max_id", value: maxId)
         ]
         return components.url!.absoluteString
     }

--- a/fedi-readerTests/MockStatusFactory.swift
+++ b/fedi-readerTests/MockStatusFactory.swift
@@ -16,6 +16,7 @@ enum MockStatusFactory {
         isQuote: Bool = false,
         favourited: Bool = false,
         reblogged: Bool = false,
+        bookmarked: Bool = false,
         visibility: Visibility = .public,
         inReplyToId: String? = nil,
         repliesCount: Int = 2
@@ -68,7 +69,7 @@ enum MockStatusFactory {
             favourited: favourited,
             reblogged: reblogged,
             muted: false,
-            bookmarked: false,
+            bookmarked: bookmarked,
             pinned: false,
             inReplyToId: inReplyToId,
             inReplyToAccountId: nil

--- a/fedi-readerTests/TabConfigurationTests.swift
+++ b/fedi-readerTests/TabConfigurationTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import fedi_reader
+
+@Suite("Tab Configuration Tests")
+struct TabConfigurationTests {
+    @Test("default configuration shows home explore messages and profile")
+    func defaultConfigurationShowsExpectedVisibleTabs() {
+        #expect(
+            TabConfiguration.defaultConfiguration.visibleTabs == [.links, .explore, .mentions, .profile]
+        )
+        #expect(
+            TabConfiguration.defaultConfiguration.hiddenTabs == [.lists, .bookmarks]
+        )
+    }
+
+    @Test("normalization keeps home visible even if it was hidden")
+    func normalizationKeepsHomeVisible() {
+        let configuration = TabConfiguration(
+            visibleTabs: [.explore, .mentions, .profile],
+            hiddenTabs: [.links, .lists, .bookmarks]
+        )
+
+        let normalized = configuration.normalized()
+
+        #expect(normalized.visibleTabs.contains(.links))
+        #expect(normalized.hiddenTabs.contains(.links) == false)
+    }
+
+    @Test("normalization keeps profile visible even if it was hidden")
+    func normalizationKeepsProfileVisible() {
+        let configuration = TabConfiguration(
+            visibleTabs: [.links, .explore, .mentions],
+            hiddenTabs: [.profile, .lists, .bookmarks]
+        )
+
+        let normalized = configuration.normalized()
+
+        #expect(normalized.visibleTabs.contains(.profile))
+        #expect(normalized.hiddenTabs.contains(.profile) == false)
+    }
+
+    @Test("normalization preserves custom home position among visible tabs")
+    func normalizationPreservesCustomHomePosition() {
+        let configuration = TabConfiguration(
+            visibleTabs: [.explore, .links, .mentions, .profile],
+            hiddenTabs: [.lists, .bookmarks]
+        )
+
+        let normalized = configuration.normalized()
+
+        #expect(normalized.visibleTabs == [.explore, .links, .mentions, .profile])
+    }
+
+    @Test("normalization appends missing tabs to the hidden list")
+    func normalizationAppendsMissingTabsToHiddenList() {
+        let configuration = TabConfiguration(
+            visibleTabs: [.links, .explore],
+            hiddenTabs: []
+        )
+
+        let normalized = configuration.normalized()
+
+        #expect(normalized.visibleTabs == [.links, .explore, .profile])
+        #expect(normalized.hiddenTabs == [.lists, .mentions, .bookmarks])
+    }
+}

--- a/fedi-readerTests/TimelineServiceBookmarksTests.swift
+++ b/fedi-readerTests/TimelineServiceBookmarksTests.swift
@@ -1,0 +1,162 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Timeline Service Bookmarks Tests", .serialized)
+@MainActor
+struct TimelineServiceBookmarksTests {
+    @Test("refreshBookmarks loads bookmarks from the authenticated account")
+    func refreshBookmarksLoadsBookmarks() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = makeAccount()
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let statuses = [
+                MockStatusFactory.makeStatus(id: "bookmark-1"),
+                MockStatusFactory.makeStatus(id: "bookmark-2")
+            ]
+            MockURLProtocol.setMockResponse(
+                for: bookmarksURL(instance: account.instance, maxId: nil),
+                data: try makeEncoder().encode(statuses)
+            )
+
+            await service.refreshBookmarks()
+
+            #expect(service.bookmarks.map(\.id) == ["bookmark-1", "bookmark-2"])
+            #expect(MockURLProtocol.lastRequest?.value(forHTTPHeaderField: "Authorization") == "Bearer secret-token")
+        }
+    }
+
+    @Test("loadMoreBookmarks appends older bookmarked statuses")
+    func loadMoreBookmarksAppendsOlderBookmarkedStatuses() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = makeAccount()
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let initialStatuses = [
+                MockStatusFactory.makeStatus(id: "bookmark-1"),
+                MockStatusFactory.makeStatus(id: "bookmark-2")
+            ]
+            let olderStatuses = [
+                MockStatusFactory.makeStatus(id: "bookmark-3")
+            ]
+            MockURLProtocol.setMockResponse(
+                for: bookmarksURL(instance: account.instance, maxId: nil),
+                data: try makeEncoder().encode(initialStatuses)
+            )
+            MockURLProtocol.setMockResponse(
+                for: bookmarksURL(instance: account.instance, maxId: "bookmark-2"),
+                data: try makeEncoder().encode(olderStatuses)
+            )
+
+            await service.refreshBookmarks()
+            await service.loadMoreBookmarks()
+
+            #expect(service.bookmarks.map(\.id) == ["bookmark-1", "bookmark-2", "bookmark-3"])
+        }
+    }
+
+    @Test("bookmark action inserts newly bookmarked status into bookmarks timeline")
+    func bookmarkActionInsertsNewlyBookmarkedStatusIntoBookmarksTimeline() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = makeAccount()
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let status = MockStatusFactory.makeStatus(id: "bookmark-new")
+            let updatedStatus = MockStatusFactory.makeStatus(id: "bookmark-new", bookmarked: true)
+            MockURLProtocol.setMockResponse(
+                for: bookmarkActionURL(instance: account.instance, statusId: status.id),
+                data: try makeEncoder().encode(updatedStatus)
+            )
+
+            _ = try await service.bookmark(status: status)
+
+            #expect(service.bookmarks.map(\.id) == ["bookmark-new"])
+        }
+    }
+
+    private func makeClient() -> MastodonClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return MastodonClient(configuration: configuration)
+    }
+
+    private func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private func makeAccount() -> Account {
+        Account(
+            id: "mastodon.social:\(UUID().uuidString)",
+            instance: "mastodon.social",
+            username: "tester",
+            displayName: "Tester",
+            acct: "tester@mastodon.social",
+            isActive: true
+        )
+    }
+
+    private func bookmarksURL(instance: String, maxId: String?) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/bookmarks"
+        components.queryItems = [URLQueryItem(name: "limit", value: String(Constants.Pagination.defaultLimit))]
+        if let maxId {
+            components.queryItems?.append(URLQueryItem(name: "max_id", value: maxId))
+        }
+        return components.url!.absoluteString
+    }
+
+    private func bookmarkActionURL(instance: String, statusId: String) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/statuses/\(statusId)/bookmark"
+        return components.url!.absoluteString
+    }
+}


### PR DESCRIPTION
- Updated references from "Profile" to "Settings" for configuring Read Later services in AGENTS.md and README.md.
- Removed unused AppStorage for listsInSeparateTab in FediReaderApp.swift and SettingsView.swift.
- Enhanced AppState to manage new bookmarks and hashtags navigation paths.
- Implemented loading and refreshing functionality for bookmarks in TimelineService.
- Added support for fetching followed tags and managing hashtag timelines in MastodonClient.
- Improved LinkFeed and StatusDetail views to accommodate bookmarks and hashtag functionalities.

These changes streamline user navigation and enhance the overall experience with bookmarks and tags.