### PR TITLE
Filter private mentions and polish link cards

### DIFF
--- a/fedi-reader/Models/MastodonTypes/AuthorAttribution.swift
+++ b/fedi-reader/Models/MastodonTypes/AuthorAttribution.swift
@@ -24,11 +24,11 @@ struct AuthorAttribution: Sendable {
         self.profilePictureURL = profilePictureURL
     }
 
-    var preferredName: String? {
+    nonisolated var preferredName: String? {
         name ?? mastodonHandle
     }
 
-    var preferredURL: URL? {
+    nonisolated var preferredURL: URL? {
         if let mastodonProfileURL, let url = URL(string: mastodonProfileURL) {
             return url
         }
@@ -40,4 +40,3 @@ struct AuthorAttribution: Sendable {
         return nil
     }
 }
-

--- a/fedi-reader/Services/LinkFilterService.swift
+++ b/fedi-reader/Services/LinkFilterService.swift
@@ -16,13 +16,27 @@ enum FeedScopedLinkData {
     static func filteredStatuses(
         in service: LinkFilterService,
         feedId: String,
-        userFilterAccountId: String?
+        userFilterAccountId: String?,
+        filterPrivateMentionsFromFeeds: Bool
     ) -> [LinkStatus] {
-        service.filter(linkStatuses: statuses(in: service, feedId: feedId), byAccountId: userFilterAccountId)
+        service.filter(
+            linkStatuses: statuses(in: service, feedId: feedId),
+            byAccountId: userFilterAccountId,
+            filterPrivateMentionsFromFeeds: filterPrivateMentionsFromFeeds
+        )
     }
 
-    static func accounts(in service: LinkFilterService, feedId: String) -> [MastodonAccount] {
-        service.uniqueAccounts(in: statuses(in: service, feedId: feedId))
+    static func accounts(
+        in service: LinkFilterService,
+        feedId: String,
+        filterPrivateMentionsFromFeeds: Bool
+    ) -> [MastodonAccount] {
+        let visibleStatuses = service.filter(
+            linkStatuses: statuses(in: service, feedId: feedId),
+            byAccountId: nil,
+            filterPrivateMentionsFromFeeds: filterPrivateMentionsFromFeeds
+        )
+        return service.uniqueAccounts(in: visibleStatuses)
     }
 
     static func isLoading(in service: LinkFilterService, feedId: String) -> Bool {
@@ -468,9 +482,22 @@ final class LinkFilterService {
     // MARK: - Filtering Options
     
     /// Filters link statuses by author account ID. Returns all when `accountId` is nil.
-    func filter(linkStatuses: [LinkStatus], byAccountId accountId: String?) -> [LinkStatus] {
-        guard let accountId = accountId else { return linkStatuses }
-        return linkStatuses.filter { $0.status.displayStatus.account.id == accountId }
+    func filter(
+        linkStatuses: [LinkStatus],
+        byAccountId accountId: String?,
+        filterPrivateMentionsFromFeeds: Bool = PrivateMentionsFeedFilter.defaultValue
+    ) -> [LinkStatus] {
+        let statusesAfterPrivacyFilter: [LinkStatus]
+        if filterPrivateMentionsFromFeeds {
+            statusesAfterPrivacyFilter = linkStatuses.filter {
+                !PrivateMentionsFeedFilter.isPrivateMention($0.status)
+            }
+        } else {
+            statusesAfterPrivacyFilter = linkStatuses
+        }
+
+        guard let accountId = accountId else { return statusesAfterPrivacyFilter }
+        return statusesAfterPrivacyFilter.filter { $0.status.displayStatus.account.id == accountId }
     }
 
     /// Returns unique author accounts present in the provided link statuses.

--- a/fedi-reader/Services/LinkPreviewService.swift
+++ b/fedi-reader/Services/LinkPreviewService.swift
@@ -11,6 +11,7 @@ import os
 actor LinkPreviewService {
     static let shared = LinkPreviewService()
     private static let logger = Logger(subsystem: "app.fedi-reader", category: "LinkPreviewService")
+    private static let previewRangeByteLimit = 65_535
 
     // MARK: - Types
     struct LinkPreview: Hashable, Sendable {
@@ -36,6 +37,36 @@ actor LinkPreviewService {
         let imageURL: URL?
         let siteName: String?
         let fediverseCreator: String?
+
+        var isEmpty: Bool {
+            title?.isEmpty != false
+                && description?.isEmpty != false
+                && imageURL == nil
+                && siteName?.isEmpty != false
+                && fediverseCreator?.isEmpty != false
+        }
+
+        var isMissingImportantPreviewMetadata: Bool {
+            title?.isEmpty != false
+                || imageURL == nil
+                || siteName?.isEmpty != false
+        }
+
+        func merging(_ other: ParsedPreviewMetadata) -> ParsedPreviewMetadata {
+            ParsedPreviewMetadata(
+                title: title ?? other.title,
+                description: description ?? other.description,
+                imageURL: imageURL ?? other.imageURL,
+                siteName: siteName ?? other.siteName,
+                fediverseCreator: fediverseCreator ?? other.fediverseCreator
+            )
+        }
+    }
+
+    private struct FetchedHTML: Sendable {
+        let html: String
+        let statusCode: Int
+        let usedRangeRequest: Bool
     }
 
     // MARK: - State
@@ -94,11 +125,21 @@ actor LinkPreviewService {
             return preview
         }
 
-        // Step 2: GET first bytes (head) of the document
-        let html = await fetchHeadHTML(from: finalURL)
-        let parsed = await Task.detached(priority: .utility) {
-            Self.parseHTML(html, baseURL: finalURL)
+        // Step 2: GET first bytes of the document, then fall back to the full HTML
+        // only when the head slice has no usable preview metadata.
+        let fetchedHeadHTML = await fetchHTML(from: finalURL, useRangeRequest: true)
+        var parsed = await Task.detached(priority: .utility) {
+            Self.parseHTML(fetchedHeadHTML.html, baseURL: finalURL)
         }.value
+        if Self.shouldFetchFullHTML(after: fetchedHeadHTML, parsed: parsed) {
+            let fullHTML = await fetchHTML(from: finalURL, useRangeRequest: false)
+            let fullParsed = await Task.detached(priority: .utility) {
+                Self.parseHTML(fullHTML.html, baseURL: finalURL)
+            }.value
+            if !fullParsed.isEmpty {
+                parsed = parsed.merging(fullParsed)
+            }
+        }
         let creator = Self.normalizeFediverseCreator(parsed.fediverseCreator)
         let preview = LinkPreview(
             url: url,
@@ -181,22 +222,48 @@ actor LinkPreviewService {
         }
     }
 
-    private func fetchHeadHTML(from url: URL) async -> String {
+    private func fetchHTML(from url: URL, useRangeRequest: Bool) async -> FetchedHTML {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        // Request only the first ~32KB; meta tags typically live in <head>
-        request.setValue("bytes=0-32767", forHTTPHeaderField: "Range")
+        if useRangeRequest {
+            // Request only the first ~64KB; most preview metadata lives in <head>.
+            request.setValue("bytes=0-\(Self.previewRangeByteLimit)", forHTTPHeaderField: "Range")
+        }
         do {
             let (data, response) = try await session.data(for: request)
             let http = response as? HTTPURLResponse
             let statusCode = http?.statusCode ?? 0
             let html = String(data: data, encoding: .utf8) ?? ""
-            Self.logger.debug("Fetched HTML head: \(url.absoluteString, privacy: .public) -> \(statusCode), size: \(data.count) bytes, html length: \(html.count)")
-            return html
+            let fetchKind = useRangeRequest ? "head" : "full"
+            Self.logger.debug("Fetched HTML \(fetchKind, privacy: .public): \(url.absoluteString, privacy: .public) -> \(statusCode), size: \(data.count) bytes, html length: \(html.count)")
+            return FetchedHTML(
+                html: html,
+                statusCode: statusCode,
+                usedRangeRequest: useRangeRequest
+            )
         } catch {
-            Self.logger.error("Failed to fetch HTML head for \(url.absoluteString, privacy: .public): \(error.localizedDescription)")
-            return ""
+            let fetchKind = useRangeRequest ? "head" : "full"
+            Self.logger.error("Failed to fetch HTML \(fetchKind, privacy: .public) for \(url.absoluteString, privacy: .public): \(error.localizedDescription)")
+            return FetchedHTML(
+                html: "",
+                statusCode: 0,
+                usedRangeRequest: useRangeRequest
+            )
         }
+    }
+
+    private nonisolated static func shouldFetchFullHTML(
+        after fetchedHTML: FetchedHTML,
+        parsed: ParsedPreviewMetadata
+    ) -> Bool {
+        guard fetchedHTML.usedRangeRequest else {
+            return false
+        }
+
+        let partialResponseLikelyIncomplete = fetchedHTML.statusCode == 206
+            || fetchedHTML.html.utf8.count >= previewRangeByteLimit
+
+        return parsed.isEmpty || (partialResponseLikelyIncomplete && parsed.isMissingImportantPreviewMetadata)
     }
 
     // MARK: - Parsing

--- a/fedi-reader/Utilities/ConversationSearch/DirectMessageMentionFormatter.swift
+++ b/fedi-reader/Utilities/ConversationSearch/DirectMessageMentionFormatter.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum DirectMessageMentionFormatter {
-    static func mentionPrefix(for recipients: [MastodonAccount]) -> String {
+    nonisolated static func mentionPrefix(for recipients: [MastodonAccount]) -> String {
         var mentions: [String] = []
         var seenHandles = Set<String>()
 
@@ -14,7 +14,7 @@ enum DirectMessageMentionFormatter {
         return mentions.joined(separator: " ")
     }
 
-    static func hiddenHandles(for accounts: [MastodonAccount]) -> Set<String> {
+    nonisolated static func hiddenHandles(for accounts: [MastodonAccount]) -> Set<String> {
         var handles = Set<String>()
 
         for account in accounts {
@@ -25,7 +25,7 @@ enum DirectMessageMentionFormatter {
         return handles
     }
 
-    static func stripLeadingMentions(from text: String, hiddenHandles: Set<String>) -> String {
+    nonisolated static func stripLeadingMentions(from text: String, hiddenHandles: Set<String>) -> String {
         guard
             !hiddenHandles.isEmpty,
             let prefix = leadingMentionPrefix(in: text, hiddenHandles: hiddenHandles)
@@ -36,7 +36,7 @@ enum DirectMessageMentionFormatter {
         return String(text.dropFirst(prefix.count))
     }
 
-    static func conversationPreview(for status: Status, hiddenHandles: Set<String>) -> String {
+    nonisolated static func conversationPreview(for status: Status, hiddenHandles: Set<String>) -> String {
         let strippedText = stripLeadingMentions(
             from: status.content.htmlToPlainText,
             hiddenHandles: hiddenHandles
@@ -50,7 +50,7 @@ enum DirectMessageMentionFormatter {
     }
 
     @available(iOS 15.0, macOS 12.0, *)
-    static func stripLeadingMentions(
+    nonisolated static func stripLeadingMentions(
         from attributedString: AttributedString,
         hiddenHandles: Set<String>
     ) -> AttributedString {
@@ -71,7 +71,7 @@ enum DirectMessageMentionFormatter {
         return stripped
     }
 
-    private static func insertHandleVariants(from rawHandle: String, into handles: inout Set<String>) {
+    private nonisolated static func insertHandleVariants(from rawHandle: String, into handles: inout Set<String>) {
         guard let normalized = HandleInputParser.normalizeHandle(rawHandle) else { return }
         handles.insert(normalized)
 
@@ -80,7 +80,7 @@ enum DirectMessageMentionFormatter {
         }
     }
 
-    private static func leadingMentionPrefix(in text: String, hiddenHandles: Set<String>) -> String? {
+    private nonisolated static func leadingMentionPrefix(in text: String, hiddenHandles: Set<String>) -> String? {
         var index = text.startIndex
         while index < text.endIndex, text[index].isWhitespace {
             index = text.index(after: index)
@@ -115,7 +115,7 @@ enum DirectMessageMentionFormatter {
         return String(text[..<index])
     }
 
-    private static func attachmentPreview(for attachments: [MediaAttachment]) -> String {
+    private nonisolated static func attachmentPreview(for attachments: [MediaAttachment]) -> String {
         guard !attachments.isEmpty else { return "" }
 
         let attachmentTypes = Set(attachments.map(\.type))

--- a/fedi-reader/Utilities/ConversationSearch/HandleInputParser.swift
+++ b/fedi-reader/Utilities/ConversationSearch/HandleInputParser.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 enum HandleInputParser {
-    private static let delimiters = CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: ","))
+    private nonisolated static let delimiters = CharacterSet.whitespacesAndNewlines.union(CharacterSet(charactersIn: ","))
 
-    static func tokenize(_ input: String) -> HandleInputTokens {
+    nonisolated static func tokenize(_ input: String) -> HandleInputTokens {
         let tokens = input
             .components(separatedBy: delimiters)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -24,7 +24,7 @@ enum HandleInputParser {
         )
     }
 
-    static func normalizeHandle(_ raw: String) -> String? {
+    nonisolated static func normalizeHandle(_ raw: String) -> String? {
         var cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return nil }
 
@@ -38,7 +38,7 @@ enum HandleInputParser {
         return cleaned.lowercased()
     }
 
-    static func searchQueryVariants(for rawToken: String) -> [String] {
+    nonisolated static func searchQueryVariants(for rawToken: String) -> [String] {
         let trimmed = rawToken.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
 
@@ -68,5 +68,4 @@ enum HandleInputParser {
         return variants
     }
 }
-
 

--- a/fedi-reader/Utilities/HTMLParser/String+HTMLParser.swift
+++ b/fedi-reader/Utilities/HTMLParser/String+HTMLParser.swift
@@ -1,35 +1,34 @@
 import Foundation
 
 extension String {
-    var htmlStripped: String {
+    nonisolated var htmlStripped: String {
         HTMLParser.stripHTML(self)
     }
     
-    var htmlToPlainText: String {
+    nonisolated var htmlToPlainText: String {
         HTMLParser.convertToPlainText(self)
     }
 
-    var htmlToPlainTextPreservingNewlines: String {
+    nonisolated var htmlToPlainTextPreservingNewlines: String {
         HTMLParser.convertToPlainTextPreservingNewlines(self)
     }
     
-    var extractedLinks: [URL] {
+    nonisolated var extractedLinks: [URL] {
         HTMLParser.extractLinks(from: self)
     }
     
     @available(iOS 15.0, macOS 12.0, *)
-    var htmlToAttributedString: AttributedString {
+    nonisolated var htmlToAttributedString: AttributedString {
         HTMLParser.convertToAttributedString(self)
     }
     
     @available(iOS 15.0, macOS 12.0, *)
-    func htmlToAttributedStringWithHashtags(hashtagHandler: @escaping (String) -> URL?) -> AttributedString {
+    nonisolated func htmlToAttributedStringWithHashtags(hashtagHandler: @escaping (String) -> URL?) -> AttributedString {
         HTMLParser.convertToAttributedString(self, hashtagHandler: hashtagHandler)
     }
 
     @available(iOS 15.0, macOS 12.0, *)
-    func htmlToAttributedStringPreservingNewlinesWithHashtags(hashtagHandler: @escaping (String) -> URL?) -> AttributedString {
+    nonisolated func htmlToAttributedStringPreservingNewlinesWithHashtags(hashtagHandler: @escaping (String) -> URL?) -> AttributedString {
         HTMLParser.convertToAttributedString(self, preserveNewlines: true, hashtagHandler: hashtagHandler)
     }
 }
-

--- a/fedi-reader/Utilities/MessageEmbeddedContentLayoutResolver.swift
+++ b/fedi-reader/Utilities/MessageEmbeddedContentLayoutResolver.swift
@@ -1,0 +1,154 @@
+//
+//  MessageEmbeddedContentLayoutResolver.swift
+//  fedi-reader
+//
+//  Splits direct-message content around an embedded link so the preview can
+//  replace the inline URL while preserving any surrounding text.
+//
+
+import Foundation
+
+struct MessageEmbeddedContentLayout: Equatable, Sendable {
+    let candidate: MessageLinkPreviewCandidate?
+    let leadingContent: String?
+    let trailingContent: String?
+}
+
+enum MessageEmbeddedContentLayoutResolver {
+    nonisolated static func resolve(
+        from status: Status,
+        hiddenHandles: Set<String>
+    ) -> MessageEmbeddedContentLayout {
+        guard let candidate = MessageLinkPreviewResolver.resolve(from: status) else {
+            return MessageEmbeddedContentLayout(
+                candidate: nil,
+                leadingContent: nil,
+                trailingContent: nil
+            )
+        }
+
+        if let htmlSegments = splitHTMLContent(status.content, around: candidate.url) {
+            return MessageEmbeddedContentLayout(
+                candidate: candidate,
+                leadingContent: displayableHTMLSegment(htmlSegments.leading, hiddenHandles: hiddenHandles),
+                trailingContent: displayableHTMLSegment(htmlSegments.trailing, hiddenHandles: hiddenHandles)
+            )
+        }
+
+        let plainTextContent = DirectMessageMentionFormatter.stripLeadingMentions(
+            from: status.content.htmlToPlainTextPreservingNewlines,
+            hiddenHandles: hiddenHandles
+        )
+
+        if let plainTextSegments = splitPlainTextContent(plainTextContent, around: candidate.url) {
+            return MessageEmbeddedContentLayout(
+                candidate: candidate,
+                leadingContent: displayablePlainTextSegment(plainTextSegments.leading),
+                trailingContent: displayablePlainTextSegment(plainTextSegments.trailing)
+            )
+        }
+
+        return MessageEmbeddedContentLayout(
+            candidate: candidate,
+            leadingContent: nil,
+            trailingContent: nil
+        )
+    }
+
+    private nonisolated static func splitHTMLContent(
+        _ html: String,
+        around url: URL
+    ) -> (leading: String, trailing: String)? {
+        let pattern = #"<a[^>]+href\s*=\s*["']([^"']+)["'][^>]*>.*?</a>"#
+
+        guard let regex = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return nil
+        }
+
+        let range = NSRange(html.startIndex..., in: html)
+        for match in regex.matches(in: html, options: [], range: range) {
+            guard let elementRange = Range(match.range, in: html),
+                  let hrefRange = Range(match.range(at: 1), in: html) else {
+                continue
+            }
+
+            let href = HTMLParser.decodeHTMLEntities(String(html[hrefRange]))
+            guard let candidateURL = URL(string: href), urlsMatch(candidateURL, url) else {
+                continue
+            }
+
+            return (
+                leading: String(html[..<elementRange.lowerBound]),
+                trailing: String(html[elementRange.upperBound...])
+            )
+        }
+
+        return nil
+    }
+
+    private nonisolated static func splitPlainTextContent(
+        _ text: String,
+        around url: URL
+    ) -> (leading: String, trailing: String)? {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return splitPlainTextContentByLiteralMatch(text, around: url)
+        }
+
+        let range = NSRange(text.startIndex..., in: text)
+        for match in detector.matches(in: text, options: [], range: range) {
+            guard let detectedURL = match.url,
+                  urlsMatch(detectedURL, url),
+                  let matchRange = Range(match.range, in: text) else {
+                continue
+            }
+
+            return (
+                leading: String(text[..<matchRange.lowerBound]),
+                trailing: String(text[matchRange.upperBound...])
+            )
+        }
+
+        return splitPlainTextContentByLiteralMatch(text, around: url)
+    }
+
+    private nonisolated static func splitPlainTextContentByLiteralMatch(
+        _ text: String,
+        around url: URL
+    ) -> (leading: String, trailing: String)? {
+        guard let range = text.range(of: url.absoluteString) else {
+            return nil
+        }
+
+        return (
+            leading: String(text[..<range.lowerBound]),
+            trailing: String(text[range.upperBound...])
+        )
+    }
+
+    private nonisolated static func displayableHTMLSegment(
+        _ content: String,
+        hiddenHandles: Set<String>
+    ) -> String? {
+        let visibleText = DirectMessageMentionFormatter.stripLeadingMentions(
+            from: content.htmlToPlainTextPreservingNewlines,
+            hiddenHandles: hiddenHandles
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !visibleText.isEmpty else { return nil }
+        return content
+    }
+
+    private nonisolated static func displayablePlainTextSegment(_ content: String) -> String? {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private nonisolated static func urlsMatch(_ lhs: URL, _ rhs: URL) -> Bool {
+        lhs.absoluteString == rhs.absoluteString
+            || lhs.standardized.absoluteString == rhs.standardized.absoluteString
+    }
+}

--- a/fedi-reader/Utilities/MessageLinkPreviewContentResolver.swift
+++ b/fedi-reader/Utilities/MessageLinkPreviewContentResolver.swift
@@ -1,0 +1,137 @@
+//
+//  MessageLinkPreviewContentResolver.swift
+//  fedi-reader
+//
+//  Resolves the display content for embedded DM link previews, merging
+//  Mastodon card data with fetched HTML metadata when the card is sparse.
+//
+
+import Foundation
+
+struct MessageLinkPreviewContent: Equatable, Sendable {
+    let title: String
+    let description: String
+    let imageURL: URL?
+    let providerDisplay: String
+    let authorName: String?
+    let authorURL: URL?
+    let isMastodonAttribution: Bool
+    let showLinkIcon: Bool
+}
+
+enum MessageLinkPreviewContentResolver {
+    nonisolated static func shouldFetchPreview(for candidate: MessageLinkPreviewCandidate) -> Bool {
+        guard let card = candidate.card else {
+            return true
+        }
+
+        return isSparseTitle(card.decodedTitle, for: candidate.url)
+            || trimmed(card.decodedDescription) == nil
+            || card.imageURL == nil
+            || trimmed(card.decodedProviderName) == nil
+    }
+
+    nonisolated static func resolve(
+        candidate: MessageLinkPreviewCandidate,
+        linkPreview: LinkPreviewService.LinkPreview?,
+        authorAttribution: AuthorAttribution?,
+        authorDisplayName: String?
+    ) -> MessageLinkPreviewContent {
+        let fallbackProvider = HTMLParser.extractDomain(from: candidate.url) ?? candidate.url.absoluteString
+        let cardAuthorURL = candidate.card?.authorUrl.flatMap(URL.init(string:))
+        let resolvedAuthorURL = authorAttribution?.preferredURL ?? cardAuthorURL ?? linkPreview?.fediverseCreatorURL
+        let resolvedAuthorName = trimmed(authorDisplayName)
+            ?? trimmed(authorAttribution?.preferredName)
+            ?? trimmed(candidate.card?.decodedAuthorName)
+            ?? trimmed(linkPreview?.fediverseCreator)
+
+        let providerDisplay = trimmed(candidate.card?.decodedProviderName)
+            ?? trimmed(linkPreview?.siteName)
+            ?? trimmed(linkPreview?.provider)
+            ?? fallbackProvider
+
+        let title = preferredTitle(
+            candidate: candidate,
+            linkPreview: linkPreview,
+            fallbackProvider: providerDisplay
+        )
+
+        let description = trimmed(candidate.card?.decodedDescription)
+            ?? trimmed(linkPreview?.description)
+            ?? ""
+
+        let isMastodonAttribution = authorAttribution?.mastodonHandle != nil
+            || authorAttribution?.mastodonProfileURL != nil
+            || linkPreview?.fediverseCreator != nil
+            || linkPreview?.fediverseCreatorURL != nil
+            || resolvedAuthorURL.flatMap { MastodonProfileReference.acct(from: $0) } != nil
+
+        let authorName: String? = if let resolvedAuthorURL {
+            resolvedAuthorName ?? (resolvedAuthorURL.absoluteString.isEmpty ? nil : "Author")
+        } else {
+            resolvedAuthorName
+        }
+
+        return MessageLinkPreviewContent(
+            title: title,
+            description: description,
+            imageURL: linkPreview?.imageURL ?? candidate.card?.imageURL,
+            providerDisplay: providerDisplay,
+            authorName: authorName,
+            authorURL: resolvedAuthorURL,
+            isMastodonAttribution: isMastodonAttribution,
+            showLinkIcon: true
+        )
+    }
+
+    private nonisolated static func preferredTitle(
+        candidate: MessageLinkPreviewCandidate,
+        linkPreview: LinkPreviewService.LinkPreview?,
+        fallbackProvider: String
+    ) -> String {
+        if let cardTitle = trimmed(candidate.card?.decodedTitle),
+           !isSparseTitle(cardTitle, for: candidate.url) {
+            return cardTitle
+        }
+
+        if let previewTitle = trimmed(linkPreview?.title),
+           !isSparseTitle(previewTitle, for: candidate.url) {
+            return previewTitle
+        }
+
+        if let cardTitle = trimmed(candidate.card?.decodedTitle) {
+            return cardTitle
+        }
+
+        if let previewTitle = trimmed(linkPreview?.title) {
+            return previewTitle
+        }
+
+        return fallbackProvider
+    }
+
+    private nonisolated static func isSparseTitle(_ title: String?, for url: URL) -> Bool {
+        guard let title = trimmed(title) else {
+            return true
+        }
+
+        let normalizedTitle = normalizedComparable(title)
+        let normalizedURL = normalizedComparable(url.absoluteString)
+        let normalizedDomain = HTMLParser.extractDomain(from: url).map(normalizedComparable)
+
+        return normalizedTitle == normalizedURL || normalizedTitle == normalizedDomain
+    }
+
+    private nonisolated static func normalizedComparable(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+    }
+
+    private nonisolated static func trimmed(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+}

--- a/fedi-reader/Utilities/MessageLinkPreviewResolver.swift
+++ b/fedi-reader/Utilities/MessageLinkPreviewResolver.swift
@@ -1,0 +1,108 @@
+//
+//  MessageLinkPreviewResolver.swift
+//  fedi-reader
+//
+//  Resolves which link, if any, should be previewed for a private/direct message.
+//
+
+import Foundation
+
+struct MessageLinkPreviewCandidate: Equatable, Sendable {
+    let url: URL
+    let card: PreviewCard?
+}
+
+enum MessageLinkPreviewResolver {
+    nonisolated static func resolve(from status: Status) -> MessageLinkPreviewCandidate? {
+        let contentLinks = externalLinks(from: status)
+        guard !contentLinks.isEmpty else {
+            return nil
+        }
+
+        if let card = matchingPreviewCard(from: status, contentLinks: contentLinks),
+           let url = card.linkURL {
+            return MessageLinkPreviewCandidate(url: url, card: card)
+        }
+
+        return MessageLinkPreviewCandidate(url: contentLinks[0], card: nil)
+    }
+
+    nonisolated static func previewCard(from status: Status) -> PreviewCard? {
+        guard let card = status.displayStatus.card,
+              (card.type == .link || card.type == .rich),
+              card.linkURL != nil else {
+            return nil
+        }
+
+        return card
+    }
+
+    private nonisolated static func matchingPreviewCard(
+        from status: Status,
+        contentLinks: [URL]
+    ) -> PreviewCard? {
+        guard let card = previewCard(from: status),
+              let cardURL = card.linkURL,
+              contentLinks.contains(where: { urlsMatch($0, cardURL) }) else {
+            return nil
+        }
+
+        return card
+    }
+
+    private nonisolated static func externalLinks(from status: Status) -> [URL] {
+        let displayStatus = status.displayStatus
+        let excludedDomains = previewExcludedDomains(for: displayStatus)
+
+        let htmlLinks = HTMLParser.extractExternalLinks(
+            from: displayStatus.content,
+            excludingDomains: excludedDomains
+        ).filter {
+            isPreviewableExternalURL($0, excludingDomains: excludedDomains)
+        }
+        if !htmlLinks.isEmpty {
+            return htmlLinks
+        }
+
+        let plainTextLinks = HTMLParser.extractPlainTextLinks(from: displayStatus.content)
+        return plainTextLinks.filter {
+            isPreviewableExternalURL($0, excludingDomains: excludedDomains)
+        }
+    }
+
+    private nonisolated static func previewExcludedDomains(for status: Status) -> [String] {
+        var domains: [String] = []
+
+        if let host = URL(string: status.uri)?.host?.lowercased() {
+            domains.append(host)
+        }
+
+        if let host = URL(string: status.url ?? "")?.host?.lowercased(), !domains.contains(host) {
+            domains.append(host)
+        }
+
+        return domains
+    }
+
+    private nonisolated static func isPreviewableExternalURL(
+        _ url: URL,
+        excludingDomains domains: [String]
+    ) -> Bool {
+        guard HTMLParser.isExternalURL(url),
+              let host = url.host?.lowercased() else {
+            return false
+        }
+
+        let path = url.path.lowercased()
+        if path.hasPrefix("/@") || path.hasPrefix("/tags/") {
+            return false
+        }
+
+        return !domains.contains { host.contains($0) }
+    }
+
+    private nonisolated static func urlsMatch(_ lhs: URL, _ rhs: URL) -> Bool {
+        lhs.absoluteString == rhs.absoluteString
+            || lhs.standardized.absoluteString == rhs.standardized.absoluteString
+    }
+}

--- a/fedi-reader/Utilities/MessageMediaLayoutResolver.swift
+++ b/fedi-reader/Utilities/MessageMediaLayoutResolver.swift
@@ -1,0 +1,53 @@
+//
+//  MessageMediaLayoutResolver.swift
+//  fedi-reader
+//
+//  Provides aspect-aware chat media sizing so DM attachments stay readable
+//  without collapsing into extreme letterboxed shapes.
+//
+
+import CoreGraphics
+import Foundation
+
+enum MessageMediaLayoutResolver {
+    nonisolated static func size(for attachment: MediaAttachment) -> CGSize {
+        let maxWidth: CGFloat = 260
+        let maxHeight: CGFloat = 240
+        let minWidth: CGFloat = 140
+        let minHeight: CGFloat = 120
+        let aspectRatio = clampedAspectRatio(for: attachment)
+
+        if aspectRatio >= 1 {
+            let width = maxWidth
+            let height = clamped(width / aspectRatio, min: minHeight, max: maxHeight)
+            return CGSize(width: width, height: height)
+        }
+
+        let height = maxHeight
+        let width = clamped(height * aspectRatio, min: minWidth, max: maxWidth)
+        return CGSize(width: width, height: height)
+    }
+
+    nonisolated static func clampedAspectRatio(for attachment: MediaAttachment) -> CGFloat {
+        let minimumAspectRatio: CGFloat = 0.65
+        let maximumAspectRatio: CGFloat = 1.8
+        let rawAspectRatio = attachment.meta?.original?.aspect
+            ?? attachment.meta?.small?.aspect
+            ?? aspectRatio(
+                width: attachment.meta?.original?.width ?? attachment.meta?.small?.width,
+                height: attachment.meta?.original?.height ?? attachment.meta?.small?.height
+            )
+            ?? 1
+
+        return clamped(CGFloat(rawAspectRatio), min: minimumAspectRatio, max: maximumAspectRatio)
+    }
+
+    private nonisolated static func aspectRatio(width: Int?, height: Int?) -> Double? {
+        guard let width, let height, width > 0, height > 0 else { return nil }
+        return Double(width) / Double(height)
+    }
+
+    private nonisolated static func clamped(_ value: CGFloat, min minimum: CGFloat, max maximum: CGFloat) -> CGFloat {
+        Swift.min(Swift.max(value, minimum), maximum)
+    }
+}

--- a/fedi-reader/Utilities/PrivateMentionsFeedFilter.swift
+++ b/fedi-reader/Utilities/PrivateMentionsFeedFilter.swift
@@ -1,0 +1,18 @@
+//
+//  PrivateMentionsFeedFilter.swift
+//  fedi-reader
+//
+//  Shared preference and helpers for filtering private mentions from link feeds.
+//
+
+import Foundation
+
+enum PrivateMentionsFeedFilter {
+    nonisolated static let storageKey = "filterPrivateMentionsFromFeeds"
+    nonisolated static let defaultValue = true
+
+    nonisolated static func isPrivateMention(_ status: Status) -> Bool {
+        let visibility = status.displayStatus.visibility
+        return visibility == .private || visibility == .direct
+    }
+}

--- a/fedi-reader/Views/Components/AuthorAttributionView.swift
+++ b/fedi-reader/Views/Components/AuthorAttributionView.swift
@@ -107,6 +107,7 @@ struct AuthorAttributionView: View {
             Text(authorName)
                 .font(.roundedCaption)
                 .lineLimit(1)
+                .minimumScaleFactor(0.75)
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 2)

--- a/fedi-reader/Views/Components/LinkCardContent.swift
+++ b/fedi-reader/Views/Components/LinkCardContent.swift
@@ -9,6 +9,12 @@
 import SwiftUI
 
 struct LinkCardContent: View {
+    enum Layout: Sendable {
+        case standard
+        case compact
+        case feed
+    }
+
     let title: String
     let description: String
     let imageURL: URL?
@@ -17,81 +23,291 @@ struct LinkCardContent: View {
     let authorURL: URL?
     var isMastodonAttribution: Bool = false
     var showLinkIcon: Bool = false
+    var layout: Layout = .standard
+
+    private var horizontalSpacing: CGFloat {
+        switch layout {
+        case .standard:
+            12
+        case .compact:
+            8
+        case .feed:
+            0
+        }
+    }
+
+    private var thumbnailWidth: CGFloat {
+        switch layout {
+        case .standard:
+            100
+        case .compact:
+            72
+        case .feed:
+            0
+        }
+    }
+
+    private var contentVerticalPadding: CGFloat {
+        switch layout {
+        case .standard:
+            8
+        case .compact:
+            6
+        case .feed:
+            8
+        }
+    }
+
+    private var contentTrailingPadding: CGFloat {
+        switch layout {
+        case .standard:
+            12
+        case .compact:
+            6
+        case .feed:
+            12
+        }
+    }
+
+    private var titleFont: Font {
+        switch layout {
+        case .standard:
+            .roundedHeadline
+        case .compact:
+            .roundedCallout.weight(.semibold)
+        case .feed:
+            .roundedTitle3.bold()
+        }
+    }
+
+    private var titleLineLimit: Int {
+        switch layout {
+        case .standard:
+            2
+        case .compact:
+            3
+        case .feed:
+            3
+        }
+    }
+
+    private var descriptionFont: Font {
+        switch layout {
+        case .standard:
+            .roundedSubheadline
+        case .compact:
+            .roundedCaption
+        case .feed:
+            .roundedSubheadline
+        }
+    }
+
+    private var descriptionLineLimit: Int {
+        switch layout {
+        case .standard:
+            2
+        case .compact:
+            3
+        case .feed:
+            3
+        }
+    }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            if let imageURL {
-                AsyncImage(url: imageURL) { image in
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                } placeholder: {
-                    Rectangle()
-                        .fill(.tertiary)
-                }
-                .frame(width: 100)
-                .frame(minHeight: 100, maxHeight: .infinity)
-                .clipped()
-            } else {
-                Rectangle()
-                    .fill(.tertiary)
-                    .frame(width: 100)
-                    .frame(minHeight: 100, maxHeight: .infinity)
-                    .overlay {
-                        Image(systemName: "link")
-                            .font(.title)
-                            .foregroundStyle(.secondary)
-                    }
+        Group {
+            switch layout {
+            case .feed:
+                feedLayout
+            case .standard, .compact:
+                horizontalLayout
             }
+        }
+    }
+
+    private var horizontalLayout: some View {
+        HStack(alignment: .top, spacing: horizontalSpacing) {
+            thumbnailView
 
             VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.roundedHeadline)
-                    .lineLimit(2)
-
-                if !description.isEmpty {
-                    Text(description)
-                        .font(.roundedSubheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                }
-
-                HStack(spacing: 8) {
-                    if showLinkIcon {
-                        Image(systemName: "link")
-                            .font(.roundedCaption2)
-                    }
-
-                    Text(providerDisplay)
-                        .font(.roundedCaption)
-                        .lineLimit(1)
-
-                    if let authorName {
-                        Text("•")
-                            .foregroundStyle(.tertiary)
-
-                        if let authorURL {
-                            Link(destination: authorURL) {
-                                AuthorAttributionView(
-                                    authorName: authorName,
-                                    isMastodonAttribution: isMastodonAttribution,
-                                    style: .chip
-                                )
-                            }
-                            .buttonStyle(.plain)
-                        } else {
-                            Text(authorName)
-                                .font(.roundedCaption)
-                                .foregroundStyle(.tertiary)
-                        }
-                    }
-                }
-                .foregroundStyle(.tertiary)
+                titleAndDescription
+                footerContent
             }
-            .padding(.vertical, 8)
-            .padding(.trailing, 12)
+            .padding(.vertical, contentVerticalPadding)
+            .padding(.trailing, contentTrailingPadding)
 
             Spacer()
+        }
+    }
+
+    private var feedLayout: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            feedImageView
+
+            VStack(alignment: .leading, spacing: 8) {
+                titleAndDescription
+                footerContent
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
+            .padding(.bottom, 8)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var titleAndDescription: some View {
+        Text(title)
+            .font(titleFont)
+            .lineLimit(titleLineLimit)
+
+        if !description.isEmpty {
+            Text(description)
+                .font(descriptionFont)
+                .foregroundStyle(.secondary)
+                .lineLimit(descriptionLineLimit)
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnailView: some View {
+        if let imageURL {
+            AsyncImage(url: imageURL) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Rectangle()
+                    .fill(.tertiary)
+            }
+            .frame(width: thumbnailWidth)
+            .frame(minHeight: thumbnailWidth, maxHeight: .infinity)
+            .clipped()
+        } else {
+            Rectangle()
+                .fill(.tertiary)
+                .frame(width: thumbnailWidth)
+                .frame(minHeight: thumbnailWidth, maxHeight: .infinity)
+                .overlay {
+                    Image(systemName: "link")
+                        .font(.title)
+                        .foregroundStyle(.secondary)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var feedImageView: some View {
+        if let imageURL {
+            AsyncImage(url: imageURL) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                Rectangle()
+                    .fill(Color(.tertiarySystemBackground))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 180)
+            .clipped()
+        } else {
+            Rectangle()
+                .fill(Color(.tertiarySystemBackground))
+                .frame(maxWidth: .infinity)
+                .frame(height: 140)
+                .overlay {
+                    Image(systemName: "link")
+                        .font(.largeTitle)
+                        .foregroundStyle(.tertiary)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var footerContent: some View {
+        if layout == .compact, authorName != nil {
+            VStack(alignment: .leading, spacing: 4) {
+                providerRow
+
+                if let authorName {
+                    authorView(name: authorName, foregroundStyle: Color.secondary)
+                }
+            }
+        } else if layout == .feed {
+            ViewThatFits(in: .horizontal) {
+                footerRow(authorMaximumWidth: 140)
+                footerRow(authorMaximumWidth: 96)
+                stackedFooter
+            }
+        } else {
+            footerRow()
+        }
+    }
+
+    @ViewBuilder
+    private var stackedFooter: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            providerRow
+
+            if let authorName {
+                authorView(name: authorName, foregroundStyle: Color.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func footerRow(authorMaximumWidth: CGFloat? = nil) -> some View {
+        HStack(spacing: 8) {
+            providerRow
+
+            if let authorName {
+                Text("•")
+                    .foregroundStyle(.tertiary)
+
+                if let authorMaximumWidth {
+                    authorView(name: authorName, foregroundStyle: Color.secondary)
+                        .frame(maxWidth: authorMaximumWidth, alignment: .leading)
+                } else {
+                    authorView(name: authorName, foregroundStyle: Color.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var providerRow: some View {
+        HStack(spacing: 8) {
+            if showLinkIcon {
+                Image(systemName: "link")
+                    .font(.roundedCaption2)
+            }
+
+            Text(providerDisplay)
+                .font(.roundedCaption)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .layoutPriority(1)
+        .foregroundStyle(.tertiary)
+    }
+
+    @ViewBuilder
+    private func authorView(name: String, foregroundStyle: Color) -> some View {
+        if let authorURL {
+            Link(destination: authorURL) {
+                AuthorAttributionView(
+                    authorName: name,
+                    isMastodonAttribution: isMastodonAttribution,
+                    style: .chip
+                )
+            }
+            .buttonStyle(.plain)
+        } else {
+            Text(name)
+                .font(.roundedCaption)
+                .foregroundStyle(foregroundStyle)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
         }
     }
 }
@@ -99,7 +315,7 @@ struct LinkCardContent: View {
 // MARK: - Initializers from domain types
 
 extension LinkCardContent {
-    init(link: TrendingLink) {
+    init(link: TrendingLink, layout: Layout = .standard) {
         title = link.decodedTitle
         description = link.decodedDescription
         imageURL = link.imageURL
@@ -108,9 +324,15 @@ extension LinkCardContent {
         authorURL = link.authorUrl.flatMap { URL(string: $0) }
         isMastodonAttribution = false
         showLinkIcon = false
+        self.layout = layout
     }
 
-    init(card: PreviewCard, authorAttribution: AuthorAttribution?, authorDisplayName: String? = nil) {
+    init(
+        card: PreviewCard,
+        authorAttribution: AuthorAttribution?,
+        authorDisplayName: String? = nil,
+        layout: Layout = .standard
+    ) {
         title = card.decodedTitle
         description = card.decodedDescription
         imageURL = card.imageURL
@@ -132,5 +354,49 @@ extension LinkCardContent {
         isMastodonAttribution = authorAttribution?.mastodonHandle != nil
             || authorAttribution?.mastodonProfileURL != nil
         showLinkIcon = true
+        self.layout = layout
+    }
+
+    init(
+        preview: LinkPreviewService.LinkPreview,
+        authorAttribution: AuthorAttribution?,
+        authorDisplayName: String? = nil,
+        layout: Layout = .standard
+    ) {
+        let resolvedURL = preview.finalURL ?? preview.url
+        let fallbackProvider = preview.provider
+            ?? preview.siteName
+            ?? HTMLParser.extractDomain(from: resolvedURL)
+            ?? resolvedURL.absoluteString
+        let fallbackTitle = preview.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedTitle = (fallbackTitle?.isEmpty == false ? fallbackTitle : nil) ?? fallbackProvider
+        let resolvedDescription = preview.description?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let resolvedAuthorName = authorDisplayName
+            ?? authorAttribution?.preferredName
+            ?? preview.fediverseCreator
+        let resolvedAuthorURL = authorAttribution?.preferredURL ?? preview.fediverseCreatorURL
+
+        title = resolvedTitle
+        description = resolvedDescription
+        imageURL = preview.imageURL
+        providerDisplay = preview.siteName ?? fallbackProvider
+
+        if let resolvedAuthorURL {
+            authorName = resolvedAuthorName ?? "Author"
+            authorURL = resolvedAuthorURL
+        } else if let resolvedAuthorName {
+            authorName = resolvedAuthorName
+            authorURL = nil
+        } else {
+            authorName = nil
+            authorURL = nil
+        }
+
+        isMastodonAttribution = authorAttribution?.mastodonHandle != nil
+            || authorAttribution?.mastodonProfileURL != nil
+            || preview.fediverseCreator != nil
+            || preview.fediverseCreatorURL != nil
+        showLinkIcon = true
+        self.layout = layout
     }
 }

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedContentView.swift
@@ -132,6 +132,8 @@ struct LinkFeedContentView: View {
     @Environment(AppState.self) private var appState
     @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
+    @AppStorage(PrivateMentionsFeedFilter.storageKey)
+    private var filterPrivateMentionsFromFeeds = PrivateMentionsFeedFilter.defaultValue
 
     @State private var selectedTabIndex: Int = 0
     @State private var scrollProxy: ScrollViewProxy?
@@ -182,7 +184,11 @@ struct LinkFeedContentView: View {
     }
 
     private var currentAccounts: [MastodonAccount] {
-        FeedScopedLinkData.accounts(in: linkFilterService, feedId: currentTab.id)
+        FeedScopedLinkData.accounts(
+            in: linkFilterService,
+            feedId: currentTab.id,
+            filterPrivateMentionsFromFeeds: filterPrivateMentionsFromFeeds
+        )
     }
 
     private var currentUserFilter: String? {
@@ -193,7 +199,8 @@ struct LinkFeedContentView: View {
         FeedScopedLinkData.filteredStatuses(
             in: linkFilterService,
             feedId: currentTab.id,
-            userFilterAccountId: currentUserFilter
+            userFilterAccountId: currentUserFilter,
+            filterPrivateMentionsFromFeeds: filterPrivateMentionsFromFeeds
         )
     }
 

--- a/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
+++ b/fedi-reader/Views/Feed/LinkFeedView/LinkFeedThreeColumnView.swift
@@ -16,6 +16,8 @@ struct LinkFeedThreeColumnView: View {
     @Environment(LinkFilterService.self) private var linkFilterService
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @Environment(\.layoutMode) private var layoutMode
+    @AppStorage(PrivateMentionsFeedFilter.storageKey)
+    private var filterPrivateMentionsFromFeeds = PrivateMentionsFeedFilter.defaultValue
 
     @State private var selectedTabIndex: Int = 0
     @State private var selectedArticle: (url: URL, status: Status)?
@@ -83,7 +85,11 @@ struct LinkFeedThreeColumnView: View {
     }
 
     private var currentAccounts: [MastodonAccount] {
-        FeedScopedLinkData.accounts(in: linkFilterService, feedId: currentTab.id)
+        FeedScopedLinkData.accounts(
+            in: linkFilterService,
+            feedId: currentTab.id,
+            filterPrivateMentionsFromFeeds: filterPrivateMentionsFromFeeds
+        )
     }
 
     private var currentUserFilter: String? {
@@ -94,7 +100,8 @@ struct LinkFeedThreeColumnView: View {
         FeedScopedLinkData.filteredStatuses(
             in: linkFilterService,
             feedId: currentTab.id,
-            userFilterAccountId: currentUserFilter
+            userFilterAccountId: currentUserFilter,
+            filterPrivateMentionsFromFeeds: filterPrivateMentionsFromFeeds
         )
     }
 

--- a/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
+++ b/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
@@ -44,53 +44,24 @@ struct ChatBubble: View {
     
     var body: some View {
         if let status = status {
-            Button {
-                appState.navigate(to: .status(status))
-            } label: {
-                VStack(alignment: isSent ? .trailing : .leading, spacing: 6) {
-                    // Message content
-                    if showsTextContent {
-                        if #available(iOS 15.0, macOS 12.0, *) {
-                            HashtagLinkText(
-                                content: status.content,
-                                onHashtagTap: { appState.navigate(to: .hashtag($0)) },
-                                emojiLookup: Dictionary(uniqueKeysWithValues: status.emojis.map { ($0.shortcode, $0) }),
-                                hiddenMentionHandles: hiddenMentionHandles
-                            )
-                            .font(.roundedBody)
-                            .multilineTextAlignment(.leading)
-                        } else {
-                            Text(displayPlainText)
-                                .font(.roundedBody)
-                                .multilineTextAlignment(.leading)
-                        }
-                    }
-                    
-                    if !mediaAttachments.isEmpty {
-                        chatMediaAttachments
-                    }
-                    
-                    // Timestamp
-                    Text(message.createdAt, style: .time)
-                        .font(.roundedCaption2)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 18)
-                        .fill(isSent ? ThemeColor.resolved(from: themeColorName).color.opacity(0.2) : Color(.secondarySystemBackground))
-                )
-                .overlay(alignment: isSent ? .bottomLeading : .bottomTrailing) {
-                    // Tapback-style favorite indicator
-                    if hasFavorites {
-                        TapbackView(count: status.favouritesCount, isMine: isFavoritedByMe)
-                            .offset(x: isSent ? -8 : 8, y: 8)
-                    }
+            let embeddedLayout = MessageEmbeddedContentLayoutResolver.resolve(
+                from: status,
+                hiddenHandles: hiddenMentionHandles
+            )
+
+            VStack(alignment: isSent ? .trailing : .leading, spacing: 6) {
+                if let candidate = embeddedLayout.candidate {
+                    embeddedMessageContent(
+                        status: status,
+                        candidate: candidate,
+                        layout: embeddedLayout
+                    )
+                } else {
+                    standardMessageContent(status: status)
                 }
             }
-            .buttonStyle(.plain)
-            .padding(.bottom, hasFavorites ? 8 : 0) // Extra space for tapback
+            .padding(.bottom, hasFavorites && embeddedLayout.candidate == nil ? 8 : 0) // Extra space for tapback
+            .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
             .contextMenu {
                 Button {
                     appState.navigate(to: .profile(account))
@@ -110,6 +81,84 @@ struct ChatBubble: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func standardMessageContent(status: Status) -> some View {
+        Button {
+            appState.navigate(to: .status(status))
+        } label: {
+            VStack(alignment: isSent ? .trailing : .leading, spacing: 6) {
+                if showsTextContent {
+                    messageTextContent(status.content)
+                }
+
+                if !mediaAttachments.isEmpty {
+                    chatMediaAttachments
+                }
+
+                Text(message.createdAt, style: .time)
+                    .font(.roundedCaption2)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(messageBubbleShape.fill(messageBubbleColor))
+            .overlay(alignment: isSent ? .bottomLeading : .bottomTrailing) {
+                if hasFavorites {
+                    TapbackView(count: status.favouritesCount, isMine: isFavoritedByMe)
+                        .offset(x: isSent ? -8 : 8, y: 8)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func embeddedMessageContent(
+        status: Status,
+        candidate: MessageLinkPreviewCandidate,
+        layout: MessageEmbeddedContentLayout
+    ) -> some View {
+        if let leadingContent = layout.leadingContent {
+            messageTextBubble(
+                content: leadingContent,
+                status: status
+            )
+        }
+
+        MessageLinkPreviewCard(
+            status: status,
+            candidate: candidate,
+            isSent: isSent
+        )
+
+        if let trailingContent = layout.trailingContent {
+            messageTextBubble(
+                content: trailingContent,
+                status: status
+            )
+        }
+
+        if !mediaAttachments.isEmpty {
+            Button {
+                appState.navigate(to: .status(status))
+            } label: {
+                chatMediaAttachments
+            }
+            .buttonStyle(.plain)
+        }
+
+        HStack(spacing: 6) {
+            Text(message.createdAt, style: .time)
+                .font(.roundedCaption2)
+                .foregroundStyle(.secondary)
+
+            if hasFavorites {
+                TapbackView(count: status.favouritesCount, isMine: isFavoritedByMe)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
     }
 
     private func toggleFavorite(status: Status) async {
@@ -132,6 +181,202 @@ struct ChatBubble: View {
             }
         }
     }
+
+    @ViewBuilder
+    private func messageTextContent(_ content: String) -> some View {
+        if #available(iOS 15.0, macOS 12.0, *) {
+            HashtagLinkText(
+                content: content,
+                onHashtagTap: { appState.navigate(to: .hashtag($0)) },
+                emojiLookup: Dictionary(uniqueKeysWithValues: status?.emojis.map { ($0.shortcode, $0) } ?? []),
+                hiddenMentionHandles: hiddenMentionHandles
+            )
+            .font(.roundedBody)
+            .multilineTextAlignment(.leading)
+        } else {
+            Text(
+                DirectMessageMentionFormatter.stripLeadingMentions(
+                    from: content.htmlToPlainText,
+                    hiddenHandles: hiddenMentionHandles
+                )
+            )
+            .font(.roundedBody)
+            .multilineTextAlignment(.leading)
+        }
+    }
+
+    private func messageTextBubble(content: String, status: Status) -> some View {
+        Button {
+            appState.navigate(to: .status(status))
+        } label: {
+            messageTextContent(content)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(messageBubbleShape.fill(messageBubbleColor))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var messageBubbleShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 18)
+    }
+
+    private var messageBubbleColor: Color {
+        isSent ? ThemeColor.resolved(from: themeColorName).color.opacity(0.2) : Color(.secondarySystemBackground)
+    }
+}
+
+private struct MessageLinkPreviewCard: View {
+    let status: Status
+    let candidate: MessageLinkPreviewCandidate
+    let isSent: Bool
+
+    @Environment(AppState.self) private var appState
+    @Environment(\.openURL) private var openURL
+    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
+
+    @State private var linkPreview: LinkPreviewService.LinkPreview?
+    @State private var authorAttribution: AuthorAttribution?
+    @State private var resolvedAuthorAccount: MastodonAccount?
+
+    private var previewURL: URL? {
+        candidate.url
+    }
+
+    var body: some View {
+        Button {
+            openLink(candidate.url)
+        } label: {
+            linkCardContent(for: candidate)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .glassEffect(.clear, in: cardBackgroundShape)
+                .clipShape(cardBackgroundShape)
+                .environment(\.openURL, authorLinkOpenURLAction)
+        }
+        .buttonStyle(.plain)
+        .frame(maxWidth: maxCardWidth, alignment: isSent ? .trailing : .leading)
+        .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
+        .task(id: previewURL?.absoluteString) {
+            await loadPreviewState()
+        }
+    }
+
+    private var cardBackgroundShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 16)
+    }
+
+    private var maxCardWidth: CGFloat { 520 }
+
+    private func linkCardContent(for candidate: MessageLinkPreviewCandidate) -> some View {
+        let content = MessageLinkPreviewContentResolver.resolve(
+            candidate: candidate,
+            linkPreview: linkPreview,
+            authorAttribution: authorAttribution,
+            authorDisplayName: resolvedAuthorAccount?.preferredDisplayName
+        )
+        return LinkCardContent(
+            title: content.title,
+            description: content.description,
+            imageURL: content.imageURL,
+            providerDisplay: content.providerDisplay,
+            authorName: content.authorName,
+            authorURL: content.authorURL,
+            isMastodonAttribution: content.isMastodonAttribution,
+            showLinkIcon: content.showLinkIcon,
+            layout: .feed
+        )
+    }
+
+    private func loadPreviewState() async {
+        async let fetchedPreview: LinkPreviewService.LinkPreview? = if MessageLinkPreviewContentResolver.shouldFetchPreview(for: candidate) {
+            await LinkPreviewService.shared.preview(for: candidate.url)
+        } else {
+            nil
+        }
+        async let fetchedAttribution: AuthorAttribution? = AttributionChecker.shared.checkAttribution(for: candidate.url)
+
+        let preview = await fetchedPreview
+        let attribution = await fetchedAttribution
+        let authorAccount = await appState.client.resolveProfileAccount(
+            handle: attribution?.mastodonHandle,
+            profileURL: currentAuthorURL(
+                for: candidate,
+                authorAttribution: attribution,
+                linkPreview: preview
+            )
+        )
+
+        guard !Task.isCancelled else {
+            return
+        }
+
+        linkPreview = preview
+        authorAttribution = attribution
+        resolvedAuthorAccount = authorAccount
+    }
+
+    private func openLink(_ url: URL) {
+        let preference = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
+        switch preference {
+        case .externalBrowser:
+            openURL(url)
+        case .safari:
+            #if os(iOS)
+            appState.present(sheet: .safariView(url: url))
+            #else
+            openURL(url)
+            #endif
+        case .inApp:
+            appState.navigate(to: .article(url: url, status: status))
+        }
+    }
+
+    private func currentAuthorURL(
+        for candidate: MessageLinkPreviewCandidate,
+        authorAttribution: AuthorAttribution?,
+        linkPreview: LinkPreviewService.LinkPreview?
+    ) -> URL? {
+        if let preferredURL = authorAttribution?.preferredURL {
+            return preferredURL
+        }
+
+        if let cardURL = candidate.card?.authorUrl.flatMap({ URL(string: $0) }) {
+            return cardURL
+        }
+
+        return linkPreview?.fediverseCreatorURL
+    }
+
+    private var authorLinkOpenURLAction: OpenURLAction {
+        OpenURLAction { url in
+            guard MastodonProfileReference.acct(handle: authorAttribution?.mastodonHandle, profileURL: url) != nil else {
+                return .systemAction(url)
+            }
+
+            Task {
+                let account = if let resolvedAuthorAccount {
+                    resolvedAuthorAccount
+                } else {
+                    await appState.client.resolveProfileAccount(
+                        handle: authorAttribution?.mastodonHandle,
+                        profileURL: url
+                    )
+                }
+
+                if let account {
+                    await MainActor.run {
+                        resolvedAuthorAccount = account
+                        appState.navigate(to: .profile(account))
+                    }
+                } else {
+                    await MainActor.run {
+                        openURL(url)
+                    }
+                }
+            }
+            return .handled
+        }
+    }
 }
 
 // MARK: - Chat Media Attachment View
@@ -140,6 +385,10 @@ private struct ChatMediaAttachmentView: View {
     let attachment: MediaAttachment
     let isSent: Bool
     let autoPlayGifs: Bool
+
+    private var mediaSize: CGSize {
+        MessageMediaLayoutResolver.size(for: attachment)
+    }
 
     private var imageURL: URL? {
         URL(string: attachment.previewUrl ?? attachment.url)
@@ -164,15 +413,15 @@ private struct ChatMediaAttachmentView: View {
                 Rectangle()
                     .fill(.tertiary)
             }
-            .frame(maxWidth: 220, maxHeight: 220)
+            .frame(width: mediaSize.width, height: mediaSize.height)
 
             // Overlay: video player when autoplay is on
             if shouldAutoplayVideo, let url = videoURL {
                 ChatGifvPlayerView(url: url)
-                    .frame(maxWidth: 220, maxHeight: 220)
+                    .frame(width: mediaSize.width, height: mediaSize.height)
             }
         }
-        .frame(maxWidth: 220, maxHeight: 220)
+        .frame(width: mediaSize.width, height: mediaSize.height)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(alignment: .bottomTrailing) {
             if attachment.type == .video || attachment.type == .gifv {
@@ -197,6 +446,7 @@ private struct ChatGifvPlayerView: View {
         Group {
             if let player {
                 VideoPlayer(player: player)
+                    .clipped()
                     .onAppear {
                         player.isMuted = true
                         player.play()
@@ -219,4 +469,3 @@ private struct ChatGifvPlayerView: View {
 }
 
 // MARK: - Tapback View (iMessage-style reaction indicator)
-

--- a/fedi-reader/Views/Feed/Mentions/ChatMessageGroup.swift
+++ b/fedi-reader/Views/Feed/Mentions/ChatMessageGroup.swift
@@ -6,11 +6,13 @@ struct ChatMessageGroup: View {
     let hiddenMentionHandles: Set<String>
     @Environment(AppState.self) private var appState
     
+    private let opposingSideMinimumSpace: CGFloat = 16
+    
     var body: some View {
         if group.isSent {
             // Sent messages (right-aligned)
-            HStack(alignment: .bottom, spacing: 8) {
-                Spacer(minLength: 60)
+            HStack(alignment: .bottom, spacing: 6) {
+                Spacer(minLength: opposingSideMinimumSpace)
                 
                 // Messages
                 VStack(alignment: .trailing, spacing: 4) {
@@ -24,6 +26,7 @@ struct ChatMessageGroup: View {
                         )
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .trailing)
                 
                 // Avatar (only shown for first message in group)
                 if group.messages.first != nil {
@@ -32,33 +35,33 @@ struct ChatMessageGroup: View {
                             appState.navigate(to: .profile(currentAccount))
                         }
                     } label: {
-                        ProfileAvatarView(url: group.account.avatarURL, size: 32)
+                        ProfileAvatarView(url: group.account.avatarURL, size: 28)
                     }
                     .buttonStyle(.plain)
                 } else {
                     // Spacer to align messages
                     Circle()
                         .fill(Color.clear)
-                        .frame(width: 32, height: 32)
+                        .frame(width: 28, height: 28)
                 }
             }
             .padding(.vertical, 4)
         } else {
             // Received messages (left-aligned)
-            HStack(alignment: .bottom, spacing: 8) {
+            HStack(alignment: .bottom, spacing: 6) {
                 // Avatar (only shown for first message in group)
                 if group.messages.first != nil {
                     Button {
                         appState.navigate(to: .profile(group.account))
                     } label: {
-                        ProfileAvatarView(url: group.account.avatarURL, size: 32)
+                        ProfileAvatarView(url: group.account.avatarURL, size: 28)
                     }
                     .buttonStyle(.plain)
                 } else {
                     // Spacer to align messages
                     Circle()
                         .fill(Color.clear)
-                        .frame(width: 32, height: 32)
+                        .frame(width: 28, height: 28)
                 }
                 
                 // Messages
@@ -90,8 +93,9 @@ struct ChatMessageGroup: View {
                         )
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 
-                Spacer(minLength: 60)
+                Spacer(minLength: opposingSideMinimumSpace)
             }
             .padding(.vertical, 4)
         }
@@ -99,4 +103,3 @@ struct ChatMessageGroup: View {
 }
 
 // MARK: - Chat Bubble
-

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
@@ -109,7 +109,7 @@ struct GroupedConversationDetailView: View {
                             .id(group.id)
                     }
                 }
-                .padding(.horizontal, 12)
+                .padding(.horizontal, 6)
                 .padding(.vertical, 8)
             }
             .scrollContentBackground(.hidden)
@@ -364,4 +364,3 @@ struct GroupedConversationDetailView: View {
 }
 
 // MARK: - Grouped Message
-

--- a/fedi-reader/Views/Settings/SettingsView.swift
+++ b/fedi-reader/Views/Settings/SettingsView.swift
@@ -17,6 +17,8 @@ struct SettingsView: View {
     @AppStorage("showQuoteBoost") private var showQuoteBoost = true
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
     @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
+    @AppStorage(PrivateMentionsFeedFilter.storageKey)
+    private var filterPrivateMentionsFromFeeds = PrivateMentionsFeedFilter.defaultValue
 
     private var accountID: String? {
         appState.currentAccount?.id
@@ -60,6 +62,7 @@ struct SettingsView: View {
                     showQuoteBoost: $showQuoteBoost,
                     showHandleInFeed: $showHandleInFeed,
                     articleViewerPreferenceRaw: $articleViewerPreferenceRaw,
+                    filterPrivateMentionsFromFeeds: $filterPrivateMentionsFromFeeds,
                     lists: lists,
                     isCompactDevice: isCompactDevice
                 )
@@ -145,6 +148,8 @@ struct SettingsView: View {
                     Text("15 minutes").tag(15)
                     Text("30 minutes").tag(30)
                 }
+
+                Toggle("Filter Private Mentions From Feeds", isOn: $filterPrivateMentionsFromFeeds)
             }
             
             // Posting
@@ -222,6 +227,7 @@ private struct SettingsTwoColumnView: View {
     @Binding var showQuoteBoost: Bool
     @Binding var showHandleInFeed: Bool
     @Binding var articleViewerPreferenceRaw: String
+    @Binding var filterPrivateMentionsFromFeeds: Bool
     let lists: [MastodonList]
     let isCompactDevice: Bool
 
@@ -441,6 +447,11 @@ private struct SettingsTwoColumnView: View {
                     }
                     .pickerStyle(.menu)
                     .listRowInsets(Self.detailRowInsets)
+
+                    settingsToggleRow(
+                        "Filter Private Mentions From Feeds",
+                        isOn: $filterPrivateMentionsFromFeeds
+                    )
                 } header: {
                     Text("Timeline").font(.roundedTitle3)
                 }

--- a/fedi-readerTests/LinkFilterServiceTests.swift
+++ b/fedi-readerTests/LinkFilterServiceTests.swift
@@ -660,12 +660,118 @@ struct LinkFilterServiceTests {
         let scopedStatuses = FeedScopedLinkData.filteredStatuses(
             in: service,
             feedId: "list-1",
-            userFilterAccountId: nil
+            userFilterAccountId: nil,
+            filterPrivateMentionsFromFeeds: false
         )
-        let scopedAccounts = FeedScopedLinkData.accounts(in: service, feedId: "list-1")
+        let scopedAccounts = FeedScopedLinkData.accounts(
+            in: service,
+            feedId: "list-1",
+            filterPrivateMentionsFromFeeds: false
+        )
 
         #expect(scopedStatuses.map(\.id) == ["list-1"])
         #expect(scopedAccounts.map(\.id) == ["acct-list"])
+    }
+
+    @Test("Private mention feed filter defaults to enabled")
+    func privateMentionFeedFilterDefaultsToEnabled() {
+        #expect(PrivateMentionsFeedFilter.defaultValue)
+    }
+
+    @Test("Feed-scoped data filters private mentions when enabled")
+    func feedScopedDataFiltersPrivateMentionsWhenEnabled() async {
+        let publicAuthor = MockStatusFactory.makeAccount(id: "acct-public", username: "public")
+        let privateAuthor = MockStatusFactory.makeAccount(id: "acct-private", username: "private")
+        let directAuthor = MockStatusFactory.makeAccount(id: "acct-direct", username: "direct")
+
+        let statuses = [
+            MockStatusFactory.makeStatus(
+                id: "public-link",
+                hasCard: true,
+                cardURL: "https://example.com/public",
+                account: publicAuthor,
+                visibility: .public
+            ),
+            MockStatusFactory.makeStatus(
+                id: "private-link",
+                hasCard: true,
+                cardURL: "https://example.com/private",
+                account: privateAuthor,
+                visibility: .private
+            ),
+            MockStatusFactory.makeStatus(
+                id: "direct-link",
+                hasCard: true,
+                cardURL: "https://example.com/direct",
+                account: directAuthor,
+                visibility: .direct
+            )
+        ]
+
+        _ = await service.processStatuses(statuses, for: AppState.homeFeedID)
+
+        let scopedStatuses = FeedScopedLinkData.filteredStatuses(
+            in: service,
+            feedId: AppState.homeFeedID,
+            userFilterAccountId: nil,
+            filterPrivateMentionsFromFeeds: true
+        )
+        let scopedAccounts = FeedScopedLinkData.accounts(
+            in: service,
+            feedId: AppState.homeFeedID,
+            filterPrivateMentionsFromFeeds: true
+        )
+
+        #expect(scopedStatuses.map(\.id) == ["public-link"])
+        #expect(scopedAccounts.map(\.id) == ["acct-public"])
+    }
+
+    @Test("Feed-scoped data can include private mentions when disabled")
+    func feedScopedDataCanIncludePrivateMentionsWhenDisabled() async {
+        let publicAuthor = MockStatusFactory.makeAccount(id: "acct-public", username: "public")
+        let privateAuthor = MockStatusFactory.makeAccount(id: "acct-private", username: "private")
+        let directAuthor = MockStatusFactory.makeAccount(id: "acct-direct", username: "direct")
+
+        let statuses = [
+            MockStatusFactory.makeStatus(
+                id: "public-link",
+                hasCard: true,
+                cardURL: "https://example.com/public",
+                account: publicAuthor,
+                visibility: .public
+            ),
+            MockStatusFactory.makeStatus(
+                id: "private-link",
+                hasCard: true,
+                cardURL: "https://example.com/private",
+                account: privateAuthor,
+                visibility: .private
+            ),
+            MockStatusFactory.makeStatus(
+                id: "direct-link",
+                hasCard: true,
+                cardURL: "https://example.com/direct",
+                account: directAuthor,
+                visibility: .direct
+            )
+        ]
+
+        _ = await service.processStatuses(statuses, for: AppState.homeFeedID)
+
+        let scopedStatuses = FeedScopedLinkData.filteredStatuses(
+            in: service,
+            feedId: AppState.homeFeedID,
+            userFilterAccountId: nil,
+            filterPrivateMentionsFromFeeds: false
+        )
+        let scopedAccounts = FeedScopedLinkData.accounts(
+            in: service,
+            feedId: AppState.homeFeedID,
+            filterPrivateMentionsFromFeeds: false
+        )
+
+        #expect(scopedStatuses.map(\.id) == ["public-link", "private-link", "direct-link"])
+        #expect(Set(scopedAccounts.map(\.id)) == Set(["acct-public", "acct-private", "acct-direct"]))
     }
     
     // MARK: - Filter by Account

--- a/fedi-readerTests/LinkPreviewServiceTests.swift
+++ b/fedi-readerTests/LinkPreviewServiceTests.swift
@@ -4,6 +4,8 @@ import Foundation
 
 private final class LinkPreviewServiceMockURLProtocol: URLProtocol {
     static var mockResponses: [String: (Data, HTTPURLResponse)] = [:]
+    static var queuedResponses: [String: [(Data, HTTPURLResponse)]] = [:]
+    static var requestHandler: ((URLRequest) -> (Data, HTTPURLResponse)?)?
     private static let lock = NSLock()
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -15,8 +17,7 @@ private final class LinkPreviewServiceMockURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        guard let url = request.url?.absoluteString,
-              let (data, response) = Self.response(for: url) else {
+        guard let (data, response) = Self.response(for: request) else {
             client?.urlProtocolDidFinishLoading(self)
             return
         }
@@ -32,6 +33,8 @@ private final class LinkPreviewServiceMockURLProtocol: URLProtocol {
         lock.lock()
         defer { lock.unlock() }
         mockResponses.removeAll()
+        queuedResponses.removeAll()
+        requestHandler = nil
     }
 
     static func setMockResponse(
@@ -51,14 +54,46 @@ private final class LinkPreviewServiceMockURLProtocol: URLProtocol {
         mockResponses[url] = (data, response)
     }
 
-    private static func response(for url: String) -> (Data, HTTPURLResponse)? {
+    static func queueMockResponses(
+        for url: String,
+        responses: [(data: Data, statusCode: Int, headerFields: [String: String]?)]
+    ) {
         lock.lock()
         defer { lock.unlock() }
+        queuedResponses[url] = responses.map { response in
+            let httpResponse = HTTPURLResponse(
+                url: URL(string: url)!,
+                statusCode: response.statusCode,
+                httpVersion: nil,
+                headerFields: response.headerFields
+            )!
+            return (response.data, httpResponse)
+        }
+    }
+
+    private static func response(for request: URLRequest) -> (Data, HTTPURLResponse)? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let requestHandler {
+            return requestHandler(request)
+        }
+        guard let url = request.url?.absoluteString else {
+            return nil
+        }
+        if var queued = queuedResponses[url], !queued.isEmpty {
+            let response = queued.removeFirst()
+            if queued.isEmpty {
+                queuedResponses.removeValue(forKey: url)
+            } else {
+                queuedResponses[url] = queued
+            }
+            return response
+        }
         return mockResponses[url]
     }
 }
 
-@Suite("Link Preview Service Tests")
+@Suite("Link Preview Service Tests", .serialized)
 struct LinkPreviewServiceTests {
 
     @Test("Fetches fediverse creator when meta attributes are reversed")
@@ -89,5 +124,130 @@ struct LinkPreviewServiceTests {
 
         #expect(creator?.name == "@alice@mastodon.social")
         #expect(creator?.url?.absoluteString == "https://mastodon.social/@alice")
+    }
+
+    @Test("Falls back to full HTML fetch when the head range lacks preview metadata")
+    func fallsBackToFullHTMLFetchWhenHeadRangeLacksPreviewMetadata() async {
+        LinkPreviewServiceMockURLProtocol.reset()
+
+        let url = "https://example.com/article"
+        let sparseHTML = """
+        <html>
+            <head>
+                <meta charset="utf-8">
+            </head>
+            <body>Partial</body>
+        </html>
+        """
+        let fullHTML = """
+        <html>
+            <head>
+                <meta property="og:title" content="Recovered Title">
+                <meta property="og:image" content="https://example.com/feature.jpg">
+                <meta property="og:site_name" content="Example Site">
+            </head>
+            <body>Full</body>
+        </html>
+        """
+
+        LinkPreviewServiceMockURLProtocol.requestHandler = { request in
+            guard request.url?.absoluteString == url else { return nil }
+
+            let statusCode: Int
+            let data: Data
+
+            if request.httpMethod == "HEAD" {
+                statusCode = 200
+                data = Data()
+            } else if request.value(forHTTPHeaderField: "Range") != nil {
+                statusCode = 206
+                data = Data(sparseHTML.utf8)
+            } else {
+                statusCode = 200
+                data = Data(fullHTML.utf8)
+            }
+
+            let response = HTTPURLResponse(
+                url: URL(string: url)!,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html"]
+            )!
+
+            return (data, response)
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [LinkPreviewServiceMockURLProtocol.self]
+        let service = LinkPreviewService(configuration: configuration)
+
+        let preview = await service.preview(for: URL(string: url)!)
+
+        #expect(preview?.title == "Recovered Title")
+        #expect(preview?.imageURL?.absoluteString == "https://example.com/feature.jpg")
+        #expect(preview?.siteName == "Example Site")
+    }
+
+    @Test("Falls back to full HTML fetch when the head range has a title but no image")
+    func fallsBackToFullHTMLFetchWhenHeadRangeHasTitleButNoImage() async {
+        LinkPreviewServiceMockURLProtocol.reset()
+
+        let url = "https://example.com/article"
+        let sparseHTML = """
+        <html>
+            <head>
+                <meta property="og:title" content="Recovered Title">
+                <meta property="og:site_name" content="Example Site">
+            </head>
+            <body>Partial</body>
+        </html>
+        """
+        let fullHTML = """
+        <html>
+            <head>
+                <meta property="og:title" content="Recovered Title">
+                <meta property="og:image" content="https://example.com/feature.jpg">
+                <meta property="og:site_name" content="Example Site">
+            </head>
+            <body>Full</body>
+        </html>
+        """
+
+        LinkPreviewServiceMockURLProtocol.requestHandler = { request in
+            guard request.url?.absoluteString == url else { return nil }
+
+            let statusCode: Int
+            let data: Data
+
+            if request.httpMethod == "HEAD" {
+                statusCode = 200
+                data = Data()
+            } else if request.value(forHTTPHeaderField: "Range") != nil {
+                statusCode = 206
+                data = Data(sparseHTML.utf8)
+            } else {
+                statusCode = 200
+                data = Data(fullHTML.utf8)
+            }
+
+            let response = HTTPURLResponse(
+                url: URL(string: url)!,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/html"]
+            )!
+
+            return (data, response)
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [LinkPreviewServiceMockURLProtocol.self]
+        let service = LinkPreviewService(configuration: configuration)
+
+        let preview = await service.preview(for: URL(string: url)!)
+
+        #expect(preview?.title == "Recovered Title")
+        #expect(preview?.imageURL?.absoluteString == "https://example.com/feature.jpg")
+        #expect(preview?.siteName == "Example Site")
     }
 }

--- a/fedi-readerTests/MessageEmbeddedContentLayoutResolverTests.swift
+++ b/fedi-readerTests/MessageEmbeddedContentLayoutResolverTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import fedi_reader
+
+@Suite("Message Embedded Content Layout Resolver Tests")
+struct MessageEmbeddedContentLayoutResolverTests {
+    @Test("Keeps text before an embedded link when the link is at the end")
+    func keepsLeadingTextWhenLinkEndsMessage() {
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>Read this <a href=\"https://example.com/story\">https://example.com/story</a></p>",
+            hasCard: true,
+            cardURL: "https://example.com/story"
+        )
+
+        let layout = MessageEmbeddedContentLayoutResolver.resolve(from: status, hiddenHandles: [])
+
+        #expect(layout.candidate?.url.absoluteString == "https://example.com/story")
+        #expect(layout.leadingContent?.htmlToPlainText == "Read this")
+        #expect(layout.trailingContent == nil)
+    }
+
+    @Test("Keeps text after an embedded link when the link starts the message")
+    func keepsTrailingTextWhenLinkStartsMessage() {
+        let status = MockStatusFactory.makeStatus(
+            content: "<p><a href=\"https://example.com/story\">https://example.com/story</a> worth your time</p>",
+            hasCard: true,
+            cardURL: "https://example.com/story"
+        )
+
+        let layout = MessageEmbeddedContentLayoutResolver.resolve(from: status, hiddenHandles: [])
+
+        #expect(layout.candidate?.url.absoluteString == "https://example.com/story")
+        #expect(layout.leadingContent == nil)
+        #expect(layout.trailingContent?.htmlToPlainText == "worth your time")
+    }
+
+    @Test("Splits message text around an embedded link in the middle")
+    func splitsTextAroundEmbeddedLink() {
+        let status = MockStatusFactory.makeStatus(
+            content: """
+            <p>Before <a href="https://example.com/story">the story</a> after</p>
+            """,
+            hasCard: true,
+            cardURL: "https://example.com/story"
+        )
+
+        let layout = MessageEmbeddedContentLayoutResolver.resolve(from: status, hiddenHandles: [])
+
+        #expect(layout.leadingContent?.htmlToPlainText == "Before")
+        #expect(layout.trailingContent?.htmlToPlainText == "after")
+    }
+
+    @Test("Drops hidden direct-message mentions before the embedded link")
+    func dropsHiddenMentionsBeforeEmbeddedLink() {
+        let status = MockStatusFactory.makeStatus(
+            content: """
+            <p>@alice <a href="https://example.com/story">the story</a> hello there</p>
+            """,
+            hasCard: true,
+            cardURL: "https://example.com/story"
+        )
+
+        let layout = MessageEmbeddedContentLayoutResolver.resolve(
+            from: status,
+            hiddenHandles: ["alice"]
+        )
+
+        #expect(layout.leadingContent == nil)
+        #expect(layout.trailingContent?.htmlToPlainText == "hello there")
+    }
+
+    @Test("Falls back to plain-text links when no anchor tag exists")
+    func fallsBackToPlainTextLinkSplitting() {
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>Take a look https://example.com/plain next</p>"
+        )
+
+        let layout = MessageEmbeddedContentLayoutResolver.resolve(from: status, hiddenHandles: [])
+
+        #expect(layout.candidate?.url.absoluteString == "https://example.com/plain")
+        #expect(layout.leadingContent == "Take a look")
+        #expect(layout.trailingContent == "next")
+    }
+
+    @Test("Ignores unrelated rich cards that are not inline links")
+    func ignoresUnrelatedRichCards() {
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>Just reacting here</p>",
+            hasCard: true,
+            cardURL: "https://tenor.example/gif",
+            cardType: .rich
+        )
+
+        let layout = MessageEmbeddedContentLayoutResolver.resolve(from: status, hiddenHandles: [])
+
+        #expect(layout.candidate == nil)
+        #expect(layout.leadingContent == nil)
+        #expect(layout.trailingContent == nil)
+    }
+}

--- a/fedi-readerTests/MessageLinkPreviewContentResolverTests.swift
+++ b/fedi-readerTests/MessageLinkPreviewContentResolverTests.swift
@@ -1,0 +1,126 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Message Link Preview Content Resolver Tests")
+struct MessageLinkPreviewContentResolverTests {
+
+    @Test("Fetches preview metadata when the card title is only the domain")
+    func fetchesPreviewMetadataWhenCardTitleIsOnlyTheDomain() {
+        let card = PreviewCard(
+            url: "https://blog.sam-clemente.me/post",
+            title: "blog.sam-clemente.me",
+            description: "",
+            type: .link,
+            authorName: nil,
+            authorUrl: nil,
+            providerName: "blog.sam-clemente.me",
+            providerUrl: nil,
+            html: nil,
+            width: nil,
+            height: nil,
+            image: nil,
+            blurhash: nil,
+            embedUrl: nil
+        )
+        let candidate = MessageLinkPreviewCandidate(
+            url: URL(string: card.url)!,
+            card: card
+        )
+
+        #expect(MessageLinkPreviewContentResolver.shouldFetchPreview(for: candidate))
+    }
+
+    @Test("Uses fetched preview metadata to fill sparse card content")
+    func usesFetchedPreviewMetadataToFillSparseCardContent() {
+        let card = PreviewCard(
+            url: "https://blog.sam-clemente.me/post",
+            title: "blog.sam-clemente.me",
+            description: "",
+            type: .link,
+            authorName: nil,
+            authorUrl: nil,
+            providerName: "blog.sam-clemente.me",
+            providerUrl: nil,
+            html: nil,
+            width: nil,
+            height: nil,
+            image: nil,
+            blurhash: nil,
+            embedUrl: nil
+        )
+        let candidate = MessageLinkPreviewCandidate(
+            url: URL(string: card.url)!,
+            card: card
+        )
+        let preview = LinkPreviewService.LinkPreview(
+            url: URL(string: "https://blog.sam-clemente.me/post")!,
+            finalURL: URL(string: "https://blog.sam-clemente.me/post")!,
+            title: "A Better Title",
+            description: "Recovered description",
+            imageURL: URL(string: "https://blog.sam-clemente.me/feature.jpg"),
+            siteName: "Sam Clemente Blog",
+            provider: "blog.sam-clemente.me",
+            fediverseCreator: "@sam@mastodon.social",
+            fediverseCreatorURL: URL(string: "https://mastodon.social/@sam")
+        )
+
+        let content = MessageLinkPreviewContentResolver.resolve(
+            candidate: candidate,
+            linkPreview: preview,
+            authorAttribution: nil,
+            authorDisplayName: nil
+        )
+
+        #expect(content.title == "A Better Title")
+        #expect(content.description == "Recovered description")
+        #expect(content.imageURL?.absoluteString == "https://blog.sam-clemente.me/feature.jpg")
+        #expect(content.providerDisplay == "blog.sam-clemente.me")
+        #expect(content.authorName == "@sam@mastodon.social")
+        #expect(content.authorURL?.absoluteString == "https://mastodon.social/@sam")
+    }
+
+    @Test("Prefers fetched preview image when both card and source metadata provide images")
+    func prefersFetchedPreviewImageWhenAvailable() {
+        let card = PreviewCard(
+            url: "https://blog.sam-clemente.me/post",
+            title: "A Better Title",
+            description: "Recovered description",
+            type: .link,
+            authorName: nil,
+            authorUrl: nil,
+            providerName: "blog.sam-clemente.me",
+            providerUrl: nil,
+            html: nil,
+            width: nil,
+            height: nil,
+            image: "https://blog.sam-clemente.me/card-image.jpg",
+            blurhash: nil,
+            embedUrl: nil
+        )
+        let candidate = MessageLinkPreviewCandidate(
+            url: URL(string: card.url)!,
+            card: card
+        )
+        let preview = LinkPreviewService.LinkPreview(
+            url: URL(string: "https://blog.sam-clemente.me/post")!,
+            finalURL: URL(string: "https://blog.sam-clemente.me/post")!,
+            title: "A Better Title",
+            description: "Recovered description",
+            imageURL: URL(string: "https://blog.sam-clemente.me/feature.jpg"),
+            siteName: "Sam Clemente Blog",
+            provider: "blog.sam-clemente.me",
+            fediverseCreator: nil,
+            fediverseCreatorURL: nil
+        )
+
+        let content = MessageLinkPreviewContentResolver.resolve(
+            candidate: candidate,
+            linkPreview: preview,
+            authorAttribution: nil,
+            authorDisplayName: nil
+        )
+
+        #expect(content.imageURL?.absoluteString == "https://blog.sam-clemente.me/feature.jpg")
+    }
+}

--- a/fedi-readerTests/MessageLinkPreviewResolverTests.swift
+++ b/fedi-readerTests/MessageLinkPreviewResolverTests.swift
@@ -1,0 +1,97 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Message Link Preview Resolver Tests")
+struct MessageLinkPreviewResolverTests {
+
+    @Test("Uses preview cards for link and rich cards")
+    func usesPreviewCardsForEligibleCardTypes() {
+        let linkStatus = MockStatusFactory.makeStatus(
+            content: "<p><a href=\"https://example.com/article\">article</a></p>",
+            hasCard: true,
+            cardURL: "https://example.com/article"
+        )
+        let richStatus = MockStatusFactory.makeStatus(
+            content: "<p>Watch this https://example.com/embed</p>",
+            hasCard: true,
+            cardURL: "https://example.com/embed",
+            cardType: .rich
+        )
+
+        let linkCandidate = MessageLinkPreviewResolver.resolve(from: linkStatus)
+        let richCandidate = MessageLinkPreviewResolver.resolve(from: richStatus)
+
+        #expect(linkCandidate?.url.absoluteString == "https://example.com/article")
+        #expect(linkCandidate?.card?.url == "https://example.com/article")
+        #expect(richCandidate?.url.absoluteString == "https://example.com/embed")
+        #expect(richCandidate?.card?.url == "https://example.com/embed")
+    }
+
+    @Test("Ignores preview cards when their URL is not in message content")
+    func ignoresPreviewCardsWhenURLIsNotInMessageContent() {
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>Read this too <a href=\"https://example.com/secondary\">secondary</a></p>",
+            hasCard: true,
+            cardURL: "https://example.com/primary"
+        )
+
+        let candidate = MessageLinkPreviewResolver.resolve(from: status)
+
+        #expect(candidate?.url.absoluteString == "https://example.com/secondary")
+        #expect(candidate?.card == nil)
+    }
+
+    @Test("Falls back to first external link when no preview card exists")
+    func fallsBackToFirstExternalLinkWhenNoPreviewCardExists() {
+        let anchorStatus = MockStatusFactory.makeStatus(
+            content: """
+            <p>
+            <a href="https://mastodon.social/@someone">mention</a>
+            <a href="https://example.com/story">story</a>
+            </p>
+            """
+        )
+        let plainTextStatus = MockStatusFactory.makeStatus(
+            content: "<p>Read this next: https://example.com/plain-text-story</p>"
+        )
+
+        let anchorCandidate = MessageLinkPreviewResolver.resolve(from: anchorStatus)
+        let plainTextCandidate = MessageLinkPreviewResolver.resolve(from: plainTextStatus)
+
+        #expect(anchorCandidate?.url.absoluteString == "https://example.com/story")
+        #expect(anchorCandidate?.card == nil)
+        #expect(plainTextCandidate?.url.absoluteString == "https://example.com/plain-text-story")
+        #expect(plainTextCandidate?.card == nil)
+    }
+
+    @Test("Returns nil when only Mastodon internal links are present")
+    func returnsNilWhenOnlyMastodonInternalLinksArePresent() {
+        let status = MockStatusFactory.makeStatus(
+            content: """
+            <p>
+            <a href="https://mastodon.social/@someone">profile</a>
+            <a href="https://mastodon.social/tags/swift">tag</a>
+            </p>
+            """
+        )
+
+        let candidate = MessageLinkPreviewResolver.resolve(from: status)
+
+        #expect(candidate == nil)
+    }
+
+    @Test("Returns nil when no inline external link is present")
+    func returnsNilWhenNoInlineExternalLinkIsPresent() {
+        let status = MockStatusFactory.makeStatus(
+            content: "<p>Just reacting here</p>",
+            hasCard: true,
+            cardURL: "https://tenor.example/gif",
+            cardType: .rich
+        )
+
+        let candidate = MessageLinkPreviewResolver.resolve(from: status)
+
+        #expect(candidate == nil)
+    }
+}

--- a/fedi-readerTests/MessageMediaLayoutResolverTests.swift
+++ b/fedi-readerTests/MessageMediaLayoutResolverTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import fedi_reader
+
+@Suite("Message Media Layout Resolver Tests")
+struct MessageMediaLayoutResolverTests {
+
+    @Test("Defaults to a square layout when metadata is missing")
+    func defaultsToSquareLayoutWhenMetadataIsMissing() {
+        let attachment = MediaAttachment(
+            id: "attachment-1",
+            type: .image,
+            url: "https://example.com/image.jpg",
+            previewUrl: "https://example.com/preview.jpg",
+            remoteUrl: nil,
+            description: nil,
+            blurhash: nil,
+            meta: nil
+        )
+
+        let size = MessageMediaLayoutResolver.size(for: attachment)
+
+        #expect(size.width == 260)
+        #expect(size.height == 240)
+    }
+
+    @Test("Clamps very wide media to a readable chat height")
+    func clampsVeryWideMediaToReadableChatHeight() {
+        let attachment = MediaAttachment(
+            id: "attachment-2",
+            type: .gifv,
+            url: "https://example.com/clip.mp4",
+            previewUrl: "https://example.com/clip.jpg",
+            remoteUrl: nil,
+            description: nil,
+            blurhash: nil,
+            meta: MediaMeta(
+                original: MediaDimensions(width: 1600, height: 300, size: nil, aspect: 5.3333),
+                small: nil,
+                focus: nil
+            )
+        )
+
+        let size = MessageMediaLayoutResolver.size(for: attachment)
+
+        #expect(size.width == 260)
+        #expect(abs(size.height - 144.44444) < 0.01)
+    }
+
+    @Test("Keeps tall media from collapsing too narrow")
+    func keepsTallMediaFromCollapsingTooNarrow() {
+        let attachment = MediaAttachment(
+            id: "attachment-3",
+            type: .image,
+            url: "https://example.com/tall.jpg",
+            previewUrl: "https://example.com/tall-preview.jpg",
+            remoteUrl: nil,
+            description: nil,
+            blurhash: nil,
+            meta: MediaMeta(
+                original: MediaDimensions(width: 300, height: 1200, size: nil, aspect: 0.25),
+                small: nil,
+                focus: nil
+            )
+        )
+
+        let size = MessageMediaLayoutResolver.size(for: attachment)
+
+        #expect(abs(size.width - 156) < 0.01)
+        #expect(size.height == 240)
+    }
+}


### PR DESCRIPTION
Summary
- ensure private mentions are filtered from feed search/mention views while keeping attribution tooling intact
- tighten link preview rendering so cards align with feed expectations and resize cleanly across components
- add / update layout tests and helpers to prevent regressions in media/link sizing and embedded content

Testing
- Not run (not requested)