### PR TITLE
FEDI-52 add Safari viewer option for article links

### DIFF
--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -55,6 +55,7 @@ final class AppState {
     var mentionsNavigationPath: [NavigationDestination] = []
     var moreTabPath: [NavigationDestination] = []
     var presentedSheet: SheetDestination?
+    var presentedSafariURL: SafariPresentation?
     var presentedAlert: AlertItem?
     
     init() {
@@ -563,10 +564,20 @@ final class AppState {
     }
     
     func present(sheet: SheetDestination) {
-        Self.logger.info("Presenting sheet: \(sheet.id, privacy: .public)")
-        presentedSheet = sheet
+        switch sheet {
+        case .safariView(let url):
+            Self.logger.info("Presenting Safari full screen: \(url.absoluteString, privacy: .public)")
+            presentedSafariURL = SafariPresentation(url: url)
+        default:
+            Self.logger.info("Presenting sheet: \(sheet.id, privacy: .public)")
+            presentedSheet = sheet
+        }
     }
-    
+
+    func dismissSafari() {
+        presentedSafariURL = nil
+    }
+
     func dismissSheet() {
         if let sheet = presentedSheet {
             Self.logger.info("Dismissing sheet: \(sheet.id, privacy: .public)")
@@ -678,6 +689,18 @@ enum NavigationDestination: Hashable {
     case accountFollowers(accountId: String, account: MastodonAccount)
 }
 
+// MARK: - Safari Presentation
+
+struct SafariPresentation: Identifiable {
+    let id: String
+    let url: URL
+
+    init(url: URL) {
+        self.url = url
+        self.id = url.absoluteString
+    }
+}
+
 // MARK: - Sheet Destinations
 
 enum SheetDestination: Identifiable {
@@ -687,6 +710,7 @@ enum SheetDestination: Identifiable {
     case readLaterLogin(ReadLaterServiceType)
     case shareSheet(url: URL)
     case accountSwitcher
+    case safariView(url: URL)
     
     var id: String {
         switch self {
@@ -696,6 +720,7 @@ enum SheetDestination: Identifiable {
         case .readLaterLogin(let type): return "readLater-\(type.rawValue)"
         case .shareSheet: return "share"
         case .accountSwitcher: return "accountSwitcher"
+        case .safariView(let url): return "safari-\(url.absoluteString)"
         }
     }
 }

--- a/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
+++ b/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
@@ -16,11 +16,20 @@ struct TrendingLinkRow: View {
     let link: TrendingLink
     @Environment(AppState.self) private var appState
     @Environment(ReadLaterManager.self) private var readLaterManager
+    @AppStorage("useSafariViewer") private var useSafariViewer = false
 
     var body: some View {
         Button {
             if let url = link.linkURL {
+                #if os(iOS)
+                if useSafariViewer {
+                    appState.present(sheet: .safariView(url: url))
+                } else {
+                    appState.navigate(to: .article(url: url, status: nil))
+                }
+                #else
                 appState.navigate(to: .article(url: url, status: nil))
+                #endif
             }
         } label: {
             LinkCardContent(link: link)

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -19,6 +19,7 @@ struct LinkFeedThreeColumnView: View {
 
     @State private var selectedTabIndex: Int = 0
     @State private var selectedArticle: (url: URL, status: Status)?
+    @AppStorage("useSafariViewer") private var useSafariViewer = false
     @State private var scrollProxy: ScrollViewProxy?
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("threeColumnListsWidth") private var persistedListsWidth: Double = 200
@@ -343,7 +344,15 @@ struct LinkFeedThreeColumnView: View {
                     shouldBlockPostTaps: { false },
                     onItemAppear: { checkLoadMore(at: $0, totalCount: $1) },
                     onArticleSelect: { url, status in
+                        #if os(iOS)
+                        if useSafariViewer {
+                            appState.present(sheet: .safariView(url: url))
+                        } else {
+                            selectedArticle = (url: url, status: status)
+                        }
+                        #else
                         selectedArticle = (url: url, status: status)
+                        #endif
                     },
                     scrollProxy: $scrollProxy,
                     onFirstVisibleChange: { statusId in

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedTwoColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedTwoColumnView.swift
@@ -21,6 +21,7 @@ struct LinkFeedTwoColumnView: View {
 
     @State private var selectedArticle: (url: URL, status: Status)?
     @AppStorage("linkFeedTwoColumnPostsWidth") private var persistedPostsWidth: Double = 350
+    @AppStorage("useSafariViewer") private var useSafariViewer = false
     @State private var postsWidth: Double = 350
 
     private static let minPostsWidth: CGFloat = 280
@@ -94,7 +95,15 @@ struct LinkFeedTwoColumnView: View {
 
             HStack(spacing: 0) {
                 LinkFeedContentView(onArticleSelect: { url, status in
+                    #if os(iOS)
+                    if useSafariViewer {
+                        appState.present(sheet: .safariView(url: url))
+                    } else {
+                        selectedArticle = (url, status)
+                    }
+                    #else
                     selectedArticle = (url, status)
+                    #endif
                 }, feedTabsOverride: feedTabsOverride, showsFeedPicker: showsFeedPicker, allowsSwipeNavigation: allowsSwipeNavigation, titleOverride: titleOverride, userFilterToolbarPlacement: userFilterToolbarPlacement)
                 .frame(width: layout.postsWidth)
                 .background(Color(.systemBackground))

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
@@ -26,6 +26,7 @@ struct LinkStatusRow: View {
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+    @AppStorage("useSafariViewer") private var useSafariViewer = false
 
     @State private var blueskyDescription: String?
     @State private var hasLoadedBlueskyDescription = false
@@ -216,7 +217,15 @@ struct LinkStatusRow: View {
                 if let onArticleSelect {
                     onArticleSelect(linkStatus.primaryURL, linkStatus.status)
                 } else {
+                    #if os(iOS)
+                    if useSafariViewer {
+                        appState.present(sheet: .safariView(url: linkStatus.primaryURL))
+                    } else {
+                        appState.navigate(to: .article(url: linkStatus.primaryURL, status: linkStatus.status))
+                    }
+                    #else
                     appState.navigate(to: .article(url: linkStatus.primaryURL, status: linkStatus.status))
+                    #endif
                 }
             }
         } label: {

--- a/fedi-reader/Views/Feed/StatusDetailRowView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailRowView.swift
@@ -5,6 +5,7 @@ struct StatusDetailRowView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openURL) private var openURL
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+    @AppStorage("useSafariViewer") private var useSafariViewer = false
 
     @State private var authorAttribution: AuthorAttribution?
     @State private var resolvedAuthorAccount: MastodonAccount?
@@ -99,7 +100,15 @@ struct StatusDetailRowView: View {
             if let card = displayStatus.card, card.type == .link {
                 Button {
                     if let url = card.linkURL {
+                        #if os(iOS)
+                        if useSafariViewer {
+                            appState.present(sheet: .safariView(url: url))
+                        } else {
+                            appState.navigate(to: .article(url: url, status: status))
+                        }
+                        #else
                         appState.navigate(to: .article(url: url, status: status))
+                        #endif
                     }
                 } label: {
                     LinkCardContent(

--- a/fedi-reader/Views/Feed/StatusRowView.swift
+++ b/fedi-reader/Views/Feed/StatusRowView.swift
@@ -8,6 +8,7 @@ struct StatusRowView: View {
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+    @AppStorage("useSafariViewer") private var useSafariViewer = false
     
     @State private var blueskyDescription: String?
     @State private var hasLoadedBlueskyDescription = false
@@ -336,7 +337,15 @@ struct StatusRowView: View {
     private func linkCard(_ card: PreviewCard) -> some View {
         Button {
             if let url = card.linkURL {
+                #if os(iOS)
+                if useSafariViewer {
+                    appState.present(sheet: .safariView(url: url))
+                } else {
+                    appState.navigate(to: .article(url: url, status: status))
+                }
+                #else
                 appState.navigate(to: .article(url: url, status: status))
+                #endif
             }
         } label: {
             VStack(alignment: .leading, spacing: 0) {

--- a/fedi-reader/Views/Root/ContentView.swift
+++ b/fedi-reader/Views/Root/ContentView.swift
@@ -59,6 +59,14 @@ struct ContentView: View {
         .sheet(item: $state.presentedSheet) { sheet in
             sheetContent(for: sheet)
         }
+        #if os(iOS)
+        .fullScreenCover(item: $state.presentedSafariURL) { presentation in
+            SFSafariView(url: presentation.url) {
+                state.dismissSafari()
+            }
+            .ignoresSafeArea()
+        }
+        #endif
         .alert(item: $state.presentedAlert) { alert in
             Alert(
                 title: Text(alert.title),
@@ -101,6 +109,8 @@ struct ContentView: View {
         case .accountSwitcher:
             AccountSwitcherView()
                 .environment(appState)
+        case .safariView:
+            EmptyView()
         }
     }
 }

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -17,6 +17,7 @@ struct SettingsView: View {
     @AppStorage("defaultListId") private var defaultListId = ""
     @AppStorage("showQuoteBoost") private var showQuoteBoost = true
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+    @AppStorage("useSafariViewer") private var useSafariViewer = false
 
     private var accountID: String? {
         appState.currentAccount?.id
@@ -60,6 +61,7 @@ struct SettingsView: View {
                     defaultListId: $defaultListId,
                     showQuoteBoost: $showQuoteBoost,
                     showHandleInFeed: $showHandleInFeed,
+                    useSafariViewer: $useSafariViewer,
                     lists: lists,
                     isCompactDevice: isCompactDevice
                 )
@@ -88,6 +90,13 @@ struct SettingsView: View {
                 Toggle("Auto-play GIFs", isOn: $autoPlayGifs)
                 Toggle("Hide Tab Bar Labels", isOn: $hideTabBarLabels)
                 Toggle("Show Handle in Feed", isOn: $showHandleInFeed)
+
+                #if os(iOS)
+                Picker("Article Viewer", selection: $useSafariViewer) {
+                    Text("FediReader").tag(false)
+                    Text("Safari").tag(true)
+                }
+                #endif
 
                 NavigationLink(value: NavigationDestination.tabOrder) {
                     Label("Tab Order", systemImage: "rectangle.3.group")
@@ -221,6 +230,7 @@ private struct SettingsTwoColumnView: View {
     @Binding var defaultListId: String
     @Binding var showQuoteBoost: Bool
     @Binding var showHandleInFeed: Bool
+    @Binding var useSafariViewer: Bool
     let lists: [MastodonList]
     let isCompactDevice: Bool
 
@@ -364,6 +374,16 @@ private struct SettingsTwoColumnView: View {
                     settingsToggleRow("Auto-play GIFs", isOn: $autoPlayGifs)
                     settingsToggleRow("Hide Tab Bar Labels", isOn: $hideTabBarLabels)
                     settingsToggleRow("Show Handle in Feed", isOn: $showHandleInFeed)
+                    #if os(iOS)
+                    Picker(selection: $useSafariViewer) {
+                        Text("FediReader").tag(false)
+                        Text("Safari").tag(true)
+                    } label: {
+                        Text("Article Viewer").font(.roundedBody)
+                    }
+                    .pickerStyle(.menu)
+                    .listRowInsets(Self.detailRowInsets)
+                    #endif
                     NavigationLink(value: NavigationDestination.tabOrder) {
                         Label("Tab Order", systemImage: "rectangle.3.group")
                             .font(.roundedBody)

--- a/fedi-reader/Views/Web/SFSafariView.swift
+++ b/fedi-reader/Views/Web/SFSafariView.swift
@@ -1,0 +1,50 @@
+//
+//  SFSafariView.swift
+//  fedi-reader
+//
+//  UIViewControllerRepresentable wrapper for SFSafariViewController (iOS only).
+//
+
+import SwiftUI
+#if os(iOS)
+import SafariServices
+
+struct SFSafariView: UIViewControllerRepresentable {
+    let url: URL
+    var onDismiss: (() -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onDismiss: onDismiss)
+    }
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<SFSafariView>) -> SFSafariViewController {
+        let configuration = SFSafariViewController.Configuration()
+        configuration.barCollapsingEnabled = false
+        let controller = SFSafariViewController(url: url, configuration: configuration)
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: UIViewControllerRepresentableContext<SFSafariView>) {}
+
+    final class Coordinator: NSObject, SFSafariViewControllerDelegate {
+        let onDismiss: (() -> Void)?
+
+        init(onDismiss: (() -> Void)?) {
+            self.onDismiss = onDismiss
+        }
+
+        func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+            onDismiss?()
+        }
+    }
+}
+#elseif os(macOS)
+struct SFSafariView: View {
+    let url: URL
+
+    var body: some View {
+        EmptyView()
+    }
+}
+#endif


### PR DESCRIPTION
- Introduced a new setting to allow users to choose between viewing articles in the app or using Safari.
- Updated AppState to manage Safari presentation and dismiss functionality.
- Enhanced various views (StatusDetailRowView, StatusRowView, TrendingLinkRow, etc.) to present links based on the user's preference.
- Implemented full-screen Safari view for iOS, improving the user experience when accessing external links.

These changes provide users with more flexibility in how they view articles, enhancing overall navigation and usability.