### PR TITLE
Hide other users in private mention feed

### DIFF
--- a/fedi-reader/Utilities/ConversationSearch/DirectMessageMentionFormatter.swift
+++ b/fedi-reader/Utilities/ConversationSearch/DirectMessageMentionFormatter.swift
@@ -13,5 +13,92 @@ enum DirectMessageMentionFormatter {
 
         return mentions.joined(separator: " ")
     }
-}
 
+    static func hiddenHandles(for accounts: [MastodonAccount]) -> Set<String> {
+        var handles = Set<String>()
+
+        for account in accounts {
+            insertHandleVariants(from: account.acct, into: &handles)
+            insertHandleVariants(from: account.username, into: &handles)
+        }
+
+        return handles
+    }
+
+    static func stripLeadingMentions(from text: String, hiddenHandles: Set<String>) -> String {
+        guard
+            !hiddenHandles.isEmpty,
+            let prefix = leadingMentionPrefix(in: text, hiddenHandles: hiddenHandles)
+        else {
+            return text
+        }
+
+        return String(text.dropFirst(prefix.count))
+    }
+
+    @available(iOS 15.0, macOS 12.0, *)
+    static func stripLeadingMentions(
+        from attributedString: AttributedString,
+        hiddenHandles: Set<String>
+    ) -> AttributedString {
+        guard !hiddenHandles.isEmpty else {
+            return attributedString
+        }
+
+        let plainText = String(attributedString.characters)
+        guard
+            let prefix = leadingMentionPrefix(in: plainText, hiddenHandles: hiddenHandles),
+            let range = attributedString.range(of: prefix, options: [.anchored])
+        else {
+            return attributedString
+        }
+
+        var stripped = attributedString
+        stripped.removeSubrange(range)
+        return stripped
+    }
+
+    private static func insertHandleVariants(from rawHandle: String, into handles: inout Set<String>) {
+        guard let normalized = HandleInputParser.normalizeHandle(rawHandle) else { return }
+        handles.insert(normalized)
+
+        if let atIndex = normalized.firstIndex(of: "@"), atIndex > normalized.startIndex {
+            handles.insert(String(normalized[..<atIndex]))
+        }
+    }
+
+    private static func leadingMentionPrefix(in text: String, hiddenHandles: Set<String>) -> String? {
+        var index = text.startIndex
+        while index < text.endIndex, text[index].isWhitespace {
+            index = text.index(after: index)
+        }
+
+        var matchedMention = false
+
+        while index < text.endIndex {
+            guard text[index] == "@" else { break }
+
+            let tokenStart = index
+            while index < text.endIndex, !text[index].isWhitespace {
+                index = text.index(after: index)
+            }
+
+            let token = String(text[tokenStart..<index])
+            guard
+                let normalized = HandleInputParser.normalizeHandle(token),
+                hiddenHandles.contains(normalized)
+            else {
+                break
+            }
+
+            matchedMention = true
+
+            while index < text.endIndex, text[index].isWhitespace {
+                index = text.index(after: index)
+            }
+        }
+
+        guard matchedMention else { return nil }
+        return String(text[..<index])
+    }
+}

--- a/fedi-reader/Views/Feed/HashtagLinkText.swift
+++ b/fedi-reader/Views/Feed/HashtagLinkText.swift
@@ -16,6 +16,7 @@ struct HashtagLinkText: View {
     let onHashtagTap: (String) -> Void
     /// When provided (e.g. from status.emojis), used for emoji replacement; otherwise uses current instance's cached emoji.
     var emojiLookup: [String: CustomEmoji]? = nil
+    var hiddenMentionHandles: Set<String> = []
     @Environment(AppState.self) private var appState
     
     var body: some View {
@@ -42,10 +43,14 @@ struct HashtagLinkText: View {
             }
             return url
         }, emojiLookup: resolvedLookup)
+        let displayString = DirectMessageMentionFormatter.stripLeadingMentions(
+            from: attributedString,
+            hiddenHandles: hiddenMentionHandles
+        )
         
         #if os(iOS)
         if #available(iOS 16.0, *) {
