### PR TITLE
Fix thread execution regression in timeline refresh

### DIFF
--- a/fedi-reader/Services/StatusContextRefreshCoordinator.swift
+++ b/fedi-reader/Services/StatusContextRefreshCoordinator.swift
@@ -1,0 +1,161 @@
+import Foundation
+import os
+
+actor StatusContextRefreshCoordinator {
+    typealias PublishUpdate = @Sendable (StatusContextUpdatePayload) async -> Void
+
+    private struct ScheduledRefresh {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private static let logger = Logger(subsystem: "app.fedi-reader", category: "StatusContextRefreshCoordinator")
+
+    private let client: MastodonClient
+    private let authService: AuthService
+    private let remoteReplyService: RemoteReplyService
+    private var scheduledRefreshes: [String: ScheduledRefresh] = [:]
+
+    init(client: MastodonClient, authService: AuthService, remoteReplyService: RemoteReplyService) {
+        self.client = client
+        self.authService = authService
+        self.remoteReplyService = remoteReplyService
+    }
+
+    func scheduleAsyncRefreshPolling(
+        for status: Status,
+        header: AsyncRefreshHeader,
+        instance: String,
+        token: String,
+        publish: @escaping PublishUpdate
+    ) {
+        scheduleRefresh(forStatusId: status.id) { [weak self] refreshID in
+            guard let self else { return }
+            await self.runAsyncRefreshPolling(
+                refreshID: refreshID,
+                status: status,
+                header: header,
+                instance: instance,
+                token: token,
+                publish: publish
+            )
+        }
+    }
+
+    func scheduleFallbackRemoteReplyFetch(
+        for status: Status,
+        context: StatusContext,
+        publish: @escaping PublishUpdate
+    ) {
+        scheduleRefresh(forStatusId: status.id) { [weak self] refreshID in
+            guard let self else { return }
+            await self.runFallbackRemoteReplyFetch(
+                refreshID: refreshID,
+                status: status,
+                context: context,
+                publish: publish
+            )
+        }
+    }
+
+    func cancelRefresh(forStatusId statusId: String) {
+        scheduledRefreshes[statusId]?.task.cancel()
+        scheduledRefreshes.removeValue(forKey: statusId)
+    }
+
+    private func scheduleRefresh(
+        forStatusId statusId: String,
+        operation: @escaping @Sendable (UUID) async -> Void
+    ) {
+        cancelRefresh(forStatusId: statusId)
+
+        let refreshID = UUID()
+        let task = Task(priority: .utility) {
+            await operation(refreshID)
+        }
+        scheduledRefreshes[statusId] = ScheduledRefresh(id: refreshID, task: task)
+    }
+
+    private func runAsyncRefreshPolling(
+        refreshID: UUID,
+        status: Status,
+        header: AsyncRefreshHeader,
+        instance: String,
+        token: String,
+        publish: @escaping PublishUpdate
+    ) async {
+        defer { finishRefresh(refreshID: refreshID, forStatusId: status.id) }
+
+        var attempts = 0
+        let maxAttempts = Constants.RemoteReplies.asyncRefreshMaxPollAttempts
+
+        while !Task.isCancelled, attempts < maxAttempts {
+            do {
+                let refresh = try await client.getAsyncRefreshInBackground(
+                    instance: instance,
+                    accessToken: token,
+                    id: header.id
+                )
+                if refresh.status == "finished" {
+                    Self.logger.info("Async refresh finished for status \(status.id.prefix(8), privacy: .public)")
+                    break
+                }
+            } catch let error as FediReaderError {
+                if case .serverError(404, _) = error {
+                    Self.logger.debug("Async refresh 404 for id \(header.id.prefix(12), privacy: .public), stopping poll")
+                    break
+                }
+                Self.logger.debug("Async refresh poll error: \(error.localizedDescription)")
+            } catch {
+                Self.logger.debug("Async refresh poll error: \(error.localizedDescription)")
+            }
+
+            attempts += 1
+            if Task.isCancelled { return }
+            try? await Task.sleep(nanoseconds: UInt64(header.retrySeconds) * 1_000_000_000)
+        }
+
+        if Task.isCancelled { return }
+
+        do {
+            guard let session = await authService.activeSessionSnapshot() else { return }
+            let contextWithRefresh = try await client.getStatusContextWithRefreshInBackground(
+                instance: session.instance,
+                accessToken: session.accessToken,
+                id: status.id
+            )
+            if Task.isCancelled { return }
+            await publish(
+                StatusContextUpdatePayload(statusId: status.id, context: contextWithRefresh.context)
+            )
+        } catch {
+            Self.logger.error("Failed to re-fetch context after async refresh: \(error.localizedDescription)")
+        }
+    }
+
+    private func runFallbackRemoteReplyFetch(
+        refreshID: UUID,
+        status: Status,
+        context: StatusContext,
+        publish: @escaping PublishUpdate
+    ) async {
+        defer { finishRefresh(refreshID: refreshID, forStatusId: status.id) }
+
+        guard let updatedContext = await remoteReplyService.fetchRemoteReplyContext(
+            for: status,
+            initialContext: context
+        ) else {
+            return
+        }
+
+        if Task.isCancelled { return }
+        await publish(StatusContextUpdatePayload(statusId: status.id, context: updatedContext))
+    }
+
+    private func finishRefresh(refreshID: UUID, forStatusId statusId: String) {
+        guard scheduledRefreshes[statusId]?.id == refreshID else {
+            return
+        }
+        scheduledRefreshes.removeValue(forKey: statusId)
+    }
+}

--- a/fedi-reader/Services/ThreadingService.swift
+++ b/fedi-reader/Services/ThreadingService.swift
@@ -1,33 +1,23 @@
-//
-//  ThreadingService.swift
-//  fedi-reader
-//
-//  Service for building and managing reply thread structures
-//
-
 import Foundation
-import os
 
-@Observable
-@MainActor
-final class ThreadingService {
-    private static let logger = Logger(subsystem: "app.fedi-reader", category: "ThreadingService")
-    
+actor ThreadingService {
+    static let shared = ThreadingService()
+
     /// Builds a thread tree from a flat array of statuses
     func buildThreadTree(from statuses: [Status]) -> [ThreadNode] {
         ThreadBuilder.buildThreadTree(from: statuses)
     }
-    
+
     /// Merges multiple thread trees, useful when combining statuses from different sources
     func mergeThreads(_ threads: [ThreadNode]) -> [ThreadNode] {
         ThreadBuilder.mergeThreads(threads)
     }
-    
+
     /// Finds the root thread node containing a specific status
     func findThreadRoot(for status: Status, in threads: [ThreadNode]) -> ThreadNode? {
         ThreadBuilder.findThreadRoot(for: status, in: threads)
     }
-    
+
     /// Gets the path from root to a specific status ID within a thread
     func getThreadPath(to statusId: String, from root: ThreadNode) -> [Status] {
         guard root.findNode(withId: statusId) != nil else {
@@ -44,15 +34,15 @@ final class ThreadingService {
         return path
     }
     
-    /// Helper to recursively build path to a status
+    /// Helper to recursively build the path to a status.
     private func buildPath(to statusId: String, from node: ThreadNode, currentPath: [Status], result: inout [Status]) {
         let newPath = currentPath + [node.status]
-        
+
         if node.id == statusId {
             result = newPath
             return
         }
-        
+
         for child in node.children {
             buildPath(to: statusId, from: child, currentPath: newPath, result: &result)
             if !result.isEmpty {
@@ -60,40 +50,33 @@ final class ThreadingService {
             }
         }
     }
-    
+
     /// Builds a unified thread tree from ancestors, current status, and descendants
-    /// This is useful for StatusDetailView where we have separate ancestor/descendant arrays
+    /// This is useful for `StatusDetailView`, where ancestors and descendants are loaded separately.
     func buildUnifiedThread(
         ancestors: [Status],
         current: Status,
         descendants: [Status]
     ) -> ThreadNode {
-        // Combine all statuses
         let allStatuses = ancestors + [current] + descendants
-        
-        // Build the full tree
         let threads = buildThreadTree(from: allStatuses)
-        
-        // Find the thread containing the current status
+
         if let currentThread = threads.first(where: { $0.findNode(withId: current.id) != nil }) {
             return currentThread
         }
-        
-        // Fallback: if current status isn't in any thread, create a simple node
-        // This can happen if ancestors/descendants don't properly connect
+
         let descendantNodes = buildThreadTree(from: descendants)
         return ThreadNode(status: current, children: descendantNodes)
     }
-    
+
     /// Handles orphaned replies (replies whose parent is missing)
     /// Returns threads with orphaned replies either as roots or with placeholder parents
     func handleOrphanedReplies(_ statuses: [Status]) -> [ThreadNode] {
         let statusMap = Dictionary(uniqueKeysWithValues: statuses.map { ($0.id, $0) })
-        
-        // Separate orphaned replies
+
         var orphaned: [Status] = []
         var valid: [Status] = []
-        
+
         for status in statuses {
             if let replyToId = status.inReplyToId, statusMap[replyToId] == nil {
                 orphaned.append(status)
@@ -101,14 +84,10 @@ final class ThreadingService {
                 valid.append(status)
             }
         }
-        
-        // Build normal threads from valid statuses
         var threads = buildThreadTree(from: valid)
-        
-        // Add orphaned replies as root-level threads
         let orphanedThreads = buildThreadTree(from: orphaned)
         threads.append(contentsOf: orphanedThreads)
-        
+
         return threads
     }
 }

--- a/fedi-reader/Services/TimelineService.swift
+++ b/fedi-reader/Services/TimelineService.swift
@@ -17,6 +17,7 @@ final class TimelineService {
     private let client: MastodonClient
     private let authService: AuthService
     private let remoteReplyService: RemoteReplyService
+    private let statusContextRefreshCoordinator: StatusContextRefreshCoordinator
     
     // Timeline state
     var homeTimeline: [Status] = []
@@ -69,8 +70,6 @@ final class TimelineService {
     private var hashtagTimelineLoadWaiters: [CheckedContinuation<Void, Never>] = []
     private var loadingListTimelineFeedId: String?
     
-    /// Polling tasks for async refresh, keyed by status ID. Cancelled when starting a new refresh for same status or via cancelAsyncRefreshPolling.
-    private var asyncRefreshPollingTasks: [String: Task<Void, Never>] = [:]
     private var inboxAutoRefreshTask: Task<Void, Never>?
     
     // Error state
@@ -85,6 +84,11 @@ final class TimelineService {
         self.client = client
         self.authService = authService
         self.remoteReplyService = RemoteReplyService(client: client, authService: authService)
+        self.statusContextRefreshCoordinator = StatusContextRefreshCoordinator(
+            client: client,
+            authService: authService,
+            remoteReplyService: self.remoteReplyService
+        )
     }
     
     // MARK: - Home Timeline
@@ -649,19 +653,30 @@ final class TimelineService {
         
         if let header = buildAsyncRefreshHeader(from: contextWithRefresh) {
             Self.logger.info("Async refresh available on refresh for status \(status.id.prefix(8), privacy: .public), starting polling")
-            startAsyncRefreshPolling(status: status, header: header, instance: session.instance, token: session.accessToken)
+            await statusContextRefreshCoordinator.scheduleAsyncRefreshPolling(
+                for: status,
+                header: header,
+                instance: session.instance,
+                token: session.accessToken,
+                publish: Self.publishStatusContextUpdate
+            )
         } else if shouldFetchRemoteReplies(context: context, status: status) {
-            startFallbackRemoteReplyFetch(status: status, context: context)
+            await statusContextRefreshCoordinator.scheduleFallbackRemoteReplyFetch(
+                for: status,
+                context: context,
+                publish: Self.publishStatusContextUpdate
+            )
         } else {
             let payload = StatusContextUpdatePayload(statusId: status.id, context: context)
             NotificationCenter.default.post(name: .statusContextDidUpdate, object: payload)
         }
     }
     
-    /// Cancels any active async-refresh polling for the given status. Call when leaving thread or starting a new refresh.
+    /// Cancels any active reply-context refresh work for the given status.
     func cancelAsyncRefreshPolling(forStatusId statusId: String) {
-        asyncRefreshPollingTasks[statusId]?.cancel()
-        asyncRefreshPollingTasks.removeValue(forKey: statusId)
+        Task(priority: .utility) { [statusContextRefreshCoordinator] in
+            await statusContextRefreshCoordinator.cancelRefresh(forStatusId: statusId)
+        }
     }
     
     private func buildAsyncRefreshHeader(from contextWithRefresh: MastodonClient.StatusContextWithRefresh) -> AsyncRefreshHeader? {
@@ -683,62 +698,6 @@ final class TimelineService {
         )
     }
     
-    private func startAsyncRefreshPolling(status: Status, header: AsyncRefreshHeader, instance: String, token: String) {
-        asyncRefreshPollingTasks[status.id]?.cancel()
-        asyncRefreshPollingTasks.removeValue(forKey: status.id)
-        
-        let task = Task { [weak self] in
-            guard let self else { return }
-            var attempts = 0
-            let maxAttempts = Constants.RemoteReplies.asyncRefreshMaxPollAttempts
-            
-            while !Task.isCancelled, attempts < maxAttempts {
-                do {
-                    let refresh = try await self.client.getAsyncRefreshInBackground(
-                        instance: instance,
-                        accessToken: token,
-                        id: header.id
-                    )
-                    if refresh.status == "finished" {
-                        Self.logger.info("Async refresh finished for status \(status.id.prefix(8), privacy: .public)")
-                        break
-                    }
-                } catch let err as FediReaderError {
-                    if case .serverError(404, _) = err {
-                        Self.logger.debug("Async refresh 404 for id \(header.id.prefix(12), privacy: .public), stopping poll")
-                        break
-                    }
-                    Self.logger.debug("Async refresh poll error: \(err.localizedDescription)")
-                } catch {
-                    Self.logger.debug("Async refresh poll error: \(error.localizedDescription)")
-                }
-                
-                attempts += 1
-                if Task.isCancelled { return }
-                try? await Task.sleep(nanoseconds: UInt64(header.retrySeconds) * 1_000_000_000)
-            }
-            
-            if Task.isCancelled { return }
-            
-            do {
-                guard let session = await self.authService.activeSessionSnapshot() else { return }
-                let ctxWithRefresh = try await self.client.getStatusContextWithRefreshInBackground(
-                    instance: session.instance,
-                    accessToken: session.accessToken,
-                    id: status.id
-                )
-                let payload = StatusContextUpdatePayload(statusId: status.id, context: ctxWithRefresh.context)
-                NotificationCenter.default.post(name: .statusContextDidUpdate, object: payload)
-            } catch {
-                Self.logger.error("Failed to re-fetch context after async refresh: \(error.localizedDescription)")
-            }
-            
-            self.asyncRefreshPollingTasks.removeValue(forKey: status.id)
-        }
-        
-        asyncRefreshPollingTasks[status.id] = task
-    }
-    
     /// Fetches remote replies for a status and returns updated context
     func fetchRemoteReplies(for status: Status) async throws -> [Status] {
         let context = await remoteReplyService.fetchRemoteReplyContext(for: status)
@@ -751,19 +710,8 @@ final class TimelineService {
         return context.needsRemoteReplyFetch(for: status, localInstance: localInstance)
     }
 
-    private func startFallbackRemoteReplyFetch(status: Status, context: StatusContext) {
-        Self.logger.info("Attempting fallback remote reply fetch for status: \(status.id.prefix(8), privacy: .public)")
-
-        Task { [weak self] in
-            guard let self else { return }
-            guard let updatedContext = await self.remoteReplyService.fetchRemoteReplyContext(
-                for: status,
-                initialContext: context
-            ) else {
-                return
-            }
-
-            let payload = StatusContextUpdatePayload(statusId: status.id, context: updatedContext)
+    nonisolated private static func publishStatusContextUpdate(_ payload: StatusContextUpdatePayload) async {
+        await MainActor.run {
             NotificationCenter.default.post(name: .statusContextDidUpdate, object: payload)
         }
     }

--- a/fedi-reader/Views/Feed/StatusDetailView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct StatusDetailView: View {
     let status: Status
-    @Environment(AppState.self) private var appState
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
 
     @State private var context: StatusContext?
@@ -10,12 +9,18 @@ struct StatusDetailView: View {
     @State private var isLoading = true
     @State private var isLoadingRemoteReplies = false
 
+    private let threadingService = ThreadingService.shared
+
     private var threadStatus: Status {
         status.displayStatus
     }
 
     private var parentStatus: Status? {
         context?.parentStatus(for: status)
+    }
+
+    private var replyTreeSource: [Status] {
+        context?.descendants ?? []
     }
 
     var body: some View {
@@ -149,11 +154,11 @@ struct StatusDetailView: View {
         }
         .navigationTitle("Post")
         .navigationBarTitleDisplayMode(.inline)
-        .task {
+        .task(id: threadStatus.id) {
             await loadContext()
         }
-        .onChange(of: context?.descendants) { _, descendants in
-            buildReplyTrees(descendants: descendants ?? [])
+        .task(id: replyTreeSource) {
+            await rebuildReplyTrees(from: replyTreeSource)
         }
         .refreshable {
             await refreshReplies()
@@ -165,13 +170,16 @@ struct StatusDetailView: View {
             if let payload = notification.object as? StatusContextUpdatePayload,
                payload.statusId == threadStatus.id {
                 context = payload.context
-                buildReplyTrees(descendants: payload.context.descendants)
                 isLoadingRemoteReplies = false
             }
         }
     }
 
     private func loadContext() async {
+        context = nil
+        isLoading = true
+        isLoadingRemoteReplies = false
+
         guard let service = timelineWrapper.service else {
             isLoading = false
             return
@@ -180,7 +188,6 @@ struct StatusDetailView: View {
         do {
             let loadedContext = try await service.getStatusContext(for: threadStatus)
             context = loadedContext
-            buildReplyTrees(descendants: loadedContext.descendants)
             isLoading = false
             isLoadingRemoteReplies = false
         } catch {
@@ -189,18 +196,15 @@ struct StatusDetailView: View {
         }
     }
 
-    /// Builds thread tree off main thread to avoid UI hangs with large reply counts
-    private func buildReplyTrees(descendants: [Status]) {
+    private func rebuildReplyTrees(from descendants: [Status]) async {
         if descendants.isEmpty {
             replyTrees = []
             return
         }
-        Task.detached(priority: .userInitiated) { [descendants] in
-            let trees = ThreadBuilder.buildThreadTree(from: descendants)
-            await MainActor.run {
-                replyTrees = trees
-            }
-        }
+
+        let trees = await threadingService.buildThreadTree(from: descendants)
+        guard !Task.isCancelled else { return }
+        replyTrees = trees
     }
     
     private func shouldFetchRemoteReplies(context: StatusContext) -> Bool {

--- a/fedi-reader/Views/Feed/ThreadPlaceholderView.swift
+++ b/fedi-reader/Views/Feed/ThreadPlaceholderView.swift
@@ -25,12 +25,15 @@ struct ThreadPlaceholderView: View {
             }
         }
         .navigationTitle("Thread")
-        .task {
+        .task(id: statusId) {
             await loadStatus()
         }
     }
 
     private func loadStatus() async {
+        status = nil
+        isLoading = true
+
         let client = appState.client
 
         do {

--- a/fedi-readerTests/ThreadingServiceTests.swift
+++ b/fedi-readerTests/ThreadingServiceTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import fedi_reader
+
+private func makeThreadingServiceStatus(
+    id: String,
+    inReplyToId: String? = nil,
+    createdAt: Date
+) -> Status {
+    Status(
+        id: id,
+        uri: "https://mastodon.social/statuses/\(id)",
+        url: "https://mastodon.social/@testuser/\(id)",
+        createdAt: createdAt,
+        account: MockStatusFactory.makeAccount(id: "account-\(id)", username: "user\(id)", displayName: "User \(id)"),
+        content: "<p>\(id)</p>",
+        visibility: .public,
+        sensitive: false,
+        spoilerText: "",
+        mediaAttachments: [],
+        mentions: [],
+        tags: [],
+        emojis: [],
+        reblogsCount: 0,
+        favouritesCount: 0,
+        repliesCount: 0,
+        application: nil,
+        language: "en",
+        reblog: nil,
+        card: nil,
+        poll: nil,
+        quote: nil,
+        favourited: false,
+        reblogged: false,
+        muted: false,
+        bookmarked: false,
+        pinned: false,
+        inReplyToId: inReplyToId,
+        inReplyToAccountId: nil
+    )
+}
+
+@Suite("Threading Service Tests")
+struct ThreadingServiceTests {
+    @Test("buildThreadTree returns the same ordered structure through the actor wrapper")
+    func buildThreadTreeThroughActor() async {
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let root = makeThreadingServiceStatus(id: "root", createdAt: baseDate)
+        let earlierReply = makeThreadingServiceStatus(
+            id: "reply-earlier",
+            inReplyToId: root.id,
+            createdAt: baseDate.addingTimeInterval(60)
+        )
+        let laterReply = makeThreadingServiceStatus(
+            id: "reply-later",
+            inReplyToId: root.id,
+            createdAt: baseDate.addingTimeInterval(120)
+        )
+
+        let trees = await ThreadingService().buildThreadTree(
+            from: [laterReply, root, earlierReply]
+        )
+
+        #expect(trees.count == 1)
+        #expect(trees.first?.id == root.id)
+        #expect(trees.first?.children.map(\.id) == [earlierReply.id, laterReply.id])
+    }
+}

--- a/fedi-readerTests/TimelineServiceContextTests.swift
+++ b/fedi-readerTests/TimelineServiceContextTests.swift
@@ -59,6 +59,261 @@ struct TimelineServiceContextTests {
         }
     }
 
+    @Test("Refresh with async refresh metadata publishes one final updated context")
+    func refreshContextPublishesUpdatedContextAfterAsyncRefreshPolling() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = Account(
+                id: "mastodon.social:\(UUID().uuidString)",
+                instance: "mastodon.social",
+                username: "tester",
+                displayName: "Tester",
+                acct: "tester@mastodon.social",
+                isActive: true
+            )
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let rootStatus = MockStatusFactory.makeStatus(id: "root-status", repliesCount: 2)
+            let firstReply = MockStatusFactory.makeStatus(id: "reply-1", inReplyToId: rootStatus.id)
+            let secondReply = MockStatusFactory.makeStatus(id: "reply-2", inReplyToId: rootStatus.id)
+
+            let partialContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply],
+                hasMoreReplies: true
+            )
+            let completedContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply, secondReply],
+                hasMoreReplies: false
+            )
+            let refresh = AsyncRefreshResponse(
+                asyncRefresh: AsyncRefresh(id: "refresh-123", status: "finished", resultCount: 2)
+            )
+
+            let contextURL = statusContextURL(instance: account.instance, id: rootStatus.id)
+            let refreshURL = asyncRefreshURL(instance: account.instance, id: "refresh-123")
+            let encoder = makeEncoder()
+
+            MockURLProtocol.setQueuedResponses(
+                for: contextURL,
+                responses: [
+                    (
+                        data: try encoder.encode(partialContext),
+                        statusCode: 200,
+                        headerFields: [Constants.RemoteReplies.asyncRefreshHeader: #"id="refresh-123", retry=1"#]
+                    ),
+                    (data: try encoder.encode(completedContext), statusCode: 200, headerFields: nil)
+                ]
+            )
+            MockURLProtocol.setMockResponse(
+                for: refreshURL,
+                data: try encoder.encode(refresh)
+            )
+
+            var payloads: [StatusContextUpdatePayload] = []
+            let observer = NotificationCenter.default.addObserver(
+                forName: .statusContextDidUpdate,
+                object: nil,
+                queue: nil
+            ) { notification in
+                guard let payload = notification.object as? StatusContextUpdatePayload else { return }
+                payloads.append(payload)
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            try await service.refreshContextForStatus(rootStatus)
+
+            let deliveredPayload = await waitForPayload(
+                for: rootStatus.id,
+                in: { payloads }
+            )
+
+            #expect(deliveredPayload?.context.descendants.map(\.id) == ["reply-1", "reply-2"])
+            #expect(payloads.count == 1)
+            #expect(MockURLProtocol.requestCount(for: contextURL) == 2)
+            #expect(MockURLProtocol.requestCount(for: refreshURL) == 1)
+        }
+    }
+
+    @Test("Refresh falls back to remote reply fetch when async refresh metadata is absent")
+    func refreshContextPublishesUpdatedContextAfterFallbackReplyFetch() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = Account(
+                id: "mastodon.social:\(UUID().uuidString)",
+                instance: "mastodon.social",
+                username: "tester",
+                displayName: "Tester",
+                acct: "tester@mastodon.social",
+                isActive: true
+            )
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let rootStatus = MockStatusFactory.makeStatus(id: "root-status", repliesCount: 2)
+            let firstReply = MockStatusFactory.makeStatus(id: "reply-1", inReplyToId: rootStatus.id)
+            let secondReply = MockStatusFactory.makeStatus(id: "reply-2", inReplyToId: rootStatus.id)
+
+            let partialContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply],
+                hasMoreReplies: true
+            )
+            let completedContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply, secondReply],
+                hasMoreReplies: false
+            )
+
+            let contextURL = statusContextURL(instance: account.instance, id: rootStatus.id)
+            let encoder = makeEncoder()
+
+            MockURLProtocol.setQueuedResponses(
+                for: contextURL,
+                responses: [
+                    (data: try encoder.encode(partialContext), statusCode: 200, headerFields: nil),
+                    (data: try encoder.encode(completedContext), statusCode: 200, headerFields: nil)
+                ]
+            )
+
+            var payloads: [StatusContextUpdatePayload] = []
+            let observer = NotificationCenter.default.addObserver(
+                forName: .statusContextDidUpdate,
+                object: nil,
+                queue: nil
+            ) { notification in
+                guard let payload = notification.object as? StatusContextUpdatePayload else { return }
+                payloads.append(payload)
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            try await service.refreshContextForStatus(rootStatus)
+
+            let deliveredPayload = await waitForPayload(
+                for: rootStatus.id,
+                in: { payloads }
+            )
+
+            #expect(deliveredPayload?.context.descendants.map(\.id) == ["reply-1", "reply-2"])
+            #expect(payloads.count == 1)
+            #expect(MockURLProtocol.requestCount(for: contextURL) == 2)
+        }
+    }
+
+    @Test("Cancelling refresh suppresses late context publications")
+    func cancelRefreshSuppressesLateContextPublication() async throws {
+        try await SharedTestResourceGate.withExclusiveAccess {
+            MockURLProtocol.reset()
+
+            let client = makeClient()
+            let auth = AuthService(client: client, keychain: .shared)
+            let service = TimelineService(client: client, authService: auth)
+            let account = Account(
+                id: "mastodon.social:\(UUID().uuidString)",
+                instance: "mastodon.social",
+                username: "tester",
+                displayName: "Tester",
+                acct: "tester@mastodon.social",
+                isActive: true
+            )
+
+            defer {
+                MockURLProtocol.reset()
+                Task {
+                    try? await KeychainHelper.shared.deleteToken(forAccount: account.id)
+                }
+            }
+
+            auth.currentAccount = account
+            try await KeychainHelper.shared.saveToken("secret-token", forAccount: account.id)
+
+            let rootStatus = MockStatusFactory.makeStatus(id: "root-status", repliesCount: 2)
+            let firstReply = MockStatusFactory.makeStatus(id: "reply-1", inReplyToId: rootStatus.id)
+            let secondReply = MockStatusFactory.makeStatus(id: "reply-2", inReplyToId: rootStatus.id)
+
+            let partialContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply],
+                hasMoreReplies: true
+            )
+            let completedContext = StatusContext(
+                ancestors: [],
+                descendants: [firstReply, secondReply],
+                hasMoreReplies: false
+            )
+            let refresh = AsyncRefreshResponse(
+                asyncRefresh: AsyncRefresh(id: "refresh-123", status: "finished", resultCount: 2)
+            )
+
+            let contextURL = statusContextURL(instance: account.instance, id: rootStatus.id)
+            let refreshURL = asyncRefreshURL(instance: account.instance, id: "refresh-123")
+            let encoder = makeEncoder()
+
+            MockURLProtocol.setQueuedResponses(
+                for: contextURL,
+                responses: [
+                    (
+                        data: try encoder.encode(partialContext),
+                        statusCode: 200,
+                        headerFields: [Constants.RemoteReplies.asyncRefreshHeader: #"id="refresh-123", retry=1"#]
+                    ),
+                    (data: try encoder.encode(completedContext), statusCode: 200, headerFields: nil)
+                ]
+            )
+            MockURLProtocol.setMockResponse(
+                for: refreshURL,
+                data: try encoder.encode(refresh)
+            )
+            MockURLProtocol.setResponseDelay(for: refreshURL, seconds: 0.2)
+
+            var payloads: [StatusContextUpdatePayload] = []
+            let observer = NotificationCenter.default.addObserver(
+                forName: .statusContextDidUpdate,
+                object: nil,
+                queue: nil
+            ) { notification in
+                guard let payload = notification.object as? StatusContextUpdatePayload else { return }
+                payloads.append(payload)
+            }
+            defer { NotificationCenter.default.removeObserver(observer) }
+
+            try await service.refreshContextForStatus(rootStatus)
+            service.cancelAsyncRefreshPolling(forStatusId: rootStatus.id)
+
+            try? await Task.sleep(nanoseconds: 400_000_000)
+
+            #expect(payloads.isEmpty)
+            #expect(MockURLProtocol.requestCount(for: contextURL) == 1)
+            #expect(MockURLProtocol.requestCount(for: refreshURL) == 1)
+        }
+    }
+
     private func makeClient() -> MastodonClient {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [MockURLProtocol.self]
@@ -77,5 +332,31 @@ struct TimelineServiceContextTests {
         components.host = instance
         components.path = "/api/v1/statuses/\(id)/context"
         return components.url!.absoluteString
+    }
+
+    private func asyncRefreshURL(instance: String, id: String) -> String {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = instance
+        components.path = "/api/v1_alpha/async_refreshes/\(id)"
+        return components.url!.absoluteString
+    }
+
+    private func waitForPayload(
+        for statusId: String,
+        in payloads: @escaping @MainActor () -> [StatusContextUpdatePayload],
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async -> StatusContextUpdatePayload? {
+        let start = DispatchTime.now().uptimeNanoseconds
+
+        while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+            if let payload = payloads().first(where: { $0.statusId == statusId }) {
+                return payload
+            }
+
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        return payloads().first(where: { $0.statusId == statusId })
     }
 }


### PR DESCRIPTION
**Summary**
- fix scroll quality regression by reworking background thread-tree and reply-refresh scheduling without changing UI-visible APIs
- ensure `StatusDetailView` uses a single lifecycle-bound trigger and waits on a background thread builder before publishing replies
- convert the thread-building helper into a background-safe actor (or drop it if redundant) and move async refresh polling out of `TimelineService` while keeping its main-actor responsibilities

**Testing**
- Not run (not requested)