### PR TITLE
FEDI-64 Remove manual haptic toggles in favor of system control

### DIFF
--- a/.agents/skills/linear-workflow/SKILL.md
+++ b/.agents/skills/linear-workflow/SKILL.md
@@ -18,19 +18,21 @@ description: ALWAYS check for linked Linear issue and follow conventions before 
 
 ## Instructions
 
-1. **Check branch** via `git branch --show-current`. Parse for Linear ID (e.g. `FED-123`, `PROJ-456`). Valid patterns: `FED-123-feature-name`, `sam/FED-456-fix`, `feature/FED-789-thing`.
+1. **Check branch** via `git branch --show-current`. Parse for Linear ID (e.g. `FEDI-123`, `PROJ-456`). Valid patterns: `FEDI-123-feature-name`, `sam/FEDI-456-fix`, `CountableNewt/issue92-feature-name`.
 
-2. **Confirm issue exists** via Linear MCP `get_issue` or `list_issues`.
+2. **If no Linear ID but branch has GitHub issue** (e.g. `issue92`): Every GitHub issue has a Linear comment linking the issue. Use `list_issues` with a `query` matching the branch/task to find the linked Linear issue.
 
-3. **Set In Progress** via `save_issue` with `state: "In Progress"` before making code changes or creating plans.
+3. **Confirm issue exists** via Linear MCP `get_issue` or `list_issues`.
 
-4. **During planning**: Add comments via `create_comment`—when drafting a plan, summarize the approach or key decisions on the Linear issue.
+4. **Set In Progress** via `save_issue` with `state: "In Progress"` before making code changes or creating plans.
 
-5. **During implementation**: Include the full plan via `create_comment`—when implementing from a `.plan.md` file, paste the **entire plan content** as a Linear comment so reviewers have full context.
+5. **During planning**: Add comments via `save_comment`—when drafting a plan, summarize the approach or key decisions on the Linear issue.
 
-6. **Add comments as you work** via `create_comment`—implementations, decisions, blockers.
+6. **During implementation**: Include the full plan via `save_comment`—when implementing from a `.plan.md` file, paste the **entire plan content** as a Linear comment so reviewers have full context.
 
-7. **Do not mark Done**—let Linear–GitHub integration set Done when the PR is merged.
+7. **Add comments as you work** via `save_comment`—implementations, decisions, blockers.
+
+8. **Do not mark Done**—let Linear–GitHub integration set Done when the PR is merged.
 
 If no Linear issue exists (e.g. branch is `main` or doesn’t match patterns), proceed without Linear updates—but **always check first**.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,10 @@
 
 **Linear is the source of truth, not GitHub.** Before any code edits or plan creation:
 
-1. Run `git branch --show-current`. Parse for Linear ID (e.g. `FED-123`). Valid patterns: `FED-123-feature-name`, `sam/FED-456-fix`.
+1. Run `git branch --show-current`. Parse for Linear ID (e.g. `FEDI-123`). Valid patterns: `FEDI-123-feature-name`, `sam/FEDI-456-fix`, `CountableNewt/issue92-...`.
 2. **If Linear ID found**: Use Linear MCP `get_issue` to confirm, then `save_issue` with `state: "In Progress"` before touching code or creating plans.
-3. **If no Linear ID** (e.g. `main`): Proceed without Linear updates.
+3. **If no Linear ID but branch has GitHub issue** (e.g. `issue92`, `CountableNewt/issue92-haptic-feedback`): Every GitHub issue has a Linear comment linking the issue. Use Linear MCP `list_issues` with a `query` matching the branch/task (e.g. "haptic feedback") to find the linked Linear issue, then proceed as above.
+4. **If no Linear ID** (e.g. `main`): Proceed without Linear updates.
 
 Apply in **both plan mode and implementation**—do not skip because you are "only planning."
 

