### PR TITLE
Fix attachment-only chat previews

### DIFF
--- a/fedi-reader/Utilities/ConversationSearch/DirectMessageMentionFormatter.swift
+++ b/fedi-reader/Utilities/ConversationSearch/DirectMessageMentionFormatter.swift
@@ -36,6 +36,19 @@ enum DirectMessageMentionFormatter {
         return String(text.dropFirst(prefix.count))
     }
 
+    static func conversationPreview(for status: Status, hiddenHandles: Set<String>) -> String {
+        let strippedText = stripLeadingMentions(
+            from: status.content.htmlToPlainText,
+            hiddenHandles: hiddenHandles
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !strippedText.isEmpty {
+            return strippedText
+        }
+
+        return attachmentPreview(for: status.mediaAttachments)
+    }
+
     @available(iOS 15.0, macOS 12.0, *)
     static func stripLeadingMentions(
         from attributedString: AttributedString,
@@ -100,5 +113,25 @@ enum DirectMessageMentionFormatter {
 
         guard matchedMention else { return nil }
         return String(text[..<index])
+    }
+
+    private static func attachmentPreview(for attachments: [MediaAttachment]) -> String {
+        guard !attachments.isEmpty else { return "" }
+
+        let attachmentTypes = Set(attachments.map(\.type))
+
+        if attachmentTypes == [.image] {
+            return "Sent an image"
+        }
+
+        if attachmentTypes.isSubset(of: [.video, .gifv]) {
+            return "Sent a video"
+        }
+
+        if attachmentTypes == [.audio] {
+            return "Sent an audio attachment"
+        }
+
+        return "Sent an attachment"
     }
 }

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationRow.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationRow.swift
@@ -17,8 +17,8 @@ struct GroupedConversationRow: View {
 
     private var messagePreview: String {
         guard let lastStatus = groupedConversation.lastStatus else { return "" }
-        return DirectMessageMentionFormatter.stripLeadingMentions(
-            from: lastStatus.content.htmlToPlainText,
+        return DirectMessageMentionFormatter.conversationPreview(
+            for: lastStatus,
             hiddenHandles: hiddenMentionHandles
         )
     }
@@ -87,4 +87,3 @@ struct GroupedConversationRow: View {
 }
 
 // MARK: - Group Avatar View
-

--- a/fedi-readerTests/ConversationSearchHelpersTests.swift
+++ b/fedi-readerTests/ConversationSearchHelpersTests.swift
@@ -208,6 +208,81 @@ struct ConversationSearchHelpersTests {
         #expect(String(stripped.characters) == "Hello #Swift")
     }
 
+    @Test("Conversation preview returns stripped text when text remains")
+    func conversationPreviewReturnsStrippedTextWhenTextRemains() {
+        let me = makeAccount(id: "me", username: "me", acct: "me@local.social", host: "local.social")
+        let alice = makeAccount(id: "alice", username: "alice", acct: "alice@alpha.social", host: "alpha.social")
+        let hiddenHandles = DirectMessageMentionFormatter.hiddenHandles(for: [me, alice])
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>@alice @me Hello there</p>",
+            mediaAttachments: [makeAttachment(type: .image)],
+            visibility: .direct
+        )
+
+        let preview = DirectMessageMentionFormatter.conversationPreview(for: status, hiddenHandles: hiddenHandles)
+
+        #expect(preview == "Hello there")
+    }
+
+    @Test("Conversation preview returns image fallback for image-only message")
+    func conversationPreviewReturnsImageFallback() {
+        let hiddenHandles = makeConversationHiddenHandles()
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>@alice @me</p>",
+            mediaAttachments: [makeAttachment(type: .image)],
+            visibility: .direct
+        )
+
+        let preview = DirectMessageMentionFormatter.conversationPreview(for: status, hiddenHandles: hiddenHandles)
+
+        #expect(preview == "Sent an image")
+    }
+
+    @Test("Conversation preview returns video fallback for video-only message")
+    func conversationPreviewReturnsVideoFallback() {
+        let hiddenHandles = makeConversationHiddenHandles()
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>@alice @me</p>",
+            mediaAttachments: [makeAttachment(type: .gifv)],
+            visibility: .direct
+        )
+
+        let preview = DirectMessageMentionFormatter.conversationPreview(for: status, hiddenHandles: hiddenHandles)
+
+        #expect(preview == "Sent a video")
+    }
+
+    @Test("Conversation preview returns audio fallback for audio-only message")
+    func conversationPreviewReturnsAudioFallback() {
+        let hiddenHandles = makeConversationHiddenHandles()
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>@alice @me</p>",
+            mediaAttachments: [makeAttachment(type: .audio)],
+            visibility: .direct
+        )
+
+        let preview = DirectMessageMentionFormatter.conversationPreview(for: status, hiddenHandles: hiddenHandles)
+
+        #expect(preview == "Sent an audio attachment")
+    }
+
+    @Test("Conversation preview returns generic fallback for mixed attachment message")
+    func conversationPreviewReturnsGenericFallbackForMixedAttachments() {
+        let hiddenHandles = makeConversationHiddenHandles()
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>@alice @me</p>",
+            mediaAttachments: [
+                makeAttachment(type: .image),
+                makeAttachment(type: .unknown)
+            ],
+            visibility: .direct
+        )
+
+        let preview = DirectMessageMentionFormatter.conversationPreview(for: status, hiddenHandles: hiddenHandles)
+
+        #expect(preview == "Sent an attachment")
+    }
+
     private func makeConversation(id: String, accounts: [MastodonAccount]) -> MastodonConversation {
         let sender = accounts.first ?? makeAccount(id: "fallback", username: "fallback", acct: "fallback", host: "local.social")
         let status = MockStatusFactory.makeStatus(
@@ -220,6 +295,25 @@ struct ConversationSearchHelpersTests {
             unread: false,
             accounts: accounts,
             lastStatus: status
+        )
+    }
+
+    private func makeConversationHiddenHandles() -> Set<String> {
+        let me = makeAccount(id: "me", username: "me", acct: "me@local.social", host: "local.social")
+        let alice = makeAccount(id: "alice", username: "alice", acct: "alice@alpha.social", host: "alpha.social")
+        return DirectMessageMentionFormatter.hiddenHandles(for: [me, alice])
+    }
+
+    private func makeAttachment(type: MediaType) -> MediaAttachment {
+        MediaAttachment(
+            id: UUID().uuidString,
+            type: type,
+            url: "https://example.com/\(type.rawValue)",
+            previewUrl: "https://example.com/\(type.rawValue)-preview",
+            remoteUrl: nil,
+            description: nil,
+            blurhash: nil,
+            meta: nil
         )
     }
 

--- a/fedi-readerTests/MockStatusFactory.swift
+++ b/fedi-readerTests/MockStatusFactory.swift
@@ -5,6 +5,7 @@ enum MockStatusFactory {
     static func makeStatus(
         id: String = UUID().uuidString,
         content: String = "<p>Test post content</p>",
+        mediaAttachments: [MediaAttachment] = [],
         hasCard: Bool = false,
         cardURL: String? = nil,
         cardType: CardType = .link,
@@ -54,7 +55,7 @@ enum MockStatusFactory {
             visibility: visibility,
             sensitive: false,
             spoilerText: "",
-            mediaAttachments: [],
+            mediaAttachments: mediaAttachments,
             mentions: [],
             tags: tags,
             emojis: [],


### PR DESCRIPTION
**Summary**
- derive chat preview text through a central helper that strips mentions and provides media-specific fallbacks
- keep conversation rows and styling untouched while ensuring attachment-only messages show descriptive copy
- add tests covering the new helper’s behavior across mention stripping and attachment scenarios

**Testing**
- Not run (not requested)