### PR TITLE
Add follow button to profile viewer

### DIFF
--- a/fedi-reader/Services/MastodonClient.swift
+++ b/fedi-reader/Services/MastodonClient.swift
@@ -554,6 +554,20 @@ final class MastodonClient {
         let request = buildRequest(url: url, accessToken: accessToken)
         return try await execute(request)
     }
+
+    func followAccount(instance: String, accessToken: String, accountId: String) async throws -> Relationship {
+        Self.logger.info("Following account: \(accountId.prefix(8), privacy: .public)")
+        let url = try buildURL(instance: instance, path: "\(Constants.API.accounts)/\(accountId)/follow")
+        let request = buildRequest(url: url, method: "POST", accessToken: accessToken)
+        return try await execute(request)
+    }
+
+    func unfollowAccount(instance: String, accessToken: String, accountId: String) async throws -> Relationship {
+        Self.logger.info("Unfollowing account: \(accountId.prefix(8), privacy: .public)")
+        let url = try buildURL(instance: instance, path: "\(Constants.API.accounts)/\(accountId)/unfollow")
+        let request = buildRequest(url: url, method: "POST", accessToken: accessToken)
+        return try await execute(request)
+    }
     
     func getAccountFollowers(
         instance: String,

--- a/fedi-reader/Views/Profile/ProfileSummaryView.swift
+++ b/fedi-reader/Views/Profile/ProfileSummaryView.swift
@@ -13,6 +13,9 @@ struct ProfileSummaryView: View {
 
     @Environment(AppState.self) private var appState
     @State private var featuredTagNames: [String] = []
+    @State private var relationship: Relationship?
+    @State private var isLoadingRelationship = false
+    @State private var isUpdatingRelationship = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -58,6 +61,10 @@ struct ProfileSummaryView: View {
                     Text("@\(account.acct)")
                         .font(.roundedSubheadline)
                         .foregroundStyle(.secondary)
+                }
+
+                if shouldShowFollowButton {
+                    followButton
                 }
 
                 if !account.preferredNote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -111,8 +118,51 @@ struct ProfileSummaryView: View {
             .padding(.bottom, 16)
         }
         .task(id: account.id) {
+            await loadRelationship()
             await loadFeaturedTags()
         }
+    }
+
+    private var shouldShowFollowButton: Bool {
+        guard let currentAccount = appState.currentAccount else { return false }
+        return currentAccount.id != account.id
+    }
+
+    private var followButtonLabel: String {
+        if relationship?.requested == true {
+            return "Requested"
+        }
+        if relationship?.following == true {
+            return "Following"
+        }
+        if account.locked {
+            return "Request Follow"
+        }
+        return "Follow"
+    }
+
+    @ViewBuilder
+    private var followButton: some View {
+        Button {
+            Task {
+                await toggleFollowState()
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if isLoadingRelationship || isUpdatingRelationship {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                Text(followButtonLabel)
+                    .font(.roundedSubheadline.weight(.semibold))
+            }
+            .frame(minWidth: 110)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(relationship?.following == true || relationship?.requested == true ? .secondary : .accentColor)
+        .disabled(isLoadingRelationship || isUpdatingRelationship || relationship == nil)
+        .accessibilityIdentifier("profile-follow-button")
     }
 
     private func statItem(count: Int, label: String) -> some View {
@@ -165,6 +215,69 @@ struct ProfileSummaryView: View {
                 .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
         } catch {
             featuredTagNames = []
+        }
+    }
+
+    @MainActor
+    private func loadRelationship() async {
+        guard shouldShowFollowButton,
+              let currentAccount = appState.currentAccount,
+              let token = await appState.getAccessToken() else {
+            relationship = nil
+            isLoadingRelationship = false
+            return
+        }
+
+        isLoadingRelationship = true
+        defer { isLoadingRelationship = false }
+
+        do {
+            relationship = try await appState.client.getRelationships(
+                instance: currentAccount.instance,
+                accessToken: token,
+                ids: [account.id]
+            ).first
+        } catch {
+            relationship = nil
+            appState.presentedAlert = AlertItem(
+                title: "Unable to Load Follow State",
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    @MainActor
+    private func toggleFollowState() async {
+        guard shouldShowFollowButton,
+              !isLoadingRelationship,
+              !isUpdatingRelationship,
+              let currentAccount = appState.currentAccount,
+              let token = await appState.getAccessToken() else {
+            return
+        }
+
+        isUpdatingRelationship = true
+        defer { isUpdatingRelationship = false }
+
+        do {
+            if relationship?.following == true || relationship?.requested == true {
+                relationship = try await appState.client.unfollowAccount(
+                    instance: currentAccount.instance,
+                    accessToken: token,
+                    accountId: account.id
+                )
+            } else {
+                relationship = try await appState.client.followAccount(
+                    instance: currentAccount.instance,
+                    accessToken: token,
+                    accountId: account.id
+                )
+            }
+        } catch {
+            appState.presentedAlert = AlertItem(
+                title: "Unable to Update Follow State",
+                message: error.localizedDescription
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- add the follow button to profile viewer screens except for the owner’s profile
- ensure the button integrates with the existing profile details layout

## Testing
- Not run (not requested)