### PR TITLE
FEDI-51 refactor: update article viewer preference handling across views

### DIFF
--- a/fedi-reader/App/FediReaderApp.swift
+++ b/fedi-reader/App/FediReaderApp.swift
@@ -21,6 +21,10 @@ private enum AppIntentsDependency {
 struct FediReaderApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
+    init() {
+        _ = ArticleViewerPreference.resolved()
+    }
+
     var sharedModelContainer: ModelContainer = {
         let schema = Schema([
             Account.self,

--- a/fedi-reader/Utilities/ArticleViewerPreference.swift
+++ b/fedi-reader/Utilities/ArticleViewerPreference.swift
@@ -1,0 +1,53 @@
+//
+//  ArticleViewerPreference.swift
+//  fedi-reader
+//
+//  User preference for how to open article links.
+//
+
+import Foundation
+
+enum ArticleViewerPreference: String, CaseIterable, Sendable {
+    case inApp = "inApp"
+    case safari = "safari"      // iOS only: SFSafariViewController
+    case externalBrowser = "external"
+
+    var displayName: String {
+        switch self {
+        case .inApp: return "FediReader"
+        case .safari: return "Safari"
+        case .externalBrowser: return "External Browser"
+        }
+    }
+
+    /// Options available on the current platform (Safari in-app only on iOS).
+    static var platformOptions: [ArticleViewerPreference] {
+        #if os(iOS)
+        return [.inApp, .safari, .externalBrowser]
+        #else
+        return [.inApp, .externalBrowser]
+        #endif
+    }
+
+    /// Resolves raw string from storage, defaulting to inApp for invalid values.
+    static func from(raw: String) -> ArticleViewerPreference {
+        ArticleViewerPreference(rawValue: raw) ?? .inApp
+    }
+
+    /// Resolves stored preference with migration from legacy useSafariViewer.
+    static func resolved(from storageKey: String = "articleViewerPreference", defaults: UserDefaults = .standard) -> ArticleViewerPreference {
+        if let raw = defaults.string(forKey: storageKey), let pref = ArticleViewerPreference(rawValue: raw) {
+            return pref
+        }
+        // Migrate from legacy useSafariViewer
+        let legacyKey = "useSafariViewer"
+        if defaults.object(forKey: legacyKey) != nil {
+            let useSafari = defaults.bool(forKey: legacyKey)
+            let migrated: ArticleViewerPreference = useSafari ? .safari : .inApp
+            defaults.set(migrated.rawValue, forKey: storageKey)
+            defaults.removeObject(forKey: legacyKey)
+            return migrated
+        }
+        return .inApp
+    }
+}

--- a/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
+++ b/fedi-reader/Views/Feed/ExploreFeedView/TrendingLinkRow.swift
@@ -15,21 +15,26 @@ import AppKit
 struct TrendingLinkRow: View {
     let link: TrendingLink
     @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
     @Environment(ReadLaterManager.self) private var readLaterManager
-    @AppStorage("useSafariViewer") private var useSafariViewer = false
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
 
     var body: some View {
         Button {
             if let url = link.linkURL {
-                #if os(iOS)
-                if useSafariViewer {
+                let pref = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
+                switch pref {
+                case .externalBrowser:
+                    openURL(url)
+                case .safari:
+                    #if os(iOS)
                     appState.present(sheet: .safariView(url: url))
-                } else {
+                    #else
+                    openURL(url)
+                    #endif
+                case .inApp:
                     appState.navigate(to: .article(url: url, status: nil))
                 }
-                #else
-                appState.navigate(to: .article(url: url, status: nil))
-                #endif
             }
         } label: {
             LinkCardContent(link: link)

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -12,6 +12,7 @@ import UIKit
 
 struct LinkFeedThreeColumnView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
     @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @Environment(\.layoutMode) private var layoutMode
@@ -19,7 +20,7 @@ struct LinkFeedThreeColumnView: View {
 
     @State private var selectedTabIndex: Int = 0
     @State private var selectedArticle: (url: URL, status: Status)?
-    @AppStorage("useSafariViewer") private var useSafariViewer = false
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
     @State private var scrollProxy: ScrollViewProxy?
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("threeColumnListsWidth") private var persistedListsWidth: Double = 200
@@ -344,15 +345,19 @@ struct LinkFeedThreeColumnView: View {
                     shouldBlockPostTaps: { false },
                     onItemAppear: { checkLoadMore(at: $0, totalCount: $1) },
                     onArticleSelect: { url, status in
-                        #if os(iOS)
-                        if useSafariViewer {
+                        let pref = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
+                        switch pref {
+                        case .externalBrowser:
+                            openURL(url)
+                        case .safari:
+                            #if os(iOS)
                             appState.present(sheet: .safariView(url: url))
-                        } else {
+                            #else
+                            openURL(url)
+                            #endif
+                        case .inApp:
                             selectedArticle = (url: url, status: status)
                         }
-                        #else
-                        selectedArticle = (url: url, status: status)
-                        #endif
                     },
                     scrollProxy: $scrollProxy,
                     onFirstVisibleChange: { statusId in

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedTwoColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedTwoColumnView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct LinkFeedTwoColumnView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
     @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
 
@@ -21,7 +22,7 @@ struct LinkFeedTwoColumnView: View {
 
     @State private var selectedArticle: (url: URL, status: Status)?
     @AppStorage("linkFeedTwoColumnPostsWidth") private var persistedPostsWidth: Double = 350
-    @AppStorage("useSafariViewer") private var useSafariViewer = false
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
     @State private var postsWidth: Double = 350
 
     private static let minPostsWidth: CGFloat = 280
@@ -95,15 +96,19 @@ struct LinkFeedTwoColumnView: View {
 
             HStack(spacing: 0) {
                 LinkFeedContentView(onArticleSelect: { url, status in
-                    #if os(iOS)
-                    if useSafariViewer {
+                    let pref = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
+                    switch pref {
+                    case .externalBrowser:
+                        openURL(url)
+                    case .safari:
+                        #if os(iOS)
                         appState.present(sheet: .safariView(url: url))
-                    } else {
+                        #else
+                        openURL(url)
+                        #endif
+                    case .inApp:
                         selectedArticle = (url, status)
                     }
-                    #else
-                    selectedArticle = (url, status)
-                    #endif
                 }, feedTabsOverride: feedTabsOverride, showsFeedPicker: showsFeedPicker, allowsSwipeNavigation: allowsSwipeNavigation, titleOverride: titleOverride, userFilterToolbarPlacement: userFilterToolbarPlacement)
                 .frame(width: layout.postsWidth)
                 .background(Color(.systemBackground))

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
@@ -26,7 +26,7 @@ struct LinkStatusRow: View {
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
-    @AppStorage("useSafariViewer") private var useSafariViewer = false
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
 
     @State private var blueskyDescription: String?
     @State private var hasLoadedBlueskyDescription = false
@@ -217,15 +217,19 @@ struct LinkStatusRow: View {
                 if let onArticleSelect {
                     onArticleSelect(linkStatus.primaryURL, linkStatus.status)
                 } else {
-                    #if os(iOS)
-                    if useSafariViewer {
+                    let pref = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
+                    switch pref {
+                    case .externalBrowser:
+                        openURL(linkStatus.primaryURL)
+                    case .safari:
+                        #if os(iOS)
                         appState.present(sheet: .safariView(url: linkStatus.primaryURL))
-                    } else {
+                        #else
+                        openURL(linkStatus.primaryURL)
+                        #endif
+                    case .inApp:
                         appState.navigate(to: .article(url: linkStatus.primaryURL, status: linkStatus.status))
                     }
-                    #else
-                    appState.navigate(to: .article(url: linkStatus.primaryURL, status: linkStatus.status))
-                    #endif
                 }
             }
         } label: {

--- a/fedi-reader/Views/Feed/StatusDetailRowView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailRowView.swift
@@ -5,7 +5,7 @@ struct StatusDetailRowView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openURL) private var openURL
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
-    @AppStorage("useSafariViewer") private var useSafariViewer = false
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
 
     @State private var authorAttribution: AuthorAttribution?
     @State private var resolvedAuthorAccount: MastodonAccount?
@@ -100,15 +100,19 @@ struct StatusDetailRowView: View {
             if let card = displayStatus.card, card.type == .link {
                 Button {
                     if let url = card.linkURL {
-                        #if os(iOS)
-                        if useSafariViewer {
+                        let pref = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
+                        switch pref {
+                        case .externalBrowser:
+                            openURL(url)
+                        case .safari:
+                            #if os(iOS)
                             appState.present(sheet: .safariView(url: url))
-                        } else {
+                            #else
+                            openURL(url)
+                            #endif
+                        case .inApp:
                             appState.navigate(to: .article(url: url, status: status))
                         }
-                        #else
-                        appState.navigate(to: .article(url: url, status: status))
-                        #endif
                     }
                 } label: {
                     LinkCardContent(

--- a/fedi-reader/Views/Feed/StatusRowView.swift
+++ b/fedi-reader/Views/Feed/StatusRowView.swift
@@ -8,7 +8,7 @@ struct StatusRowView: View {
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
-    @AppStorage("useSafariViewer") private var useSafariViewer = false
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
     
     @State private var blueskyDescription: String?
     @State private var hasLoadedBlueskyDescription = false
@@ -337,15 +337,19 @@ struct StatusRowView: View {
     private func linkCard(_ card: PreviewCard) -> some View {
         Button {
             if let url = card.linkURL {
-                #if os(iOS)
-                if useSafariViewer {
+                let pref = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
+                switch pref {
+                case .externalBrowser:
+                    openURL(url)
+                case .safari:
+                    #if os(iOS)
                     appState.present(sheet: .safariView(url: url))
-                } else {
+                    #else
+                    openURL(url)
+                    #endif
+                case .inApp:
                     appState.navigate(to: .article(url: url, status: status))
                 }
-                #else
-                appState.navigate(to: .article(url: url, status: status))
-                #endif
             }
         } label: {
             VStack(alignment: .leading, spacing: 0) {

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
     @AppStorage("defaultListId") private var defaultListId = ""
     @AppStorage("showQuoteBoost") private var showQuoteBoost = true
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
-    @AppStorage("useSafariViewer") private var useSafariViewer = false
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
 
     private var accountID: String? {
         appState.currentAccount?.id
@@ -61,7 +61,7 @@ struct SettingsView: View {
                     defaultListId: $defaultListId,
                     showQuoteBoost: $showQuoteBoost,
                     showHandleInFeed: $showHandleInFeed,
-                    useSafariViewer: $useSafariViewer,
+                    articleViewerPreferenceRaw: $articleViewerPreferenceRaw,
                     lists: lists,
                     isCompactDevice: isCompactDevice
                 )
@@ -91,12 +91,11 @@ struct SettingsView: View {
                 Toggle("Hide Tab Bar Labels", isOn: $hideTabBarLabels)
                 Toggle("Show Handle in Feed", isOn: $showHandleInFeed)
 
-                #if os(iOS)
-                Picker("Article Viewer", selection: $useSafariViewer) {
-                    Text("FediReader").tag(false)
-                    Text("Safari").tag(true)
+                Picker("Article Viewer", selection: $articleViewerPreferenceRaw) {
+                    ForEach(ArticleViewerPreference.platformOptions, id: \.rawValue) { option in
+                        Text(option.displayName).tag(option.rawValue)
+                    }
                 }
-                #endif
 
                 NavigationLink(value: NavigationDestination.tabOrder) {
                     Label("Tab Order", systemImage: "rectangle.3.group")
@@ -230,7 +229,7 @@ private struct SettingsTwoColumnView: View {
     @Binding var defaultListId: String
     @Binding var showQuoteBoost: Bool
     @Binding var showHandleInFeed: Bool
-    @Binding var useSafariViewer: Bool
+    @Binding var articleViewerPreferenceRaw: String
     let lists: [MastodonList]
     let isCompactDevice: Bool
 
@@ -374,16 +373,15 @@ private struct SettingsTwoColumnView: View {
                     settingsToggleRow("Auto-play GIFs", isOn: $autoPlayGifs)
                     settingsToggleRow("Hide Tab Bar Labels", isOn: $hideTabBarLabels)
                     settingsToggleRow("Show Handle in Feed", isOn: $showHandleInFeed)
-                    #if os(iOS)
-                    Picker(selection: $useSafariViewer) {
-                        Text("FediReader").tag(false)
-                        Text("Safari").tag(true)
+                    Picker(selection: $articleViewerPreferenceRaw) {
+                        ForEach(ArticleViewerPreference.platformOptions, id: \.rawValue) { option in
+                            Text(option.displayName).tag(option.rawValue)
+                        }
                     } label: {
                         Text("Article Viewer").font(.roundedBody)
                     }
                     .pickerStyle(.menu)
                     .listRowInsets(Self.detailRowInsets)
-                    #endif
                     NavigationLink(value: NavigationDestination.tabOrder) {
                         Label("Tab Order", systemImage: "rectangle.3.group")
                             .font(.roundedBody)


### PR DESCRIPTION
- Replaced the use of `useSafariViewer` with `articleViewerPreference` to allow users to select their preferred method for viewing articles.
- Updated various views (StatusDetailRowView, StatusRowView, TrendingLinkRow, etc.) to utilize the new preference, enhancing flexibility in link handling.
- Introduced initialization of `ArticleViewerPreference` in `FediReaderApp` to ensure consistent preference resolution at app launch.

These changes improve user experience by providing a more cohesive and customizable article viewing option.