### PR TITLE
FEDI-71, FEDI-72, FEDI-73: restore profile links and resilient link feed loading

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -9,5 +9,8 @@ This directory holds project-specific context for AI agents. Structure follows t
 | `skills/` | Executable capabilities ([agentskills.io](https://agentskills.io) compliant) |
 
 **Entry point:** Root [AGENTS.md](../AGENTS.md) is the single source of truth for all agents. Read it first.
+**Linear policy:** Linear is the source of truth for planning, status, blockers, and verification. Agents must keep it up to date throughout the task.
+**Issue-splitting policy:** Branch-caused regressions stay on the current parent issue. Unrelated bugs discovered while working become Linear sub-issues under that parent. If the bug was discovered by an agent during that work, apply the `Source/Agent` label.
+**Sub-issue commenting policy:** Once work is tracked in a sub-issue, ongoing comments for that work go on the sub-issue itself. Keep the parent issue to split notices and high-level coordination.
 
 **Cursor compatibility:** `.cursor/rules/` references AGENTS.md for always-apply rules.

--- a/.agents/rules/linear-workflow.md
+++ b/.agents/rules/linear-workflow.md
@@ -1,3 +1,6 @@
 # Linear Workflow
 
 **See [AGENTS.md](../../AGENTS.md) in the project root.** All agent instructions, including the full Linear workflow, are consolidated there.
+**Linear remains the source of truth for work tracking and must stay current throughout execution.**
+**Bug-tracking rule:** Regressions introduced by the current branch stay on the parent issue. Bugs discovered during the work that predate the branch must be tracked as Linear sub-issues under the current issue. Agent-discovered issues should use the `Source/Agent` label.
+**Sub-issue comment rule:** After work is split to a sub-issue, put implementation comments, blockers, verification, and completion updates on the sub-issue itself.

--- a/.agents/skills/linear-workflow/SKILL.md
+++ b/.agents/skills/linear-workflow/SKILL.md
@@ -5,7 +5,7 @@ description: ALWAYS check for linked Linear issue and follow conventions before 
 
 # Linear Workflow
 
-**MANDATORY:** Linear is the source of truth, not GitHub. Check for a linked Linear issue before starting work. Linear–GitHub integration depends on correct branch names and issue updates.
+**MANDATORY:** Linear is the source of truth for planning, implementation status, blockers, and verification, not GitHub. Check for a linked Linear issue before starting work, and keep it current throughout the task. Linear–GitHub integration depends on correct branch names and issue updates.
 
 ## When to Use (invoke this skill FIRST)
 
@@ -32,7 +32,13 @@ description: ALWAYS check for linked Linear issue and follow conventions before 
 
 7. **Add comments as you work** via `save_comment`—implementations, decisions, blockers.
 
-8. **Do not mark Done**—let Linear–GitHub integration set Done when the PR is merged.
+8. **Keep Linear current continuously**. If scope, status, blockers, implementation details, or verification results change, update the issue before continuing.
+
+9. **Handle newly discovered bugs explicitly**. If the current branch introduced the regression, keep the fix on the current parent issue and document it there. If the bug was not introduced by the current branch, create a Linear sub-issue under the current issue and note that split on the parent issue before continuing. If the issue was discovered by an agent while working another task, apply the `Source/Agent` label.
+
+10. **If work is tracked in a sub-issue, comment there**. Put the plan, implementation progress, blockers, verification notes, and completion summary on the sub-issue itself. Use the parent issue only for the split note and high-level coordination.
+
+11. **Do not mark Done**—let Linear–GitHub integration set Done when the PR is merged.
 
 If no Linear issue exists (e.g. branch is `main` or doesn’t match patterns), proceed without Linear updates—but **always check first**.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # Fedi Reader – Agent Instructions
 
 **Single source of truth for all agents.** Link-focused Mastodon news reader for iOS/macOS. Pure Swift, SwiftUI + SwiftData, `@Observable` services — no MVVM, no external dependencies.
+**Linear is the operational source of truth for planning, implementation status, blockers, and verification. Keep it current at all times.**
 
 ## GATE (first action on any request)
 
-**Linear is the source of truth, not GitHub.** Before any code edits or plan creation:
+**Linear is the source of truth for all work tracking, not GitHub.** Before any code edits or plan creation:
 
 1. Run `git branch --show-current`. Parse for Linear ID (e.g. `FEDI-123`). Valid patterns: `FEDI-123-feature-name`, `sam/FEDI-456-fix`, `CountableNewt/issue92-...`.
 2. **If Linear ID found**: Use Linear MCP `get_issue` to confirm, then `save_issue` with `state: "In Progress"` before touching code or creating plans.
@@ -12,11 +13,15 @@
 4. **If no Linear ID** (e.g. `main`): Proceed without Linear updates.
 
 Apply in **both plan mode and implementation**—do not skip because you are "only planning."
+Do not batch updates until the end of the task. If status, scope, blockers, decisions, or verification change, update Linear before continuing.
 
 ### Full Linear workflow
 
 - **During planning**: Add comments via `create_comment`—when drafting a plan, summarize the approach or key decisions on the Linear issue.
 - **While implementing**: Include the full plan via `create_comment`—when implementing from a `.plan.md` file, paste the **entire plan content** as a Linear comment. Add comments as you work—implementations, decisions, blockers.
+- **At all times**: Keep the issue current. When scope, status, blockers, implementation details, or verification results change, reflect that in Linear immediately.
+- **When new bugs surface during implementation**: If the bug was introduced by the current branch, fix it under the parent issue and document it there. If the bug was not introduced by the current branch, create a Linear sub-issue under the current issue, move tracking there, and note the split on the parent issue. If the issue was discovered by an agent while working another task, apply the `Source/Agent` label.
+- **When work moves to a sub-issue**: Comment directly on the sub-issue as the work progresses. Plans, implementation notes, blockers, verification, and completion notes for that work belong on the sub-issue itself. The parent issue should only record the split and high-level coordination updates.
 - **Before claiming done**: Add a completion comment via `create_comment`—summarize changes made and how to verify. Do not mark Done—let Linear–GitHub integration set Done when the PR is merged.
 
 ## Context routing

--- a/fedi-reader/Models/MastodonTypes/Status.swift
+++ b/fedi-reader/Models/MastodonTypes/Status.swift
@@ -202,7 +202,7 @@ struct Status: Codable, Identifiable, Hashable, Sendable {
     }
     
     nonisolated var hasLinkCard: Bool {
-        card?.type == .link
+        card?.linkURL != nil
     }
     
     nonisolated var cardURL: URL? {
@@ -212,4 +212,3 @@ struct Status: Codable, Identifiable, Hashable, Sendable {
 }
 
 // MARK: - IndirectStatus wrapper for recursive Status references
-

--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -105,17 +105,11 @@ final class LinkFilterService {
                 return false
             }
             
-            // Check for link card (exclude social post URLs: Threads, Instagram, Bluesky)
-            if targetStatus.hasLinkCard,
-               let cardURL = targetStatus.card?.linkURL,
-               !Self.isSocialPostURL(cardURL) {
+            if Self.usablePreviewCardURL(from: targetStatus) != nil {
                 return true
             }
             
-            // Check for links in content (exclude social post URLs)
-            let links = Self.extractExternalLinks(from: targetStatus)
-            let validLinks = links.filter { !Self.isSocialPostURL($0) }
-            return !validLinks.isEmpty
+            return !Self.extractExternalLinks(from: targetStatus).isEmpty
         }
         Self.logger.debug("Filtered to \(filtered.count) link statuses (\(filtered.count * 100 / max(statuses.count, 1))%)")
         return filtered
@@ -141,6 +135,24 @@ final class LinkFilterService {
     /// Processes statuses into LinkStatus objects (uses active feed)
     func processStatuses(_ statuses: [Status]) async -> [LinkStatus] {
         await processStatuses(statuses, for: activeFeedId)
+    }
+
+    /// Processes a feed and keeps requesting older pages until visible link content appears or pagination is exhausted.
+    func processStatusesEnsuringVisibleContent(
+        _ statuses: [Status],
+        for feedId: String,
+        canLoadMore: () -> Bool,
+        loadMoreStatuses: () async -> [Status]
+    ) async -> [LinkStatus] {
+        let processedStatuses = await processStatuses(statuses, for: feedId)
+        guard processedStatuses.isEmpty else { return processedStatuses }
+
+        return await continueLoadingOlderPages(
+            for: feedId,
+            targetLinkCount: 0,
+            canLoadMore: canLoadMore,
+            loadMoreStatuses: loadMoreStatuses
+        )
     }
 
     /// Incrementally appends newly fetched statuses to an existing feed cache.
@@ -173,6 +185,25 @@ final class LinkFilterService {
 
         feedCache[feedId] = merged
         return merged
+    }
+
+    /// Appends statuses and keeps requesting older pages until new link content appears or pagination is exhausted.
+    func appendStatusesEnsuringAdditionalContent(
+        _ statuses: [Status],
+        for feedId: String,
+        canLoadMore: () -> Bool,
+        loadMoreStatuses: () async -> [Status]
+    ) async -> [LinkStatus] {
+        let previousLinkCount = getCachedContent(for: feedId).count
+        let mergedStatuses = await appendStatuses(statuses, for: feedId)
+        guard mergedStatuses.count == previousLinkCount else { return mergedStatuses }
+
+        return await continueLoadingOlderPages(
+            for: feedId,
+            targetLinkCount: previousLinkCount,
+            canLoadMore: canLoadMore,
+            loadMoreStatuses: loadMoreStatuses
+        )
     }
     
     /// Enriches link statuses with author attribution from HEAD requests
@@ -296,16 +327,18 @@ final class LinkFilterService {
     
     /// Extracts external links from a status
     private nonisolated static func extractExternalLinks(from status: Status) -> [URL] {
-        // Get the instance domain to exclude internal links
-        var excludeDomains: [String] = []
-        if let host = URL(string: status.uri)?.host {
-            excludeDomains.append(host)
+        let excludeDomains = excludedDomains(for: status)
+        let anchorLinks = HTMLParser.extractLinks(from: status.content).filter {
+            isUsableExternalURL($0, excludingDomains: excludeDomains)
         }
-        
-        // Also exclude common Mastodon instances for mentions
-        excludeDomains.append(contentsOf: ["mastodon.social", "mastodon.online"])
-        
-        return HTMLParser.extractExternalLinks(from: status.content, excludingDomains: excludeDomains)
+
+        if !anchorLinks.isEmpty {
+            return anchorLinks
+        }
+
+        return HTMLParser.extractPlainTextLinks(from: status.content).filter {
+            isUsableExternalURL($0, excludingDomains: excludeDomains)
+        }
     }
     
     /// Checks if a status is a quote post
@@ -358,9 +391,7 @@ final class LinkFilterService {
             let tags = TagExtractor.extractTags(from: targetStatus)
             
             if let card = targetStatus.card,
-               card.type == .link,
-               let cardURL = card.linkURL {
-                guard !isSocialPostURL(cardURL) else { continue }
+               let cardURL = usablePreviewCardURL(from: targetStatus) {
                 
                 linkStatuses.append(
                     LinkStatus(
@@ -398,6 +429,40 @@ final class LinkFilterService {
             cardCount: cardCount,
             contentLinkCount: contentLinkCount
         )
+    }
+
+    private nonisolated static func usablePreviewCardURL(from status: Status) -> URL? {
+        guard let cardURL = status.card?.linkURL,
+              isUsableExternalURL(cardURL, excludingDomains: excludedDomains(for: status)) else {
+            return nil
+        }
+
+        return cardURL
+    }
+
+    private nonisolated static func excludedDomains(for status: Status) -> [String] {
+        var domains: [String] = []
+        if let host = URL(string: status.uri)?.host {
+            domains.append(host)
+        }
+
+        domains.append(contentsOf: ["mastodon.social", "mastodon.online"])
+        return domains
+    }
+
+    private nonisolated static func isUsableExternalURL(_ url: URL, excludingDomains domains: [String]) -> Bool {
+        guard HTMLParser.isExternalURL(url),
+              !isSocialPostURL(url),
+              let host = url.host?.lowercased() else {
+            return false
+        }
+
+        let path = url.path.lowercased()
+        if path.hasPrefix("/@") || path.hasPrefix("/tags/") {
+            return false
+        }
+
+        return !domains.contains { host.contains($0.lowercased()) }
     }
     
     // MARK: - Filtering Options
@@ -467,6 +532,23 @@ final class LinkFilterService {
         let count = linkStatuses.count
         linkStatuses = []
         Self.logger.info("Cleared link statuses: \(count) items removed")
+    }
+
+    private func continueLoadingOlderPages(
+        for feedId: String,
+        targetLinkCount: Int,
+        canLoadMore: () -> Bool,
+        loadMoreStatuses: () async -> [Status]
+    ) async -> [LinkStatus] {
+        var cachedStatuses = getCachedContent(for: feedId)
+        while cachedStatuses.count == targetLinkCount && canLoadMore() {
+            let olderStatuses = await loadMoreStatuses()
+            guard !olderStatuses.isEmpty else { break }
+
+            cachedStatuses = await appendStatuses(olderStatuses, for: feedId)
+        }
+
+        return cachedStatuses
     }
 
     private nonisolated static func mergeExistingMetadata(

--- a/fedi-reader/Services/TimelineService.swift
+++ b/fedi-reader/Services/TimelineService.swift
@@ -36,6 +36,7 @@ final class TimelineService {
     var hashtagTimeline: [Status] = []
     private var hashtagTimelineMaxId: String?
     private var hashtagTimelineTag: String?
+    private var loadingHashtagTimelineTag: String?
     
     // Loading state
     var isLoadingHome = false
@@ -58,11 +59,15 @@ final class TimelineService {
     private var mentionsMaxId: String?
     private var conversationsMaxId: String?
     private var listTimelineMaxId: String?
+    private var listTimelineFeedId: String?
     private var followedTagsMaxId: String?
     private var listAccountsMaxId: String?
     private var listsLastRefreshedAt: Date?
     private var listsLastRefreshedForAccountId: String?
     private var listLoadWaiters: [CheckedContinuation<Void, Never>] = []
+    private var listTimelineLoadWaiters: [CheckedContinuation<Void, Never>] = []
+    private var hashtagTimelineLoadWaiters: [CheckedContinuation<Void, Never>] = []
+    private var loadingListTimelineFeedId: String?
     
     /// Polling tasks for async refresh, keyed by status ID. Cancelled when starting a new refresh for same status or via cancelAsyncRefreshPolling.
     private var asyncRefreshPollingTasks: [String: Task<Void, Never>] = [:]
@@ -266,6 +271,17 @@ final class TimelineService {
         bookmarksMaxId != nil
     }
 
+    func hasPreparedLinkFeedState(feedId: String) -> Bool {
+        if feedId == AppState.homeFeedID || feedId == AppState.bookmarksFeedID {
+            return true
+        }
+        if feedId.hasPrefix("hashtag:") {
+            let tagName = String(feedId.dropFirst("hashtag:".count))
+            return hashtagTimelineTag == tagName
+        }
+        return listTimelineFeedId == feedId
+    }
+
     func loadLinkFeedStatuses(feedId: String, forceRefreshHome: Bool = false) async -> [Status] {
         if feedId == AppState.homeFeedID {
             if forceRefreshHome || homeTimeline.isEmpty {
@@ -286,7 +302,7 @@ final class TimelineService {
         }
 
         await refreshListTimeline(listId: feedId)
-        return listTimeline
+        return listTimelineFeedId == feedId ? listTimeline : []
     }
 
     func prefetchLinkFeedStatuses(feedId: String) async -> [Status] {
@@ -1114,9 +1130,12 @@ final class TimelineService {
         mentionsMaxId = nil
         conversationsMaxId = nil
         listTimelineMaxId = nil
+        listTimelineFeedId = nil
+        loadingListTimelineFeedId = nil
         listAccountsMaxId = nil
         hashtagTimelineMaxId = nil
         hashtagTimelineTag = nil
+        loadingHashtagTimelineTag = nil
         followedTagsMaxId = nil
     }
     
@@ -1134,6 +1153,40 @@ final class TimelineService {
         guard !listLoadWaiters.isEmpty else { return }
         let waiters = listLoadWaiters
         listLoadWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func waitForInFlightListTimelineLoad() async {
+        guard isLoadingListTimeline else { return }
+
+        await withCheckedContinuation { continuation in
+            listTimelineLoadWaiters.append(continuation)
+        }
+    }
+
+    private func resumeListTimelineLoadWaiters() {
+        guard !listTimelineLoadWaiters.isEmpty else { return }
+        let waiters = listTimelineLoadWaiters
+        listTimelineLoadWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func waitForInFlightHashtagTimelineLoad() async {
+        guard isLoadingHashtagTimeline else { return }
+
+        await withCheckedContinuation { continuation in
+            hashtagTimelineLoadWaiters.append(continuation)
+        }
+    }
+
+    private func resumeHashtagTimelineLoadWaiters() {
+        guard !hashtagTimelineLoadWaiters.isEmpty else { return }
+        let waiters = hashtagTimelineLoadWaiters
+        hashtagTimelineLoadWaiters.removeAll()
         for waiter in waiters {
             waiter.resume()
         }
@@ -1311,9 +1364,14 @@ final class TimelineService {
     }
     
     func loadListTimeline(listId: String, refresh: Bool = false) async {
-        guard !isLoadingListTimeline else {
-            Self.logger.debug("List timeline load already in progress, skipping")
-            return
+        while isLoadingListTimeline {
+            let currentlyLoadingFeedId = loadingListTimelineFeedId
+            Self.logger.debug("List timeline load already in progress, waiting")
+            await waitForInFlightListTimelineLoad()
+
+            if currentlyLoadingFeedId == listId {
+                return
+            }
         }
         
         guard let account = authService.currentAccount,
@@ -1325,7 +1383,13 @@ final class TimelineService {
         
         Self.logger.info("Loading list timeline \(listId.prefix(8), privacy: .public), refresh: \(refresh), current count: \(self.listTimeline.count), maxId: \(self.listTimelineMaxId?.prefix(8) ?? "nil", privacy: .public)")
         isLoadingListTimeline = true
+        loadingListTimelineFeedId = listId
         error = nil
+        defer {
+            isLoadingListTimeline = false
+            loadingListTimelineFeedId = nil
+            resumeListTimelineLoadWaiters()
+        }
         
         do {
             let statuses = try await client.getListTimeline(
@@ -1336,11 +1400,13 @@ final class TimelineService {
                 limit: Constants.Pagination.defaultLimit
             )
             
-            if refresh {
+            if refresh || listTimelineFeedId != listId {
                 listTimeline = statuses
+                listTimelineFeedId = listId
                 Self.logger.info("List timeline refreshed: \(statuses.count) statuses")
             } else {
                 listTimeline.append(contentsOf: statuses)
+                listTimelineFeedId = listId
                 Self.logger.info("List timeline loaded more: \(statuses.count) new statuses, total: \(self.listTimeline.count)")
             }
             
@@ -1363,17 +1429,23 @@ final class TimelineService {
             Self.logger.error("Error loading list timeline: \(error.localizedDescription)")
             self.error = error
         }
-        
-        isLoadingListTimeline = false
     }
     
-    func canLoadMoreListTimeline() -> Bool {
-        listTimelineMaxId != nil
+    func canLoadMoreListTimeline(listId: String? = nil) -> Bool {
+        if let listId {
+            return listTimelineFeedId == listId && listTimelineMaxId != nil
+        }
+        return listTimelineMaxId != nil
     }
     
     @discardableResult
     func loadMoreListTimeline(listId: String) async -> [Status] {
-        guard !isLoadingMore, canLoadMoreListTimeline() else { return [] }
+        if listTimelineFeedId != listId {
+            await refreshListTimeline(listId: listId)
+            return listTimelineFeedId == listId ? listTimeline : []
+        }
+
+        guard !isLoadingMore, canLoadMoreListTimeline(listId: listId) else { return [] }
         let previousCount = listTimeline.count
         
         isLoadingMore = true
@@ -1422,7 +1494,15 @@ final class TimelineService {
     }
 
     func loadHashtagTimeline(tag: String, refresh: Bool = false) async {
-        guard !isLoadingHashtagTimeline else { return }
+        while isLoadingHashtagTimeline {
+            let currentlyLoadingTag = loadingHashtagTimelineTag
+            await waitForInFlightHashtagTimelineLoad()
+
+            if currentlyLoadingTag == tag {
+                return
+            }
+        }
+
         let effectiveRefresh = refresh || hashtagTimelineTag != tag
         guard let account = authService.currentAccount,
               let token = await authService.getAccessToken(for: account) else {
@@ -1430,12 +1510,16 @@ final class TimelineService {
             return
         }
         isLoadingHashtagTimeline = true
+        loadingHashtagTimelineTag = tag
         error = nil
         if effectiveRefresh {
             hashtagTimelineMaxId = nil
-            hashtagTimelineTag = tag
         }
-        defer { isLoadingHashtagTimeline = false }
+        defer {
+            isLoadingHashtagTimeline = false
+            loadingHashtagTimelineTag = nil
+            resumeHashtagTimelineLoadWaiters()
+        }
         do {
             let statuses = try await client.getHashtagTimeline(
                 instance: account.instance,
@@ -1545,6 +1629,7 @@ final class TimelineService {
         listTimeline = []
         listAccounts = []
         listTimelineMaxId = nil
+        listTimelineFeedId = nil
         listAccountsMaxId = nil
     }
     

--- a/fedi-reader/Utilities/HTMLParser/HTMLParser.swift
+++ b/fedi-reader/Utilities/HTMLParser/HTMLParser.swift
@@ -95,6 +95,21 @@ struct HTMLParser: Sendable {
             return true
         }
     }
+
+    /// Extracts HTTP(S) URLs that appear as plain text after HTML tags are stripped.
+    nonisolated static func extractPlainTextLinks(from html: String) -> [URL] {
+        let plainText = stripHTML(html)
+        guard !plainText.isEmpty,
+              let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return []
+        }
+
+        let range = NSRange(plainText.startIndex..., in: plainText)
+        return detector.matches(in: plainText, options: [], range: range).compactMap { match in
+            guard let url = match.url, isExternalURL(url) else { return nil }
+            return url
+        }
+    }
     
     // MARK: - HTML to Plain Text
     

--- a/fedi-reader/Utilities/Thread/ThreadBuilder.swift
+++ b/fedi-reader/Utilities/Thread/ThreadBuilder.swift
@@ -4,7 +4,7 @@ enum ThreadBuilder {
     /// Builds a thread tree from a flat array of statuses
     /// Returns root-level threads (statuses that aren't replies, or whose parent isn't in the set)
     /// Uses O(n) pre-grouping to avoid O(n²) filtering on large reply threads
-    static func buildThreadTree(from statuses: [Status]) -> [ThreadNode] {
+    nonisolated static func buildThreadTree(from statuses: [Status]) -> [ThreadNode] {
         guard !statuses.isEmpty else { return [] }
         
         let statusMap = Dictionary(uniqueKeysWithValues: statuses.map { ($0.id, $0) })
@@ -18,7 +18,7 @@ enum ThreadBuilder {
     }
     
     /// Identifies root-level statuses (top of threads)
-    static func findRootStatuses(_ statuses: [Status], statusMap: [String: Status]) -> [Status] {
+    nonisolated static func findRootStatuses(_ statuses: [Status], statusMap: [String: Status]) -> [Status] {
         statuses.filter { status in
             guard let replyToId = status.inReplyToId else {
                 return true
@@ -28,21 +28,21 @@ enum ThreadBuilder {
     }
     
     /// Recursively builds a subtree; uses pre-grouped replies for O(1) child lookup
-    private static func buildSubtree(root: Status, repliesByParentId: [String: [Status]]) -> ThreadNode {
+    private nonisolated static func buildSubtree(root: Status, repliesByParentId: [String: [Status]]) -> ThreadNode {
         let directReplies = (repliesByParentId[root.id] ?? []).sorted { $0.createdAt < $1.createdAt }
         let childNodes = directReplies.map { buildSubtree(root: $0, repliesByParentId: repliesByParentId) }
         return ThreadNode(status: root, children: childNodes)
     }
     
     /// Merges multiple thread trees, combining those that share common statuses
-    static func mergeThreads(_ threads: [ThreadNode]) -> [ThreadNode] {
+    nonisolated static func mergeThreads(_ threads: [ThreadNode]) -> [ThreadNode] {
         // For now, return threads as-is. More sophisticated merging could be added later
         // if needed for cross-conversation threading
         return threads
     }
     
     /// Finds the root thread node containing a specific status
-    static func findThreadRoot(for status: Status, in threads: [ThreadNode]) -> ThreadNode? {
+    nonisolated static func findThreadRoot(for status: Status, in threads: [ThreadNode]) -> ThreadNode? {
         for thread in threads {
             if let found = thread.findNode(withId: status.id) {
                 // Walk up to find root
@@ -53,7 +53,7 @@ enum ThreadBuilder {
     }
     
     /// Helper to find the root of a node within a thread forest
-    private static func findRootOfNode(_ node: ThreadNode, in threads: [ThreadNode]) -> ThreadNode? {
+    private nonisolated static func findRootOfNode(_ node: ThreadNode, in threads: [ThreadNode]) -> ThreadNode? {
         // Check if this node is a root in any thread
         for thread in threads {
             if thread.id == node.id {
@@ -67,4 +67,3 @@ enum ThreadBuilder {
         return nil
     }
 }
-

--- a/fedi-reader/Utilities/Thread/ThreadNode.swift
+++ b/fedi-reader/Utilities/Thread/ThreadNode.swift
@@ -5,14 +5,14 @@ struct ThreadNode: Identifiable, Sendable {
     let status: Status
     var children: [ThreadNode]
     
-    init(status: Status, children: [ThreadNode] = []) {
+    nonisolated init(status: Status, children: [ThreadNode] = []) {
         self.id = status.id
         self.status = status
         self.children = children
     }
     
     /// Calculates the depth of this node in the tree (0 for root)
-    var depth: Int {
+    nonisolated var depth: Int {
         if children.isEmpty {
             return 0
         }
@@ -20,7 +20,7 @@ struct ThreadNode: Identifiable, Sendable {
     }
     
     /// Flattens the tree into a depth-first list of statuses
-    func flattened() -> [Status] {
+    nonisolated func flattened() -> [Status] {
         var result = [status]
         for child in children.sorted(by: { $0.status.createdAt < $1.status.createdAt }) {
             result.append(contentsOf: child.flattened())
@@ -29,7 +29,7 @@ struct ThreadNode: Identifiable, Sendable {
     }
     
     /// Flattens the tree into a list of ThreadNodes in depth-first order
-    func flattenedNodes() -> [ThreadNode] {
+    nonisolated func flattenedNodes() -> [ThreadNode] {
         var result = [self]
         for child in children.sorted(by: { $0.status.createdAt < $1.status.createdAt }) {
             result.append(contentsOf: child.flattenedNodes())
@@ -38,7 +38,7 @@ struct ThreadNode: Identifiable, Sendable {
     }
     
     /// Finds a node with the given status ID in this subtree
-    func findNode(withId statusId: String) -> ThreadNode? {
+    nonisolated func findNode(withId statusId: String) -> ThreadNode? {
         if id == statusId {
             return self
         }
@@ -51,7 +51,7 @@ struct ThreadNode: Identifiable, Sendable {
     }
     
     /// Gets the path from root to this node (including this node)
-    func pathToRoot() -> [Status] {
+    nonisolated func pathToRoot() -> [Status] {
         let path = [status]
         // Note: This assumes we have parent references, but we don't.
         // For now, this just returns the current status.
@@ -60,15 +60,14 @@ struct ThreadNode: Identifiable, Sendable {
     }
     
     /// Counts total number of replies in this subtree (including self)
-    var totalReplies: Int {
+    nonisolated var totalReplies: Int {
         1 + children.reduce(0) { $0 + $1.totalReplies }
     }
     
     /// Checks if this node has any children
-    var hasReplies: Bool {
+    nonisolated var hasReplies: Bool {
         !children.isEmpty
     }
 }
 
 /// Helper for building thread trees from flat status arrays
-

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -361,7 +361,7 @@ struct LinkFeedContentView: View {
             }
             return currentTab.isHome
                 ? (timelineService?.canLoadMoreHomeTimeline() ?? false)
-                : (timelineService?.canLoadMoreListTimeline() ?? false)
+                : (timelineService?.canLoadMoreListTimeline(listId: currentTab.id) ?? false)
         }()
         return LinkFeedPostList(
             statuses: statuses,
@@ -544,15 +544,7 @@ struct LinkFeedContentView: View {
         guard !isPaginating, !service.isLoadingMore else { return }
 
         let tab = currentTab
-        let canLoadMore: Bool = {
-            if tab.id == AppState.bookmarksFeedID { return service.canLoadMoreBookmarks() }
-            if tab.id.hasPrefix("hashtag:") {
-                let tagName = String(tab.id.dropFirst("hashtag:".count))
-                return service.canLoadMoreHashtagTimeline(tag: tagName)
-            }
-            return tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
-        }()
-        guard canLoadMore else { return }
+        guard canLoadMore(for: tab, using: service) else { return }
 
         isPaginating = true
         Task {
@@ -597,7 +589,8 @@ struct LinkFeedContentView: View {
         syncAppStateSelectionToCurrentTab()
         linkFilterService.switchToFeed(currentTab.id)
 
-        if linkFilterService.hasCachedContent(for: currentTab.id) {
+        let hasPreparedFeedState = service.hasPreparedLinkFeedState(feedId: currentTab.id)
+        if linkFilterService.hasCachedContent(for: currentTab.id) && hasPreparedFeedState {
             Task {
                 await linkFilterService.enrichWithAttributions()
             }
@@ -617,14 +610,22 @@ struct LinkFeedContentView: View {
 
         linkFilterService.switchToFeed(tab.id)
         let statuses = await service.loadLinkFeedStatuses(feedId: tab.id, forceRefreshHome: forceRefresh)
-        _ = await linkFilterService.processStatuses(statuses, for: tab.id)
+        _ = await linkFilterService.processStatusesEnsuringVisibleContent(
+            statuses,
+            for: tab.id,
+            canLoadMore: { canLoadMore(for: tab, using: service) },
+            loadMoreStatuses: { await loadMoreStatuses(for: tab, using: service) }
+        )
         Task {
             await linkFilterService.enrichWithAttributions()
         }
     }
 
     private func loadContentForTabIfNeeded(_ tab: FeedTabItem) async {
-        guard !linkFilterService.hasCachedContent(for: tab.id) else { return }
+        guard let service = timelineService else { return }
+        let hasCachedContent = linkFilterService.hasCachedContent(for: tab.id)
+        let hasPreparedFeedState = service.hasPreparedLinkFeedState(feedId: tab.id)
+        guard !hasCachedContent || !hasPreparedFeedState else { return }
         await loadContentForTab(tab)
     }
 
@@ -640,21 +641,29 @@ struct LinkFeedContentView: View {
     private func refreshCurrentFeed() async {
         guard let service = timelineService else { return }
         let tab = currentTab
+        let statuses: [Status]
 
         if tab.id == AppState.bookmarksFeedID {
             await service.refreshBookmarks()
-            _ = await linkFilterService.processStatuses(service.bookmarks, for: tab.id)
+            statuses = service.bookmarks
         } else if tab.id.hasPrefix("hashtag:") {
             let tagName = String(tab.id.dropFirst("hashtag:".count))
             await service.refreshHashtagTimeline(tag: tagName)
-            _ = await linkFilterService.processStatuses(service.hashtagTimeline, for: tab.id)
+            statuses = service.hashtagTimeline
         } else if tab.isHome {
             await service.refreshHomeTimeline()
-            _ = await linkFilterService.processStatuses(service.homeTimeline, for: tab.id)
+            statuses = service.homeTimeline
         } else {
             await service.refreshListTimeline(listId: tab.id)
-            _ = await linkFilterService.processStatuses(service.listTimeline, for: tab.id)
+            statuses = service.listTimeline
         }
+
+        _ = await linkFilterService.processStatusesEnsuringVisibleContent(
+            statuses,
+            for: tab.id,
+            canLoadMore: { canLoadMore(for: tab, using: service) },
+            loadMoreStatuses: { await loadMoreStatuses(for: tab, using: service) }
+        )
         Task {
             await linkFilterService.enrichWithAttributions()
         }
@@ -674,39 +683,40 @@ struct LinkFeedContentView: View {
     private func loadMoreForCurrentTab(_ tab: FeedTabItem, using service: TimelineService) async {
         defer { isPaginating = false }
 
-        let loadMore: () async -> [Status] = {
-            if tab.id == AppState.bookmarksFeedID {
-                return await service.loadMoreBookmarks()
-            }
-            if tab.id.hasPrefix("hashtag:") {
-                let tagName = String(tab.id.dropFirst("hashtag:".count))
-                return await service.loadMoreHashtagTimeline(tag: tagName)
-            }
-            if tab.isHome {
-                return await service.loadMoreHomeTimeline()
-            }
-            return await service.loadMoreListTimeline(listId: tab.id)
-        }
-        let canLoadMore: () -> Bool = {
-            if tab.id == AppState.bookmarksFeedID { return service.canLoadMoreBookmarks() }
-            if tab.id.hasPrefix("hashtag:") {
-                let tagName = String(tab.id.dropFirst("hashtag:".count))
-                return service.canLoadMoreHashtagTimeline(tag: tagName)
-            }
-            return tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
-        }
+        let newStatuses = await loadMoreStatuses(for: tab, using: service)
+        guard !newStatuses.isEmpty else { return }
 
-        // Keep fetching until we add link posts or exhaust the API (link feed can get batches with 0 links)
-        var previousLinkCount = linkFilterService.getCachedContent(for: tab.id).count
-        while canLoadMore() {
-            let newStatuses = await loadMore()
-            guard !newStatuses.isEmpty else { break }
+        _ = await linkFilterService.appendStatusesEnsuringAdditionalContent(
+            newStatuses,
+            for: tab.id,
+            canLoadMore: { canLoadMore(for: tab, using: service) },
+            loadMoreStatuses: { await loadMoreStatuses(for: tab, using: service) }
+        )
+    }
 
-            _ = await linkFilterService.appendStatuses(newStatuses, for: tab.id)
-            let newLinkCount = linkFilterService.getCachedContent(for: tab.id).count
-            if newLinkCount > previousLinkCount { break }
-            previousLinkCount = newLinkCount
+    private func canLoadMore(for tab: FeedTabItem, using service: TimelineService) -> Bool {
+        if tab.id == AppState.bookmarksFeedID {
+            return service.canLoadMoreBookmarks()
         }
+        if tab.id.hasPrefix("hashtag:") {
+            let tagName = String(tab.id.dropFirst("hashtag:".count))
+            return service.canLoadMoreHashtagTimeline(tag: tagName)
+        }
+        return tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline(listId: tab.id)
+    }
+
+    private func loadMoreStatuses(for tab: FeedTabItem, using service: TimelineService) async -> [Status] {
+        if tab.id == AppState.bookmarksFeedID {
+            return await service.loadMoreBookmarks()
+        }
+        if tab.id.hasPrefix("hashtag:") {
+            let tagName = String(tab.id.dropFirst("hashtag:".count))
+            return await service.loadMoreHashtagTimeline(tag: tagName)
+        }
+        if tab.isHome {
+            return await service.loadMoreHomeTimeline()
+        }
+        return await service.loadMoreListTimeline(listId: tab.id)
     }
 
     // MARK: - Scroll Position Preservation

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -334,7 +334,7 @@ struct LinkFeedThreeColumnView: View {
             } else {
                 let canLoadMore = currentTab.isHome
                     ? (timelineService?.canLoadMoreHomeTimeline() ?? false)
-                    : (timelineService?.canLoadMoreListTimeline() ?? false)
+                    : (timelineService?.canLoadMoreListTimeline(listId: currentTab.id) ?? false)
                 LinkFeedPostList(
                     statuses: statuses,
                     isLoading: FeedScopedLinkData.isLoading(in: linkFilterService, feedId: currentTab.id),
@@ -471,8 +471,7 @@ struct LinkFeedThreeColumnView: View {
         guard !isPaginating, !service.isLoadingMore else { return }
 
         let tab = currentTab
-        let canLoadMore = tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
-        guard canLoadMore else { return }
+        guard canLoadMore(for: tab, using: service) else { return }
 
         isPaginating = true
         Task {
@@ -517,7 +516,8 @@ struct LinkFeedThreeColumnView: View {
 
         linkFilterService.switchToFeed(currentTab.id)
 
-        if linkFilterService.hasCachedContent(for: currentTab.id) {
+        let hasPreparedFeedState = service.hasPreparedLinkFeedState(feedId: currentTab.id)
+        if linkFilterService.hasCachedContent(for: currentTab.id) && hasPreparedFeedState {
             Task {
                 await linkFilterService.enrichWithAttributions()
             }
@@ -537,28 +537,44 @@ struct LinkFeedThreeColumnView: View {
 
         linkFilterService.switchToFeed(tab.id)
         let statuses = await service.loadLinkFeedStatuses(feedId: tab.id, forceRefreshHome: forceRefresh)
-        _ = await linkFilterService.processStatuses(statuses, for: tab.id)
+        _ = await linkFilterService.processStatusesEnsuringVisibleContent(
+            statuses,
+            for: tab.id,
+            canLoadMore: { canLoadMore(for: tab, using: service) },
+            loadMoreStatuses: { await loadMoreStatuses(for: tab, using: service) }
+        )
         Task {
             await linkFilterService.enrichWithAttributions()
         }
     }
 
     private func loadContentForTabIfNeeded(_ tab: FeedTabItem) async {
-        guard !linkFilterService.hasCachedContent(for: tab.id) else { return }
+        guard let service = timelineService else { return }
+        let hasCachedContent = linkFilterService.hasCachedContent(for: tab.id)
+        let hasPreparedFeedState = service.hasPreparedLinkFeedState(feedId: tab.id)
+        guard !hasCachedContent || !hasPreparedFeedState else { return }
         await loadContentForTab(tab)
     }
 
     private func refreshCurrentFeed() async {
         guard let service = timelineService else { return }
         let tab = currentTab
+        let statuses: [Status]
 
         if tab.isHome {
             await service.refreshHomeTimeline()
-            _ = await linkFilterService.processStatuses(service.homeTimeline, for: tab.id)
+            statuses = service.homeTimeline
         } else {
             await service.refreshListTimeline(listId: tab.id)
-            _ = await linkFilterService.processStatuses(service.listTimeline, for: tab.id)
+            statuses = service.listTimeline
         }
+
+        _ = await linkFilterService.processStatusesEnsuringVisibleContent(
+            statuses,
+            for: tab.id,
+            canLoadMore: { canLoadMore(for: tab, using: service) },
+            loadMoreStatuses: { await loadMoreStatuses(for: tab, using: service) }
+        )
         Task {
             await linkFilterService.enrichWithAttributions()
         }
@@ -578,28 +594,26 @@ struct LinkFeedThreeColumnView: View {
     private func loadMoreForCurrentTab(_ tab: FeedTabItem, using service: TimelineService) async {
         defer { isPaginating = false }
 
-        let loadMore: () async -> [Status] = {
-            if tab.isHome {
-                return await service.loadMoreHomeTimeline()
-            } else {
-                return await service.loadMoreListTimeline(listId: tab.id)
-            }
-        }
-        let canLoadMore: () -> Bool = {
-            tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline()
-        }
+        let newStatuses = await loadMoreStatuses(for: tab, using: service)
+        guard !newStatuses.isEmpty else { return }
 
-        // Keep fetching until we add link posts or exhaust the API (link feed can get batches with 0 links)
-        var previousLinkCount = linkFilterService.getCachedContent(for: tab.id).count
-        while canLoadMore() {
-            let newStatuses = await loadMore()
-            guard !newStatuses.isEmpty else { break }
+        _ = await linkFilterService.appendStatusesEnsuringAdditionalContent(
+            newStatuses,
+            for: tab.id,
+            canLoadMore: { canLoadMore(for: tab, using: service) },
+            loadMoreStatuses: { await loadMoreStatuses(for: tab, using: service) }
+        )
+    }
 
-            _ = await linkFilterService.appendStatuses(newStatuses, for: tab.id)
-            let newLinkCount = linkFilterService.getCachedContent(for: tab.id).count
-            if newLinkCount > previousLinkCount { break }
-            previousLinkCount = newLinkCount
+    private func canLoadMore(for tab: FeedTabItem, using service: TimelineService) -> Bool {
+        tab.isHome ? service.canLoadMoreHomeTimeline() : service.canLoadMoreListTimeline(listId: tab.id)
+    }
+
+    private func loadMoreStatuses(for tab: FeedTabItem, using service: TimelineService) async -> [Status] {
+        if tab.isHome {
+            return await service.loadMoreHomeTimeline()
         }
+        return await service.loadMoreListTimeline(listId: tab.id)
     }
 
     private func attemptRestoreScrollIfNeeded() {

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkStatusRow.swift
@@ -111,38 +111,38 @@ struct LinkStatusRow: View {
     }
 
     private var boostAttributionChip: some View {
-        BoostAttributionChip(account: linkStatus.status.account) {
-            deferPostNavigation {
-                appState.navigate(to: .profile(linkStatus.status.account))
-            }
+        NavigationLink(value: NavigationDestination.profile(linkStatus.status.account)) {
+            BoostAttributionChip(account: linkStatus.status.account)
         }
+        .buttonStyle(.plain)
+        .allowsHitTesting(!shouldIgnoreTap())
     }
 
     private var authorHeader: some View {
         HStack(spacing: 10) {
-            Button {
-                deferPostNavigation {
-                    appState.navigate(to: .profile(linkStatus.status.displayStatus.account))
+            NavigationLink(value: NavigationDestination.profile(linkStatus.status.displayStatus.account)) {
+                HStack(spacing: 10) {
+                    ProfileAvatarView(url: linkStatus.status.displayStatus.account.avatarURL, size: Constants.UI.avatarSize)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 4) {
+                            EmojiText(text: linkStatus.status.displayStatus.account.displayName, emojis: linkStatus.status.displayStatus.account.emojis, font: .roundedSubheadline.bold())
+                                .lineLimit(1)
+
+                            AccountBadgesView(account: linkStatus.status.displayStatus.account, size: .small)
+                        }
+                        if showHandleInFeed {
+                            Text("@\(linkStatus.status.displayStatus.account.acct)")
+                                .font(.roundedCaption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
                 }
-            } label: {
-                ProfileAvatarView(url: linkStatus.status.displayStatus.account.avatarURL, size: Constants.UI.avatarSize)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    EmojiText(text: linkStatus.status.displayStatus.account.displayName, emojis: linkStatus.status.displayStatus.account.emojis, font: .roundedSubheadline.bold())
-                        .lineLimit(1)
-
-                    AccountBadgesView(account: linkStatus.status.displayStatus.account, size: .small)
-                }
-                if showHandleInFeed {
-                    Text("@\(linkStatus.status.displayStatus.account.acct)")
-                        .font(.roundedCaption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
+            .allowsHitTesting(!shouldIgnoreTap())
 
             Spacer()
 
@@ -287,22 +287,11 @@ struct LinkStatusRow: View {
             let showNav = authorURL != nil || effectiveAuthorAttribution?.mastodonHandle != nil
 
             if showNav {
-                Button {
-                    deferPostNavigation {
-                        handleAuthorAttributionNavigation()
-                    }
-                } label: {
-                    AuthorAttributionView(
-                        authorName: authorName,
-                        isMastodonAttribution: isMastodon,
-                        style: .block(
-                            profilePictureURL: profilePictureURL,
-                            mastodonHandle: effectiveAuthorAttribution?.mastodonHandle,
-                            showNavigationIcon: true
-                        )
-                    )
-                }
-                .buttonStyle(.plain)
+                authorAttributionNavigationView(
+                    authorName: authorName,
+                    profilePictureURL: profilePictureURL,
+                    isMastodon: isMastodon
+                )
             } else {
                 AuthorAttributionView(
                     authorName: authorName,
@@ -371,6 +360,83 @@ struct LinkStatusRow: View {
                     openURL(authorURL)
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private func authorAttributionNavigationView(
+        authorName: String,
+        profilePictureURL: URL?,
+        isMastodon: Bool
+    ) -> some View {
+        let attributionView = AuthorAttributionView(
+            authorName: authorName,
+            isMastodonAttribution: isMastodon,
+            style: .block(
+                profilePictureURL: profilePictureURL,
+                mastodonHandle: effectiveAuthorAttribution?.mastodonHandle,
+                showNavigationIcon: true
+            )
+        )
+
+        if let authorURL {
+            Link(destination: authorURL) {
+                attributionView
+            }
+            .buttonStyle(.plain)
+            .environment(\.openURL, authorLinkOpenURLAction)
+            .allowsHitTesting(!shouldIgnoreTap())
+        } else {
+            Button {
+                guard !shouldIgnoreTap() else { return }
+                deferPostNavigation {
+                    handleAuthorAttributionNavigation()
+                }
+            } label: {
+                attributionView
+            }
+            .buttonStyle(.plain)
+            .allowsHitTesting(!shouldIgnoreTap())
+        }
+    }
+
+    private var authorLinkOpenURLAction: OpenURLAction {
+        OpenURLAction { url in
+            guard !shouldIgnoreTap() else {
+                return .handled
+            }
+
+            guard MastodonProfileReference.acct(handle: effectiveAuthorAttribution?.mastodonHandle, profileURL: url) != nil else {
+                return .systemAction(url)
+            }
+
+            Task {
+                let account = if let resolvedMastodonAccount {
+                    resolvedMastodonAccount
+                } else {
+                    await appState.client.resolveProfileAccount(
+                        handle: effectiveAuthorAttribution?.mastodonHandle,
+                        profileURL: url
+                    )
+                }
+
+                if let account {
+                    await MainActor.run {
+                        resolvedMastodonAccount = account
+                        deferPostNavigation {
+                            appState.navigate(to: .profile(account))
+                        }
+                    }
+                } else {
+                    await MainActor.run {
+                        deferPostNavigation {
+                            openURL(url)
+                        }
+                    }
+                }
+            }
+
+            return .handled
         }
     }
 

--- a/fedi-readerTests/HTMLParserTests.swift
+++ b/fedi-readerTests/HTMLParserTests.swift
@@ -112,6 +112,19 @@ struct HTMLParserTests {
         #expect(links.count == 1)
         #expect(links.first?.host == "external.com")
     }
+
+    @Test("Extracts plain text links after stripping HTML")
+    func extractsPlainTextLinksAfterStrippingHTML() {
+        let html = """
+        <p>Read https://example.com/story and https://other.com/deep-dive for more.</p>
+        """
+
+        let links = HTMLParser.extractPlainTextLinks(from: html)
+
+        #expect(links.count == 2)
+        #expect(links.contains { $0.absoluteString == "https://example.com/story" })
+        #expect(links.contains { $0.absoluteString == "https://other.com/deep-dive" })
+    }
     
     // MARK: - HTML Stripping
     

--- a/fedi-readerTests/LinkFilterServiceTests.swift
+++ b/fedi-readerTests/LinkFilterServiceTests.swift
@@ -71,6 +71,65 @@ struct LinkFilterServiceTests {
         #expect(filtered.count == 1)
         #expect(filtered.first?.id == "1")
     }
+
+    @Test("Includes external preview cards regardless of card type")
+    func includesExternalPreviewCardsRegardlessOfCardType() async {
+        let photoCard = MockStatusFactory.makeStatus(
+            id: "photo-card",
+            hasCard: true,
+            cardURL: "https://example.com/photo-story",
+            cardType: .photo
+        )
+        let richCard = MockStatusFactory.makeStatus(
+            id: "rich-card",
+            hasCard: true,
+            cardURL: "https://example.com/rich-story",
+            cardType: .rich
+        )
+
+        let linkStatuses = await service.processStatuses([photoCard, richCard])
+
+        #expect(linkStatuses.count == 2)
+        #expect(linkStatuses.contains { $0.id == "photo-card" && $0.primaryURL.absoluteString == "https://example.com/photo-story" })
+        #expect(linkStatuses.contains { $0.id == "rich-card" && $0.primaryURL.absoluteString == "https://example.com/rich-story" })
+    }
+
+    @Test("Falls back to plain text links when no anchor tags exist")
+    func fallsBackToPlainTextLinksWhenNoAnchorTagsExist() async {
+        let status = MockStatusFactory.makeStatus(
+            id: "plain-text-url",
+            content: "<p>Read this next: https://example.com/plain-text-story</p>"
+        )
+
+        let linkStatuses = await service.processStatuses([status])
+
+        #expect(linkStatuses.count == 1)
+        #expect(linkStatuses.first?.id == "plain-text-url")
+        #expect(linkStatuses.first?.primaryURL.absoluteString == "https://example.com/plain-text-story")
+    }
+
+    @Test("Excludes statuses that only contain internal Mastodon URLs")
+    func excludesStatusesThatOnlyContainInternalMastodonURLs() async {
+        let internalCardStatus = MockStatusFactory.makeStatus(
+            id: "internal-card",
+            hasCard: true,
+            cardURL: "https://mastodon.social/@testuser/123456"
+        )
+        let internalContentStatus = MockStatusFactory.makeStatus(
+            id: "internal-content",
+            content: """
+            <p>
+            <a href="https://mastodon.social/@someone">profile</a>
+            <a href="https://mastodon.social/tags/swift">tag</a>
+            <a href="https://mastodon.social/@someone/999">status</a>
+            </p>
+            """
+        )
+
+        let linkStatuses = await service.processStatuses([internalCardStatus, internalContentStatus])
+
+        #expect(linkStatuses.isEmpty)
+    }
     
     // MARK: - Quote Post Detection
     
@@ -109,6 +168,23 @@ struct LinkFilterServiceTests {
         #expect(links.count == 2)
         #expect(links.contains { $0.absoluteString == "https://example.com/article1" })
         #expect(links.contains { $0.absoluteString == "https://other.com/article2" })
+    }
+
+    @Test("Plain text fallback only runs when anchor links are absent")
+    func plainTextFallbackOnlyRunsWhenAnchorLinksAreAbsent() async {
+        let status = MockStatusFactory.makeStatus(
+            content: """
+            <p>
+            Anchor first <a href="https://example.com/anchor-story">story</a>
+            then https://example.com/plain-text-story
+            </p>
+            """
+        )
+
+        let links = service.extractExternalLinks(from: status)
+
+        #expect(links.count == 1)
+        #expect(links.first?.absoluteString == "https://example.com/anchor-story")
     }
     
     // MARK: - Processing
@@ -370,6 +446,96 @@ struct LinkFilterServiceTests {
         #expect(linkStatuses.count == 1)
         #expect(linkStatuses.first?.id == "article")
         #expect(linkStatuses.first?.primaryURL.absoluteString == "https://example.com/article")
+    }
+
+    @Test("Processes list batches with retrievable links even when no cards are typed as link")
+    func processesListBatchesWithRetrievableLinksWhenNoCardsAreTypedAsLink() async {
+        let statuses = [
+            MockStatusFactory.makeStatus(
+                id: "photo-card",
+                hasCard: true,
+                cardURL: "https://example.com/photo-story",
+                cardType: .photo
+            ),
+            MockStatusFactory.makeStatus(
+                id: "rich-card",
+                hasCard: true,
+                cardURL: "https://example.com/rich-story",
+                cardType: .rich
+            ),
+            MockStatusFactory.makeStatus(
+                id: "plain-text",
+                content: "<p>Context https://example.com/plain-text-story</p>"
+            )
+        ]
+
+        let linkStatuses = await service.processStatuses(statuses, for: "list-3")
+
+        #expect(linkStatuses.count == 3)
+        #expect(linkStatuses.map(\.id) == ["photo-card", "rich-card", "plain-text"])
+    }
+
+    @Test("Processes older pages until empty feeds gain visible content")
+    func processesOlderPagesUntilEmptyFeedsGainVisibleContent() async {
+        let initialStatuses = [
+            MockStatusFactory.makeStatus(id: "no-link-1", content: "<p>No external links here</p>")
+        ]
+        let olderStatuses = [
+            MockStatusFactory.makeStatus(
+                id: "older-link",
+                hasCard: true,
+                cardURL: "https://example.com/older-story"
+            )
+        ]
+        var remainingPages = [olderStatuses]
+
+        let linkStatuses = await service.processStatusesEnsuringVisibleContent(
+            initialStatuses,
+            for: "list-older",
+            canLoadMore: { !remainingPages.isEmpty },
+            loadMoreStatuses: { remainingPages.removeFirst() }
+        )
+
+        #expect(linkStatuses.count == 1)
+        #expect(linkStatuses.first?.id == "older-link")
+        #expect(remainingPages.isEmpty)
+    }
+
+    @Test("Appends older pages until pagination yields additional visible content")
+    func appendsOlderPagesUntilPaginationYieldsAdditionalVisibleContent() async {
+        _ = await service.processStatuses(
+            [
+                MockStatusFactory.makeStatus(
+                    id: "existing-link",
+                    hasCard: true,
+                    cardURL: "https://example.com/existing-story"
+                )
+            ],
+            for: "list-pagination"
+        )
+
+        let firstPaginationBatch = [
+            MockStatusFactory.makeStatus(id: "no-link-page", content: "<p>Still no links</p>")
+        ]
+        let olderStatuses = [
+            MockStatusFactory.makeStatus(
+                id: "older-link",
+                hasCard: true,
+                cardURL: "https://example.com/older-story"
+            )
+        ]
+        var remainingPages = [olderStatuses]
+
+        let linkStatuses = await service.appendStatusesEnsuringAdditionalContent(
+            firstPaginationBatch,
+            for: "list-pagination",
+            canLoadMore: { !remainingPages.isEmpty },
+            loadMoreStatuses: { remainingPages.removeFirst() }
+        )
+
+        #expect(linkStatuses.count == 2)
+        #expect(linkStatuses.map(\.id) == ["existing-link", "older-link"])
+        #expect(remainingPages.isEmpty)
     }
 
     @Test("Excludes Threads and Instagram subdomains and bare domains")

--- a/fedi-readerTests/MastodonTypesTests.swift
+++ b/fedi-readerTests/MastodonTypesTests.swift
@@ -34,9 +34,11 @@ struct MastodonTypesTests {
     @Test("Status correctly identifies link card")
     func statusIdentifiesLinkCard() {
         let withCard = MockStatusFactory.makeStatus(hasCard: true, cardURL: "https://example.com")
+        let withRichCard = MockStatusFactory.makeStatus(hasCard: true, cardURL: "https://example.com/embed", cardType: .rich)
         let withoutCard = MockStatusFactory.makeStatus(hasCard: false)
         
         #expect(withCard.hasLinkCard == true)
+        #expect(withRichCard.hasLinkCard == true)
         #expect(withoutCard.hasLinkCard == false)
     }
     

--- a/fedi-readerTests/MockStatusFactory.swift
+++ b/fedi-readerTests/MockStatusFactory.swift
@@ -7,6 +7,7 @@ enum MockStatusFactory {
         content: String = "<p>Test post content</p>",
         hasCard: Bool = false,
         cardURL: String? = nil,
+        cardType: CardType = .link,
         cardTitle: String? = nil,
         uri: String? = nil,
         url: String? = nil,
@@ -29,7 +30,7 @@ enum MockStatusFactory {
                 url: url,
                 title: cardTitle ?? "Test Article",
                 description: "Test description",
-                type: .link,
+                type: cardType,
                 authorName: "Test Author",
                 authorUrl: nil,
                 providerName: "test.com",
@@ -185,6 +186,7 @@ class MockURLProtocol: URLProtocol {
     static var mockResponses: [String: (Data, HTTPURLResponse)] = [:]
     static var queuedResponses: [String: [(Data, HTTPURLResponse)]] = [:]
     static var mockErrors: [String: Error] = [:]
+    static var responseDelays: [String: TimeInterval] = [:]
     static var requestCounts: [String: Int] = [:]
     static var lastRequest: URLRequest?
     private static let lock = NSLock()
@@ -218,7 +220,12 @@ class MockURLProtocol: URLProtocol {
             }
         }
         let mockResponse = queuedResponse ?? Self.mockResponses[url]
+        let responseDelay = Self.responseDelays[url] ?? 0
         Self.lock.unlock()
+
+        if responseDelay > 0 {
+            Thread.sleep(forTimeInterval: responseDelay)
+        }
         
         if let error {
             client?.urlProtocol(self, didFailWithError: error)
@@ -241,6 +248,7 @@ class MockURLProtocol: URLProtocol {
         mockResponses.removeAll()
         queuedResponses.removeAll()
         mockErrors.removeAll()
+        responseDelays.removeAll()
         requestCounts.removeAll()
         lastRequest = nil
     }
@@ -287,6 +295,12 @@ class MockURLProtocol: URLProtocol {
         lock.lock()
         defer { lock.unlock() }
         mockErrors[url] = error
+    }
+
+    static func setResponseDelay(for url: String, seconds: TimeInterval) {
+        lock.lock()
+        defer { lock.unlock() }
+        responseDelays[url] = seconds
     }
 
     static func requestCount(for url: String) -> Int {

--- a/fedi-readerTests/ThreadBuilderTests.swift
+++ b/fedi-readerTests/ThreadBuilderTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import fedi_reader
+
+private func makeThreadStatus(
+    id: String,
+    inReplyToId: String? = nil,
+    createdAt: Date
+) -> Status {
+    Status(
+        id: id,
+        uri: "https://mastodon.social/statuses/\(id)",
+        url: "https://mastodon.social/@testuser/\(id)",
+        createdAt: createdAt,
+        account: MockStatusFactory.makeAccount(id: "account-\(id)", username: "user\(id)", displayName: "User \(id)"),
+        content: "<p>\(id)</p>",
+        visibility: .public,
+        sensitive: false,
+        spoilerText: "",
+        mediaAttachments: [],
+        mentions: [],
+        tags: [],
+        emojis: [],
+        reblogsCount: 0,
+        favouritesCount: 0,
+        repliesCount: 0,
+        application: nil,
+        language: "en",
+        reblog: nil,
+        card: nil,
+        poll: nil,
+        quote: nil,
+        favourited: false,
+        reblogged: false,
+        muted: false,
+        bookmarked: false,
+        pinned: false,
+        inReplyToId: inReplyToId,
+        inReplyToAccountId: nil
+    )
+}
+
+@Suite("ThreadBuilder Tests")
+struct ThreadBuilderTests {
+    @Test("buildThreadTree nests replies beneath their root in chronological order")
+    func buildThreadTreeNestsReplies() {
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let root = makeThreadStatus(id: "root", createdAt: baseDate)
+        let laterReply = makeThreadStatus(
+            id: "reply-later",
+            inReplyToId: root.id,
+            createdAt: baseDate.addingTimeInterval(120)
+        )
+        let earlierReply = makeThreadStatus(
+            id: "reply-earlier",
+            inReplyToId: root.id,
+            createdAt: baseDate.addingTimeInterval(60)
+        )
+        let nestedReply = makeThreadStatus(
+            id: "reply-child",
+            inReplyToId: earlierReply.id,
+            createdAt: baseDate.addingTimeInterval(180)
+        )
+
+        let trees = ThreadBuilder.buildThreadTree(
+            from: [laterReply, nestedReply, root, earlierReply]
+        )
+
+        #expect(trees.count == 1)
+        guard trees.count == 1 else { return }
+
+        let rootNode = trees[0]
+        #expect(rootNode.id == root.id)
+        #expect(rootNode.children.map(\.id) == [earlierReply.id, laterReply.id])
+        #expect(rootNode.children.first?.children.map(\.id) == [nestedReply.id])
+    }
+
+    @Test("findRootStatuses promotes orphaned replies to root threads")
+    func findRootStatusesPromotesOrphanedReplies() {
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let root = makeThreadStatus(id: "root", createdAt: baseDate)
+        let child = makeThreadStatus(
+            id: "child",
+            inReplyToId: root.id,
+            createdAt: baseDate.addingTimeInterval(60)
+        )
+        let orphan = makeThreadStatus(
+            id: "orphan",
+            inReplyToId: "missing-parent",
+            createdAt: baseDate.addingTimeInterval(120)
+        )
+
+        let statusMap = Dictionary(uniqueKeysWithValues: [root, child, orphan].map { ($0.id, $0) })
+        let roots = ThreadBuilder.findRootStatuses([root, child, orphan], statusMap: statusMap)
+
+        #expect(roots.map(\.id) == [root.id, orphan.id])
+    }
+}

--- a/fedi-readerTests/TimelineServiceLinkFeedTests.swift
+++ b/fedi-readerTests/TimelineServiceLinkFeedTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Timeline Service Link Feed Tests", .serialized)
+@MainActor
+struct TimelineServiceLinkFeedTests {
+    @Test("concurrent list feed loads return the requested list data")
+    func concurrentListFeedLoadsReturnRequestedStatuses() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = makeAccount()
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let listAURL = listTimelineURL(instance: account.instance, listId: "list-a", maxId: nil)
+            let listBURL = listTimelineURL(instance: account.instance, listId: "list-b", maxId: nil)
+            MockURLProtocol.setMockResponse(
+                for: listAURL,
+                data: try makeEncoder().encode([MockStatusFactory.makeStatus(id: "list-a-1")])
+            )
+            MockURLProtocol.setMockResponse(
+                for: listBURL,
+                data: try makeEncoder().encode([MockStatusFactory.makeStatus(id: "list-b-1")])
+            )
+            MockURLProtocol.setResponseDelay(for: listAURL, seconds: 0.2)
+
+            let firstTask = Task { await service.loadLinkFeedStatuses(feedId: "list-a") }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            let secondTask = Task { await service.loadLinkFeedStatuses(feedId: "list-b") }
+
+            let firstStatuses = await firstTask.value
+            let secondStatuses = await secondTask.value
+
+            #expect(firstStatuses.map(\.id) == ["list-a-1"])
+            #expect(secondStatuses.map(\.id) == ["list-b-1"])
+            #expect(service.hasPreparedLinkFeedState(feedId: "list-b"))
+            #expect(MockURLProtocol.requestCount(for: listAURL) == 1)
+            #expect(MockURLProtocol.requestCount(for: listBURL) == 1)
+        }
+    }
+
+    @Test("load more refreshes the selected list when shared list state belongs to another feed")
+    func loadMoreRefreshesSelectedListWhenStateBelongsToAnotherFeed() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = makeAccount()
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let listAURL = listTimelineURL(instance: account.instance, listId: "list-a", maxId: nil)
+            let listBURL = listTimelineURL(instance: account.instance, listId: "list-b", maxId: nil)
+            MockURLProtocol.setMockResponse(
+                for: listAURL,
+                data: try makeEncoder().encode([
+                    MockStatusFactory.makeStatus(id: "list-a-1"),
+                    MockStatusFactory.makeStatus(id: "list-a-2")
+                ])
+            )
+            MockURLProtocol.setMockResponse(
+                for: listBURL,
+                data: try makeEncoder().encode([
+                    MockStatusFactory.makeStatus(id: "list-b-1"),
+                    MockStatusFactory.makeStatus(id: "list-b-2")
+                ])
+            )
+
+            _ = await service.loadLinkFeedStatuses(feedId: "list-a")
+            let refreshedStatuses = await service.loadMoreListTimeline(listId: "list-b")
+
+            #expect(refreshedStatuses.map(\.id) == ["list-b-1", "list-b-2"])
+            #expect(service.hasPreparedLinkFeedState(feedId: "list-b"))
+            #expect(MockURLProtocol.requestCount(for: listBURL) == 1)
+        }
+    }
+
+    @Test("concurrent hashtag feed loads return the requested hashtag data")
+    func concurrentHashtagFeedLoadsReturnRequestedStatuses() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = makeAccount()
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let swiftURL = hashtagTimelineURL(instance: account.instance, tag: "swift", maxId: nil)
+            let iosURL = hashtagTimelineURL(instance: account.instance, tag: "ios", maxId: nil)
+            MockURLProtocol.setMockResponse(
+                for: swiftURL,
+                data: try makeEncoder().encode([MockStatusFactory.makeStatus(id: "swift-1")])
+            )
+            MockURLProtocol.setMockResponse(
+                for: iosURL,
+                data: try makeEncoder().encode([MockStatusFactory.makeStatus(id: "ios-1")])
+            )
+            MockURLProtocol.setResponseDelay(for: swiftURL, seconds: 0.2)
+
+            let firstTask = Task { await service.loadLinkFeedStatuses(feedId: AppState.hashtagFeedID("swift")) }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            let secondTask = Task { await service.loadLinkFeedStatuses(feedId: AppState.hashtagFeedID("ios")) }
+
+            let swiftStatuses = await firstTask.value
+            let iosStatuses = await secondTask.value
+
+            #expect(swiftStatuses.map(\.id) == ["swift-1"])
+            #expect(iosStatuses.map(\.id) == ["ios-1"])
+            #expect(service.hasPreparedLinkFeedState(feedId: AppState.hashtagFeedID("ios")))
+            #expect(MockURLProtocol.requestCount(for: swiftURL) == 1)
+            #expect(MockURLProtocol.requestCount(for: iosURL) == 1)
+        }
+    }
+
+    private func makeClient() -> MastodonClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockURLProtocol.self]
+        return MastodonClient(configuration: configuration)
+    }
+
+    private func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private func makeAccount() -> Account {
+        Account(
+            id: "mastodon.social:\(UUID().uuidString)",
+            instance: "mastodon.social",
+            username: "tester",
+            displayName: "Tester",
+            acct: "tester@mastodon.social",
+            isActive: true
+        )
+    }
+
+    private func listTimelineURL(instance: String, listId: String, maxId: String?) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/timelines/list/\(listId)"
+        components.queryItems = [URLQueryItem(name: "limit", value: String(Constants.Pagination.defaultLimit))]
+        if let maxId {
+            components.queryItems?.append(URLQueryItem(name: "max_id", value: maxId))
+        }
+        return components.url!.absoluteString
+    }
+
+    private func hashtagTimelineURL(instance: String, tag: String, maxId: String?) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1/timelines/tag/\(tag)"
+        components.queryItems = [URLQueryItem(name: "limit", value: String(Constants.Pagination.defaultLimit))]
+        if let maxId {
+            components.queryItems?.append(URLQueryItem(name: "max_id", value: maxId))
+        }
+        return components.url!.absoluteString
+    }
+}


### PR DESCRIPTION
## Summary
- restore profile navigation from boost chips, posting accounts, and author attribution in the link feed
- fix the Swift 6 main-actor isolation error in thread building
- keep link feeds paging older posts until visible content appears or pagination is exhausted
- document the Linear parent/sub-issue workflow and the Source/Agent label rules for agents

## Testing
- xcodebuild -scheme "fedi-reader" -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" -only-testing:fedi-readerTests/LinkFilterServiceTests -only-testing:fedi-readerTests/TimelineServiceLinkFeedTests test
- xcodebuild -scheme "fedi-reader" -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" -only-testing:fedi-readerTests test (still fails on the same pre-existing TabConfigurationTests and ListEditorEditModeFeaturesTests expectations)

Closes FEDI-71
Closes FEDI-72
Closes FEDI-73