--- a/fedi-reader/Utilities/Constants/Constants.swift
+++ b/fedi-reader/Utilities/Constants/Constants.swift
@@ -87,7 +87,6 @@ enum Constants {
     
     enum UI {
         static let defaultAnimationDuration: Double = 0.3
-        static let hapticFeedbackEnabled = true
         static let maxContentPreviewLines = 6
         static let avatarSize: CGFloat = 40
         static let smallAvatarSize: CGFloat = 28

--- a/fedi-reader/Utilities/HapticFeedback.swift
+++ b/fedi-reader/Utilities/HapticFeedback.swift
@@ -2,7 +2,8 @@
 //  HapticFeedback.swift
 //  fedi-reader
 //
-//  Haptic feedback utility that respects user settings
+//  Haptic feedback utility. The system automatically respects the user's
+//  Settings > Sounds & Haptics > System Haptics preference.
 //
 
 import SwiftUI
@@ -36,9 +37,7 @@ struct HapticFeedback {
     private static var selectionGenerator: UISelectionFeedbackGenerator?
     #endif
     
-    static func play(_ style: Style, enabled: Bool = true) {
-        guard enabled else { return }
-        
+    static func play(_ style: Style) {
         #if os(iOS)
         switch style {
         case .light:

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -132,7 +132,6 @@ struct LinkFeedContentView: View {
     @Environment(AppState.self) private var appState
     @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
-    @AppStorage("hapticFeedback") private var hapticFeedback = true
 
     @State private var selectedTabIndex: Int = 0
     @State private var scrollProxy: ScrollViewProxy?
@@ -492,7 +491,7 @@ struct LinkFeedContentView: View {
         let isDoubleTap = feedTabSelectionTracker.recordSelection(tab.id)
 
         if isSelected, isDoubleTap {
-            HapticFeedback.play(.medium, enabled: hapticFeedback)
+            HapticFeedback.play(.medium)
             appState.requestLinksScrollToTop()
             return
         }

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -16,7 +16,6 @@ struct LinkFeedThreeColumnView: View {
     @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @Environment(\.layoutMode) private var layoutMode
-    @AppStorage("hapticFeedback") private var hapticFeedback = true
 
     @State private var selectedTabIndex: Int = 0
     @State private var selectedArticle: (url: URL, status: Status)?
@@ -419,7 +418,7 @@ struct LinkFeedThreeColumnView: View {
         let isDoubleTap = feedTabSelectionTracker.recordSelection(tab.id)
 
         if isSelected, isDoubleTap {
-            HapticFeedback.play(.medium, enabled: hapticFeedback)
+            HapticFeedback.play(.medium)
             appState.requestLinksScrollToTop()
             return
         }

--- a/fedi-reader/Views/Root/MainTabView.swift
+++ b/fedi-reader/Views/Root/MainTabView.swift
@@ -10,7 +10,6 @@ struct MainTabView: View {
     @Environment(\.layoutMode) private var layoutMode
 
     @State private var tabTracker = TabSelectionTracker()
-    @AppStorage("hapticFeedback") private var hapticFeedback = true
     @AppStorage("hideTabBarLabels") private var hideTabBarLabels = false
 
     private var unreadMentionsCount: Int {
@@ -35,7 +34,7 @@ struct MainTabView: View {
         mainTabView()
             .animation(.easeInOut(duration: 0.25), value: hideTabBarLabels)
             .onChange(of: state.selectedTab) { oldValue, newValue in
-            HapticFeedback.play(.selection, enabled: hapticFeedback && !useSidebarLayout)
+            HapticFeedback.play(.selection)
             let primaryTabs = Array(visibleTabs.prefix(4))
             if primaryTabs.contains(newValue) {
                 state.moreTabPath.removeAll()
@@ -454,7 +453,7 @@ struct MainTabView: View {
                 let isDoubleTap = tabTracker.recordSelection(.links)
                 if isDoubleTap {
                     appState.requestLinksScrollToTop()
-                    HapticFeedback.play(.medium, enabled: hapticFeedback && !useSidebarLayout)
+                    HapticFeedback.play(.medium)
                 }
             } else {
                 tabTracker.reset()

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -11,7 +11,6 @@ struct SettingsView: View {
     @AppStorage("showImages") private var showImages = true
     @AppStorage("autoPlayGifs") private var autoPlayGifs = false
     @AppStorage("defaultVisibility") private var defaultVisibility = "public"
-    @AppStorage("hapticFeedback") private var hapticFeedback = true
     @AppStorage("hideTabBarLabels") private var hideTabBarLabels = false
     @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("defaultListId") private var defaultListId = ""
@@ -55,7 +54,6 @@ struct SettingsView: View {
                     showImages: $showImages,
                     autoPlayGifs: $autoPlayGifs,
                     defaultVisibility: $defaultVisibility,
-                    hapticFeedback: $hapticFeedback,
                     hideTabBarLabels: $hideTabBarLabels,
                     themeColorName: $themeColorName,
                     defaultListId: $defaultListId,
@@ -160,13 +158,6 @@ struct SettingsView: View {
                 Toggle("Show Quote Boost Option", isOn: $showQuoteBoost)
             }
             
-            // Accessibility
-            if isCompactDevice {
-                Section("Accessibility") {
-                    Toggle("Haptic Feedback", isOn: $hapticFeedback)
-                }
-            }
-            
             // About
             Section("About") {
                 HStack {
@@ -225,7 +216,6 @@ private struct SettingsTwoColumnView: View {
     @Binding var showImages: Bool
     @Binding var autoPlayGifs: Bool
     @Binding var defaultVisibility: String
-    @Binding var hapticFeedback: Bool
     @Binding var hideTabBarLabels: Bool
     @Binding var themeColorName: String
     @Binding var defaultListId: String
@@ -252,7 +242,6 @@ private struct SettingsTwoColumnView: View {
         case readLater
         case timeline
         case posting
-        case accessibility
         case about
         case debug
 
@@ -265,7 +254,6 @@ private struct SettingsTwoColumnView: View {
             case .readLater: return "Read Later"
             case .timeline: return "Timeline"
             case .posting: return "Posting"
-            case .accessibility: return "Accessibility"
             case .about: return "About"
             case .debug: return "Debug"
             }
@@ -278,7 +266,6 @@ private struct SettingsTwoColumnView: View {
             case .readLater: return "bookmark"
             case .timeline: return "list.bullet"
             case .posting: return "square.and.pencil"
-            case .accessibility: return "accessibility"
             case .about: return "info.circle"
             case .debug: return "ant"
             }
@@ -287,9 +274,6 @@ private struct SettingsTwoColumnView: View {
 
     private var visibleSections: [SettingsSection] {
         var sections: [SettingsSection] = [.display, .lists, .readLater, .timeline, .posting]
-        if isCompactDevice {
-            sections.append(.accessibility)
-        }
         sections.append(.about)
         #if DEBUG
         sections.append(.debug)
@@ -476,13 +460,6 @@ private struct SettingsTwoColumnView: View {
                     settingsToggleRow("Show Quote Boost Option", isOn: $showQuoteBoost)
                 } header: {
                     Text("Posting").font(.roundedTitle3)
-                }
-
-            case .accessibility:
-                Section {
-                    settingsToggleRow("Haptic Feedback", isOn: $hapticFeedback)
-                } header: {
-                    Text("Accessibility").font(.roundedTitle3)
                 }
 
             case .about:

--- a/fedi-reader/Views/Settings/TabOrderSettingsView.swift
+++ b/fedi-reader/Views/Settings/TabOrderSettingsView.swift
@@ -87,7 +87,6 @@ struct TabOrderSettingsView: View {
     @State private var editMode: EditMode = TabOrderSettingsFeatures.defaultEditMode
     @State private var deniedMoveAttempts: [AppTab: Int] = [:]
     @State private var previewVisibleTabs: [AppTab]? = nil
-    @AppStorage("hapticFeedback") private var hapticFeedback = true
 
     private var visibleTabs: [AppTab] {
         previewVisibleTabs ?? appState.resolvedVisibleTabs()
@@ -206,7 +205,7 @@ struct TabOrderSettingsView: View {
         let shakeDuration = TabOrderSettingsFeatures.shakeAnimationDuration
 
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            HapticFeedback.play(.medium, enabled: hapticFeedback)
+            HapticFeedback.play(.medium)
             withAnimation(.easeInOut(duration: shakeDuration)) {
                 for tab in tabs {
                     deniedMoveAttempts[tab, default: 0] += 1


### PR DESCRIPTION
Summary
- drop the unused haptic flag from app constants and views
- simplify HapticFeedback utility so it always defers to the system’s Settings > Sounds & Haptics preference
- remove the redundant Accessibility section and bindings that previously exposed the toggle

Testing
- Not run (not requested)