### PR TITLE
Unify Boost attribution chip

### DIFF
--- a/fedi-reader/Views/Components/BoostAttributionChip.swift
+++ b/fedi-reader/Views/Components/BoostAttributionChip.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct BoostAttributionChip: View {
+    let account: MastodonAccount
+    var action: (() -> Void)? = nil
+
+    @AppStorage("themeColor") private var themeColorName = "blue"
+
+    private var themeColor: Color {
+        ThemeColor.resolved(from: themeColorName).color
+    }
+
+    var body: some View {
+        Group {
+            if let action {
+                Button(action: action) {
+                    chipContent
+                }
+                .buttonStyle(.plain)
+            } else {
+                chipContent
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var chipContent: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "arrow.2.squarepath")
+                .font(.roundedCaption2)
+                .foregroundStyle(themeColor)
+
+            ProfileAvatarView(url: account.avatarURL, size: 20)
+
+            Text("Boosted by")
+                .font(.roundedCaption)
+                .foregroundStyle(.secondary)
+
+            EmojiText(text: account.preferredDisplayName, emojis: account.emojis, font: .roundedCaption.bold())
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(1)
+
+            AccountBadgesView(account: account, size: .small)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background {
+            ZStack {
+                Color(.secondarySystemBackground).opacity(0.65)
+                themeColor.opacity(0.10)
+            }
+        }
+        .clipShape(Capsule())
+        .overlay {
+            Capsule()
+                .stroke(themeColor.opacity(0.25), lineWidth: 1)
+        }
+        .contentShape(Capsule())
+    }
+}

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
@@ -24,7 +24,6 @@ struct LinkStatusRow: View {
     @Environment(\.openURL) private var openURL
     @Environment(ReadLaterManager.self) private var readLaterManager
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
-    @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
     @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
 
@@ -36,10 +35,6 @@ struct LinkStatusRow: View {
     @State private var localBookmarked: Bool?
     @State private var isManagingLists = false
 
-    private var themeColor: Color {
-        ThemeColor(rawValue: themeColorName)?.color ?? .blue
-    }
-    
     private var isBookmarked: Bool {
         localBookmarked ?? linkStatus.status.displayStatus.bookmarked ?? false
     }
@@ -59,7 +54,7 @@ struct LinkStatusRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             if linkStatus.status.isReblog {
-                reblogGradientStrip
+                boostAttributionChip
             }
 
             authorHeader
@@ -115,49 +110,12 @@ struct LinkStatusRow: View {
         }
     }
 
-    private var reblogGradientStrip: some View {
-        let reblogger = linkStatus.status.account
-        return HStack(spacing: 8) {
-            ProfileAvatarView(url: reblogger.avatarURL, size: 24, placeholderStyle: .light)
-
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Image(systemName: "arrow.2.squarepath")
-                        .font(.roundedCaption2)
-
-                    Text("Boosted by")
-                        .font(.roundedCaption)
-                }
-
-                HStack(spacing: 4) {
-                    EmojiText(text: reblogger.displayName, emojis: reblogger.emojis, font: .roundedCaption.bold())
-                        .lineLimit(1)
-
-                    AccountBadgesView(account: reblogger, size: .small)
-                }
+    private var boostAttributionChip: some View {
+        BoostAttributionChip(account: linkStatus.status.account) {
+            deferPostNavigation {
+                appState.navigate(to: .profile(linkStatus.status.account))
             }
-            .foregroundStyle(.white)
-
-            Spacer()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background {
-            LinearGradient(
-                colors: [
-                    themeColor.opacity(0.35),
-                    themeColor.opacity(0.20),
-                    themeColor.opacity(0.10),
-                    themeColor.opacity(0.05),
-                    Color.clear
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .contentShape(Rectangle())
     }
 
     private var authorHeader: some View {

--- a/fedi-reader/Views/Feed/StatusDetailRowView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailRowView.swift
@@ -22,7 +22,7 @@ struct StatusDetailRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             if status.isReblog {
-                reblogIndicator
+                boostAttributionChip
             }
 
             HStack(spacing: 10) {
@@ -148,34 +148,12 @@ struct StatusDetailRowView: View {
         .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Constants.UI.cardCornerRadius))
     }
     
-    // MARK: - Reblog Indicator
-    
-    private var reblogIndicator: some View {
-        Button {
-            appState.navigate(to: .profile(status.account))
-        } label: {
-            HStack(spacing: 8) {
-                ProfileAvatarView(url: status.account.avatarURL, size: 24)
+    // MARK: - Boost Attribution
 
-                HStack(spacing: 6) {
-                    Image(systemName: "arrow.2.squarepath")
-                        .font(.roundedCaption2)
-                    
-                    Text("Boosted by")
-                        .font(.roundedCaption)
-                    
-                    EmojiText(text: status.account.displayName, emojis: status.account.emojis, font: .roundedCaption.bold())
-                        .lineLimit(1)
-                    
-                    AccountBadgesView(account: status.account, size: .small)
-                }
-                .foregroundStyle(.secondary)
-                
-                Spacer()
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+    private var boostAttributionChip: some View {
+        BoostAttributionChip(account: status.account) {
+            appState.navigate(to: .profile(status.account))
         }
-        .buttonStyle(.plain)
     }
 
     private func currentAuthorURL(for card: PreviewCard) -> URL? {

--- a/fedi-reader/Views/Feed/StatusRowView.swift
+++ b/fedi-reader/Views/Feed/StatusRowView.swift
@@ -6,7 +6,6 @@ struct StatusRowView: View {
     @Environment(\.openURL) private var openURL
     @Environment(ReadLaterManager.self) private var readLaterManager
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
-    @AppStorage("themeColor") private var themeColorName = "blue"
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
     @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
     
@@ -22,10 +21,6 @@ struct StatusRowView: View {
         status.displayStatus
     }
     
-    private var themeColor: Color {
-        ThemeColor(rawValue: themeColorName)?.color ?? .blue
-    }
-    
     private var isBookmarked: Bool {
         localBookmarked ?? displayStatus.bookmarked ?? false
     }
@@ -36,9 +31,8 @@ struct StatusRowView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Reblog gradient strip
             if status.isReblog {
-                reblogGradientStrip
+                boostAttributionChip
             }
             
             // Reply indicator (if this is a reply)
@@ -122,55 +116,12 @@ struct StatusRowView: View {
         .buttonStyle(.plain)
     }
     
-    // MARK: - Reblog Gradient Strip
-    
-    private var reblogGradientStrip: some View {
-        Button {
-            appState.navigate(to: .profile(status.account))
-        } label: {
-            HStack(spacing: 8) {
-                ProfileAvatarView(url: status.account.avatarURL, size: 24, placeholderStyle: .light)
+    // MARK: - Boost Attribution
 
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "arrow.2.squarepath")
-                            .font(.roundedCaption2)
-                        
-                        Text("Boosted by")
-                            .font(.roundedCaption)
-                    }
-                    
-                    HStack(spacing: 4) {
-                        EmojiText(text: status.account.displayName, emojis: status.account.emojis, font: .roundedCaption.bold())
-                            .lineLimit(1)
-                        
-                        AccountBadgesView(account: status.account, size: .small)
-                    }
-                }
-                .foregroundStyle(.white)
-                
-                Spacer()
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background {
-                LinearGradient(
-                    colors: [
-                        themeColor.opacity(0.35),
-                        themeColor.opacity(0.20),
-                        themeColor.opacity(0.10),
-                        themeColor.opacity(0.05),
-                        Color.clear
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            }
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .contentShape(Rectangle())
+    private var boostAttributionChip: some View {
+        BoostAttributionChip(account: status.account) {
+            appState.navigate(to: .profile(status.account))
         }
-        .buttonStyle(.plain)
     }
     
     // MARK: - Author Header


### PR DESCRIPTION
## Summary
- add a shared `BoostAttributionChip` capsule component that keeps the boost icon, avatar, copy, and badges with a profile action closure
- replace the duplicated gradient boost UI in `LinkStatusRow`, `StatusRowView`, and `StatusDetailRowView` with the new chip so every “Boosted by” surface comes from one code path
- keep the existing profile routing hooks (including `deferPostNavigation`) while adopting the new visual style

## Testing
- Not run (not requested)