-            Text(attributedString)
+            Text(displayString)
                 .accessibilityLabel("Post content with hashtags")
                 .accessibilityHint("Double tap hashtags to view related posts")
                 .environment(\.openURL, OpenURLAction { url in
@@ -63,7 +68,7 @@ struct HashtagLinkText: View {
                 })
         } else {
             // For iOS 15, use a simpler approach
-            Text(attributedString)
+            Text(displayString)
                 .accessibilityLabel("Post content with hashtags")
                 .accessibilityHint("Double tap hashtags to view related posts")
                 .onTapGesture {
@@ -72,7 +77,7 @@ struct HashtagLinkText: View {
                 }
         }
         #else
-        Text(attributedString)
+        Text(displayString)
             .accessibilityLabel("Post content with hashtags")
             .accessibilityHint("Double tap hashtags to view related posts")
         #endif

--- a/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
+++ b/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
@@ -6,6 +6,7 @@ struct ChatBubble: View {
     let message: ChatMessage
     let account: MastodonAccount
     let isSent: Bool
+    let hiddenMentionHandles: Set<String>
     @Environment(AppState.self) private var appState
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("themeColor") private var themeColorName = "blue"
@@ -28,6 +29,18 @@ struct ChatBubble: View {
     private var isFavoritedByMe: Bool {
         status?.favourited == true
     }
+
+    private var displayPlainText: String {
+        guard let status else { return "" }
+        return DirectMessageMentionFormatter.stripLeadingMentions(
+            from: status.content.htmlToPlainText,
+            hiddenHandles: hiddenMentionHandles
+        )
+    }
+
+    private var showsTextContent: Bool {
+        !displayPlainText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
     
     var body: some View {
         if let status = status {
@@ -36,18 +49,21 @@ struct ChatBubble: View {
             } label: {
                 VStack(alignment: isSent ? .trailing : .leading, spacing: 6) {
                     // Message content
-                    if #available(iOS 15.0, macOS 12.0, *) {
-                        HashtagLinkText(
-                            content: status.content,
-                            onHashtagTap: { appState.navigate(to: .hashtag($0)) },
-                            emojiLookup: Dictionary(uniqueKeysWithValues: status.emojis.map { ($0.shortcode, $0) })
-                        )
-                        .font(.roundedBody)
-                        .multilineTextAlignment(.leading)
-                    } else {
-                        Text(status.content.htmlToPlainText)
+                    if showsTextContent {
+                        if #available(iOS 15.0, macOS 12.0, *) {
+                            HashtagLinkText(
+                                content: status.content,
+                                onHashtagTap: { appState.navigate(to: .hashtag($0)) },
+                                emojiLookup: Dictionary(uniqueKeysWithValues: status.emojis.map { ($0.shortcode, $0) }),
+                                hiddenMentionHandles: hiddenMentionHandles
+                            )
                             .font(.roundedBody)
                             .multilineTextAlignment(.leading)
+                        } else {
+                            Text(displayPlainText)
+                                .font(.roundedBody)
+                                .multilineTextAlignment(.leading)
+                        }
                     }
                     
                     if !mediaAttachments.isEmpty {
@@ -203,5 +219,4 @@ private struct ChatGifvPlayerView: View {
 }
 
 // MARK: - Tapback View (iMessage-style reaction indicator)
-
 

--- a/fedi-reader/Views/Feed/Mentions/ChatMessageGroup.swift
+++ b/fedi-reader/Views/Feed/Mentions/ChatMessageGroup.swift
@@ -3,6 +3,7 @@ import os
 
 struct ChatMessageGroup: View {
     let group: GroupedMessage
+    let hiddenMentionHandles: Set<String>
     @Environment(AppState.self) private var appState
     
     var body: some View {
@@ -15,7 +16,12 @@ struct ChatMessageGroup: View {
                 VStack(alignment: .trailing, spacing: 4) {
                     // Chat bubbles
                     ForEach(group.messages) { message in
-                        ChatBubble(message: message, account: group.account, isSent: true)
+                        ChatBubble(
+                            message: message,
+                            account: group.account,
+                            isSent: true,
+                            hiddenMentionHandles: hiddenMentionHandles
+                        )
                     }
                 }
                 
@@ -76,7 +82,12 @@ struct ChatMessageGroup: View {
                     
                     // Chat bubbles
                     ForEach(group.messages) { message in
-                        ChatBubble(message: message, account: group.account, isSent: false)
+                        ChatBubble(
+                            message: message,
+                            account: group.account,
+                            isSent: false,
+                            hiddenMentionHandles: hiddenMentionHandles
+                        )
                     }
                 }
                 
@@ -88,5 +99,4 @@ struct ChatMessageGroup: View {
 }
 
 // MARK: - Chat Bubble
-
 

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
@@ -40,6 +40,15 @@ struct GroupedConversationDetailView: View {
     private var isGroupChat: Bool {
         currentGroupedConversation.isGroupChat
     }
+
+    private var hiddenMentionHandles: Set<String> {
+        var accounts = participants
+        if let currentAccount = appState.currentAccount?.mastodonAccount {
+            accounts.append(currentAccount)
+        }
+
+        return DirectMessageMentionFormatter.hiddenHandles(for: accounts)
+    }
     
     // Get the most recent status across all conversations to reply to
     private var mostRecentStatus: Status? {
@@ -96,7 +105,7 @@ struct GroupedConversationDetailView: View {
             ScrollView {
                 LazyVStack(spacing: 0) {
                     ForEach(groupedMessages) { group in
-                        ChatMessageGroup(group: group)
+                        ChatMessageGroup(group: group, hiddenMentionHandles: hiddenMentionHandles)
                             .id(group.id)
                     }
                 }
@@ -355,5 +364,4 @@ struct GroupedConversationDetailView: View {
 }
 
 // MARK: - Grouped Message
-
 

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationRow.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationRow.swift
@@ -3,7 +3,25 @@ import os
 
 struct GroupedConversationRow: View {
     let groupedConversation: GroupedConversation
+    @Environment(AppState.self) private var appState
     @AppStorage("themeColor") private var themeColorName = "blue"
+
+    private var hiddenMentionHandles: Set<String> {
+        var accounts = groupedConversation.participants
+        if let currentAccount = appState.currentAccount?.mastodonAccount {
+            accounts.append(currentAccount)
+        }
+
+        return DirectMessageMentionFormatter.hiddenHandles(for: accounts)
+    }
+
+    private var messagePreview: String {
+        guard let lastStatus = groupedConversation.lastStatus else { return "" }
+        return DirectMessageMentionFormatter.stripLeadingMentions(
+            from: lastStatus.content.htmlToPlainText,
+            hiddenHandles: hiddenMentionHandles
+        )
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -43,7 +61,7 @@ struct GroupedConversationRow: View {
                         .foregroundStyle(.secondary)
                 }
                 
-                Text(groupedConversation.lastStatus?.content.htmlToPlainText ?? "")
+                Text(messagePreview)
                     .font(.roundedSubheadline)
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
@@ -69,5 +87,4 @@ struct GroupedConversationRow: View {
 }
 
 // MARK: - Group Avatar View
-
 

--- a/fedi-readerTests/ConversationSearchHelpersTests.swift
+++ b/fedi-readerTests/ConversationSearchHelpersTests.swift
@@ -157,6 +157,57 @@ struct ConversationSearchHelpersTests {
         #expect(prefix == "@bob@beta.social @alice@alpha.social")
     }
 
+    @Test("Hidden handles match both full and username-only mention variants")
+    func hiddenHandlesIncludeFullAndShortVariants() {
+        let alice = makeAccount(id: "alice", username: "alice", acct: "alice@alpha.social", host: "alpha.social")
+
+        let handles = DirectMessageMentionFormatter.hiddenHandles(for: [alice])
+
+        #expect(handles.contains("alice@alpha.social"))
+        #expect(handles.contains("alice"))
+    }
+
+    @Test("Strips only leading conversation mentions from plain text")
+    func stripsOnlyLeadingConversationMentionsFromPlainText() {
+        let me = makeAccount(id: "me", username: "me", acct: "me@local.social", host: "local.social")
+        let alice = makeAccount(id: "alice", username: "alice", acct: "alice@alpha.social", host: "alpha.social")
+        let hiddenHandles = DirectMessageMentionFormatter.hiddenHandles(for: [me, alice])
+
+        let stripped = DirectMessageMentionFormatter.stripLeadingMentions(
+            from: "@alice @me Hello @carol",
+            hiddenHandles: hiddenHandles
+        )
+
+        #expect(stripped == "Hello @carol")
+    }
+
+    @Test("Keeps unknown leading mentions intact")
+    func keepsUnknownLeadingMentionsIntact() {
+        let alice = makeAccount(id: "alice", username: "alice", acct: "alice@alpha.social", host: "alpha.social")
+        let hiddenHandles = DirectMessageMentionFormatter.hiddenHandles(for: [alice])
+
+        let stripped = DirectMessageMentionFormatter.stripLeadingMentions(
+            from: "@carol Hello there",
+            hiddenHandles: hiddenHandles
+        )
+
+        #expect(stripped == "@carol Hello there")
+    }
+
+    @Test("Strips leading conversation mentions from attributed strings")
+    func stripsLeadingConversationMentionsFromAttributedStrings() {
+        let alice = makeAccount(id: "alice", username: "alice", acct: "alice@alpha.social", host: "alpha.social")
+        let hiddenHandles = DirectMessageMentionFormatter.hiddenHandles(for: [alice])
+        let attributed = AttributedString("@alice Hello #Swift")
+
+        let stripped = DirectMessageMentionFormatter.stripLeadingMentions(
+            from: attributed,
+            hiddenHandles: hiddenHandles
+        )
+
+        #expect(String(stripped.characters) == "Hello #Swift")
+    }
+
     private func makeConversation(id: String, accounts: [MastodonAccount]) -> MastodonConversation {
         let sender = accounts.first ?? makeAccount(id: "fallback", username: "fallback", acct: "fallback", host: "local.social")
         let status = MockStatusFactory.makeStatus(


### PR DESCRIPTION
Summary
- keep the private-mention feed looking like a chat interface by hiding other users’ mentions
- rely on the existing UI indicators for who the conversation is with

Testing
- Not run (not requested)