### PR TITLE
FEDI-78 FEDI-79 Refine post reply threading UI and content

### DIFF
--- a/fedi-reader/Services/ThreadingService.swift
+++ b/fedi-reader/Services/ThreadingService.swift
@@ -4,8 +4,11 @@ actor ThreadingService {
     static let shared = ThreadingService()
 
     /// Builds a thread tree from a flat array of statuses
-    func buildThreadTree(from statuses: [Status]) -> [ThreadNode] {
-        ThreadBuilder.buildThreadTree(from: statuses)
+    func buildThreadTree(
+        from statuses: [Status],
+        replyOrdering: ThreadBuilder.ReplyOrdering = .chronological
+    ) -> [ThreadNode] {
+        ThreadBuilder.buildThreadTree(from: statuses, replyOrdering: replyOrdering)
     }
 
     /// Merges multiple thread trees, useful when combining statuses from different sources

--- a/fedi-reader/Utilities/Thread/ThreadBuilder.swift
+++ b/fedi-reader/Utilities/Thread/ThreadBuilder.swift
@@ -1,19 +1,28 @@
 import Foundation
 
 enum ThreadBuilder {
+    enum ReplyOrdering: Sendable {
+        case chronological
+        case prioritizeAuthor(String?)
+    }
+
     /// Builds a thread tree from a flat array of statuses
     /// Returns root-level threads (statuses that aren't replies, or whose parent isn't in the set)
     /// Uses O(n) pre-grouping to avoid O(n²) filtering on large reply threads
-    nonisolated static func buildThreadTree(from statuses: [Status]) -> [ThreadNode] {
+    nonisolated static func buildThreadTree(
+        from statuses: [Status],
+        replyOrdering: ReplyOrdering = .chronological
+    ) -> [ThreadNode] {
         guard !statuses.isEmpty else { return [] }
         
         let statusMap = Dictionary(uniqueKeysWithValues: statuses.map { ($0.id, $0) })
         let repliesByParentId = Dictionary(grouping: statuses) { $0.inReplyToId ?? "" }
         
         let rootStatuses = findRootStatuses(statuses, statusMap: statusMap)
+            .sorted(by: makeStatusComparator(replyOrdering: replyOrdering))
         
         return rootStatuses.map { root in
-            buildSubtree(root: root, repliesByParentId: repliesByParentId)
+            buildSubtree(root: root, repliesByParentId: repliesByParentId, replyOrdering: replyOrdering)
         }
     }
     
@@ -28,9 +37,16 @@ enum ThreadBuilder {
     }
     
     /// Recursively builds a subtree; uses pre-grouped replies for O(1) child lookup
-    private nonisolated static func buildSubtree(root: Status, repliesByParentId: [String: [Status]]) -> ThreadNode {
-        let directReplies = (repliesByParentId[root.id] ?? []).sorted { $0.createdAt < $1.createdAt }
-        let childNodes = directReplies.map { buildSubtree(root: $0, repliesByParentId: repliesByParentId) }
+    private nonisolated static func buildSubtree(
+        root: Status,
+        repliesByParentId: [String: [Status]],
+        replyOrdering: ReplyOrdering
+    ) -> ThreadNode {
+        let directReplies = (repliesByParentId[root.id] ?? [])
+            .sorted(by: makeStatusComparator(replyOrdering: replyOrdering))
+        let childNodes = directReplies.map {
+            buildSubtree(root: $0, repliesByParentId: repliesByParentId, replyOrdering: replyOrdering)
+        }
         return ThreadNode(status: root, children: childNodes)
     }
     
@@ -65,5 +81,37 @@ enum ThreadBuilder {
             }
         }
         return nil
+    }
+
+    private nonisolated static func makeStatusComparator(
+        replyOrdering: ReplyOrdering
+    ) -> (Status, Status) -> Bool {
+        switch replyOrdering {
+        case .chronological:
+            return chronologicalComparator
+        case let .prioritizeAuthor(authorId):
+            guard let authorId, !authorId.isEmpty else {
+                return chronologicalComparator
+            }
+
+            return { lhs, rhs in
+                let lhsPriority = lhs.account.id == authorId
+                let rhsPriority = rhs.account.id == authorId
+
+                if lhsPriority != rhsPriority {
+                    return lhsPriority && !rhsPriority
+                }
+
+                return chronologicalComparator(lhs, rhs)
+            }
+        }
+    }
+
+    private nonisolated static func chronologicalComparator(_ lhs: Status, _ rhs: Status) -> Bool {
+        if lhs.createdAt != rhs.createdAt {
+            return lhs.createdAt < rhs.createdAt
+        }
+
+        return lhs.id < rhs.id
     }
 }

--- a/fedi-reader/Views/Feed/ReplyThreadCard.swift
+++ b/fedi-reader/Views/Feed/ReplyThreadCard.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct ReplyThreadCard: View {
+    let thread: ThreadNode
+    @Environment(\.colorScheme) private var colorScheme
+    private let cardShape = RoundedRectangle(
+        cornerRadius: Constants.UI.cardCornerRadius,
+        style: .continuous
+    )
+
+    private var nestedReplyCount: Int {
+        max(thread.totalReplies - 1, 0)
+    }
+
+    private var cardFill: Color {
+        colorScheme == .dark
+            ? Color.white.opacity(0.035)
+            : Color.black.opacity(0.025)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if nestedReplyCount > 0 {
+                HStack(spacing: 8) {
+                    Label("\(nestedReplyCount) more in thread", systemImage: "arrowshape.turn.up.left.fill")
+                        .font(.roundedCaption)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+                }
+            }
+
+            ReplyThreadNodeDetailView(node: thread, depth: 0)
+        }
+        .padding(12)
+        .background(cardShape.fill(cardFill))
+        .overlay(
+            cardShape
+                .stroke(Color.secondary.opacity(0.08), lineWidth: 1)
+        )
+        .clipShape(cardShape)
+    }
+}
+
+private struct ReplyThreadNodeDetailView: View {
+    let node: ThreadNode
+    let depth: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            StatusDetailRowView(status: node.status, style: .embedded)
+
+            if !node.children.isEmpty {
+                ReplyThreadGroup(depth: depth) {
+                    ForEach(Array(node.children.enumerated()), id: \.element.id) { index, child in
+                        ReplyThreadChildView(
+                            node: child,
+                            depth: depth + 1,
+                            isLastSibling: index == node.children.count - 1
+                        )
+                    }
+                }
+                .padding(.top, 2)
+            }
+        }
+    }
+}
+
+private struct ReplyThreadGroup<Content: View>: View {
+    let depth: Int
+    let content: Content
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(depth: Int, @ViewBuilder content: () -> Content) {
+        self.depth = depth
+        self.content = content()
+    }
+
+    private var backgroundColor: Color {
+        let baseOpacity = colorScheme == .dark ? 0.04 : 0.025
+        let nestedAdjustment = depth == 0 ? baseOpacity : baseOpacity * 0.75
+        return (colorScheme == .dark ? Color.white : Color.black).opacity(nestedAdjustment)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            content
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(backgroundColor)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.secondary.opacity(0.05), lineWidth: 1)
+        )
+    }
+}
+
+private struct ReplyThreadChildView: View {
+    let node: ThreadNode
+    let depth: Int
+    let isLastSibling: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(Color.secondary.opacity(0.28))
+                    .frame(width: 5, height: 5)
+
+                Text(TimeFormatter.relativeTimeString(from: node.status.createdAt))
+                    .font(.roundedCaption)
+                    .foregroundStyle(.tertiary)
+
+                Spacer()
+            }
+
+            ReplyThreadNodeDetailView(node: node, depth: depth)
+
+            if !isLastSibling {
+                Divider()
+                    .padding(.top, 2)
+            }
+        }
+    }
+}

--- a/fedi-reader/Views/Feed/StatusDetailRowView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailRowView.swift
@@ -1,7 +1,13 @@
 import SwiftUI
 
+enum StatusDetailRowStyle {
+    case card
+    case embedded
+}
+
 struct StatusDetailRowView: View {
     let status: Status
+    let style: StatusDetailRowStyle
     @Environment(AppState.self) private var appState
     @Environment(\.openURL) private var openURL
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
@@ -10,8 +16,17 @@ struct StatusDetailRowView: View {
     @State private var authorAttribution: AuthorAttribution?
     @State private var resolvedAuthorAccount: MastodonAccount?
 
+    init(status: Status, style: StatusDetailRowStyle = .card) {
+        self.status = status
+        self.style = style
+    }
+
     var displayStatus: Status {
         status.displayStatus
+    }
+
+    private var cardShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: Constants.UI.cardCornerRadius, style: .continuous)
     }
 
     private var cardURL: URL? {
@@ -149,8 +164,19 @@ struct StatusDetailRowView: View {
             StatusActionsBar(status: displayStatus, size: .detail)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(8)
-        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Constants.UI.cardCornerRadius))
+        .padding(style == .card ? 8 : 0)
+        .background {
+            if style == .card {
+                cardShape
+                    .fill(.regularMaterial)
+            }
+        }
+        .clipShape(
+            RoundedRectangle(
+                cornerRadius: style == .card ? Constants.UI.cardCornerRadius : 0,
+                style: .continuous
+            )
+        )
     }
     
     // MARK: - Boost Attribution

--- a/fedi-reader/Views/Feed/StatusDetailView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailView.swift
@@ -5,7 +5,7 @@ struct StatusDetailView: View {
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
 
     @State private var context: StatusContext?
-    @State private var replyTrees: [ThreadNode] = []
+    @State private var replyThreads: [ThreadNode] = []
     @State private var isLoading = true
     @State private var isLoadingRemoteReplies = false
 
@@ -52,89 +52,27 @@ struct StatusDetailView: View {
                     let shouldFetchMoreReplies = shouldFetchRemoteReplies(context: context)
                     
                     if !context.descendants.isEmpty {
-                        // Single card containing reply thread (without parent)
-                        VStack(alignment: .leading, spacing: 0) {
-                            // Header with controls
-                            HStack {
-                                Text("Replies")
-                                    .font(.roundedHeadline)
-                                
-                                if isLoadingRemoteReplies {
-                                    ProgressView()
-                                        .scaleEffect(0.7)
-                                        .padding(.leading, 4)
-                                }
-                                
-                                Spacer()
-                                
-                                // Show expected count if we have more replies
-                                if threadStatus.repliesCount > context.descendants.count {
-                                    Text("\(context.descendants.count) of \(threadStatus.repliesCount)")
-                                        .font(.roundedCaption)
-                                        .foregroundStyle(.secondary)
-                                } else if context.hasMoreReplies == true {
-                                    Text("More available")
-                                        .font(.roundedCaption)
-                                        .foregroundStyle(.secondary)
-                                }
-                                
-                                // Button to fetch remote replies
-                                if shouldFetchMoreReplies && !isLoadingRemoteReplies {
-                                    Button {
-                                        Task {
-                                            await refreshReplies()
-                                        }
-                                    } label: {
-                                        Label("Fetch Remote", systemImage: "arrow.down.circle")
-                                            .font(.roundedCaption)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-                                }
+                        VStack(alignment: .leading, spacing: 4) {
+                            replyHeader(
+                                discoveredReplyCount: context.descendants.count,
+                                shouldFetchMoreReplies: shouldFetchMoreReplies,
+                                includeHorizontalPadding: true
+                            )
+
+                            ForEach(replyThreads) { thread in
+                                ReplyThreadCard(thread: thread)
                             }
-                            .padding(.horizontal, 11)
-                            .padding(.vertical, 8)
-                            
-                            Divider()
-                            
-                            // Display reply thread tree (only descendants, no parent)
-                            CompactThreadView(threads: replyTrees)
-                                .padding(.vertical, 5)
                         }
-                        .glassEffect(.regular, in: RoundedRectangle(cornerRadius: Constants.UI.cardCornerRadius))
                         .padding(.horizontal)
-                        .padding(.vertical, 5)
+                        .padding(.vertical, 2)
                     } else if shouldFetchMoreReplies || threadStatus.repliesCount > 0 {
                         // Show message if we expect replies but don't have any yet
                         VStack(alignment: .leading, spacing: 0) {
-                            HStack {
-                                Text("Replies")
-                                    .font(.roundedHeadline)
-                                
-                                if isLoadingRemoteReplies {
-                                    ProgressView()
-                                        .scaleEffect(0.7)
-                                        .padding(.leading, 4)
-                                }
-                                
-                                Spacer()
-                                
-                                // Button to fetch remote replies
-                                if !isLoadingRemoteReplies {
-                                    Button {
-                                        Task {
-                                            await refreshReplies()
-                                        }
-                                    } label: {
-                                        Label("Fetch Remote", systemImage: "arrow.down.circle")
-                                            .font(.roundedCaption)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-                                }
-                            }
-                            .padding(.horizontal)
-                            .padding(.vertical, 8)
+                            replyHeader(
+                                discoveredReplyCount: context.descendants.count,
+                                shouldFetchMoreReplies: shouldFetchMoreReplies,
+                                includeHorizontalPadding: true
+                            )
                             
                             if isLoadingRemoteReplies {
                                 HStack {
@@ -198,13 +136,16 @@ struct StatusDetailView: View {
 
     private func rebuildReplyTrees(from descendants: [Status]) async {
         if descendants.isEmpty {
-            replyTrees = []
+            replyThreads = []
             return
         }
 
-        let trees = await threadingService.buildThreadTree(from: descendants)
+        let trees = await threadingService.buildThreadTree(
+            from: descendants,
+            replyOrdering: .prioritizeAuthor(threadStatus.account.id)
+        )
         guard !Task.isCancelled else { return }
-        replyTrees = trees
+        replyThreads = trees
     }
     
     private func shouldFetchRemoteReplies(context: StatusContext) -> Bool {
@@ -222,5 +163,50 @@ struct StatusDetailView: View {
         } catch {
             isLoadingRemoteReplies = false
         }
+    }
+
+    @ViewBuilder
+    private func replyHeader(
+        discoveredReplyCount: Int,
+        shouldFetchMoreReplies: Bool,
+        includeHorizontalPadding: Bool
+    ) -> some View {
+        HStack {
+            Text("Replies")
+                .font(.roundedHeadline)
+
+            if isLoadingRemoteReplies {
+                ProgressView()
+                    .scaleEffect(0.7)
+                    .padding(.leading, 4)
+            }
+
+            Spacer()
+
+            if threadStatus.repliesCount > discoveredReplyCount {
+                Text("\(discoveredReplyCount) of \(threadStatus.repliesCount)")
+                    .font(.roundedCaption)
+                    .foregroundStyle(.secondary)
+            } else if context?.hasMoreReplies == true {
+                Text("More available")
+                    .font(.roundedCaption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if shouldFetchMoreReplies && !isLoadingRemoteReplies {
+                Button {
+                    Task {
+                        await refreshReplies()
+                    }
+                } label: {
+                    Label("Fetch Remote", systemImage: "arrow.down.circle")
+                        .font(.roundedCaption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+        .padding(.horizontal, includeHorizontalPadding ? 0 : 11)
+                        .padding(.vertical, 6)
     }
 }

--- a/fedi-readerTests/ThreadBuilderTests.swift
+++ b/fedi-readerTests/ThreadBuilderTests.swift
@@ -95,4 +95,115 @@ struct ThreadBuilderTests {
 
         #expect(roots.map(\.id) == [root.id, orphan.id])
     }
+
+    @Test("buildThreadTree prioritizes configured author within each sibling set")
+    func buildThreadTreePrioritizesConfiguredAuthor() {
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let originalAuthor = MockStatusFactory.makeAccount(id: "author-root", username: "root", displayName: "Root")
+        let otherAuthor = MockStatusFactory.makeAccount(id: "author-other", username: "other", displayName: "Other")
+
+        let root = Status(
+            id: "root",
+            uri: "https://mastodon.social/statuses/root",
+            url: "https://mastodon.social/@root/root",
+            createdAt: baseDate,
+            account: originalAuthor,
+            content: "<p>root</p>",
+            visibility: .direct,
+            sensitive: false,
+            spoilerText: "",
+            mediaAttachments: [],
+            mentions: [],
+            tags: [],
+            emojis: [],
+            reblogsCount: 0,
+            favouritesCount: 0,
+            repliesCount: 0,
+            application: nil,
+            language: "en",
+            reblog: nil,
+            card: nil,
+            poll: nil,
+            quote: nil,
+            favourited: false,
+            reblogged: false,
+            muted: false,
+            bookmarked: false,
+            pinned: false,
+            inReplyToId: nil,
+            inReplyToAccountId: nil
+        )
+
+        let earlierOtherReply = Status(
+            id: "reply-other",
+            uri: "https://mastodon.social/statuses/reply-other",
+            url: "https://mastodon.social/@other/reply-other",
+            createdAt: baseDate.addingTimeInterval(60),
+            account: otherAuthor,
+            content: "<p>reply-other</p>",
+            visibility: .direct,
+            sensitive: false,
+            spoilerText: "",
+            mediaAttachments: [],
+            mentions: [],
+            tags: [],
+            emojis: [],
+            reblogsCount: 0,
+            favouritesCount: 0,
+            repliesCount: 0,
+            application: nil,
+            language: "en",
+            reblog: nil,
+            card: nil,
+            poll: nil,
+            quote: nil,
+            favourited: false,
+            reblogged: false,
+            muted: false,
+            bookmarked: false,
+            pinned: false,
+            inReplyToId: root.id,
+            inReplyToAccountId: nil
+        )
+
+        let laterOriginalReply = Status(
+            id: "reply-original",
+            uri: "https://mastodon.social/statuses/reply-original",
+            url: "https://mastodon.social/@root/reply-original",
+            createdAt: baseDate.addingTimeInterval(120),
+            account: originalAuthor,
+            content: "<p>reply-original</p>",
+            visibility: .direct,
+            sensitive: false,
+            spoilerText: "",
+            mediaAttachments: [],
+            mentions: [],
+            tags: [],
+            emojis: [],
+            reblogsCount: 0,
+            favouritesCount: 0,
+            repliesCount: 0,
+            application: nil,
+            language: "en",
+            reblog: nil,
+            card: nil,
+            poll: nil,
+            quote: nil,
+            favourited: false,
+            reblogged: false,
+            muted: false,
+            bookmarked: false,
+            pinned: false,
+            inReplyToId: root.id,
+            inReplyToAccountId: nil
+        )
+
+        let trees = ThreadBuilder.buildThreadTree(
+            from: [root, earlierOtherReply, laterOriginalReply],
+            replyOrdering: .prioritizeAuthor(originalAuthor.id)
+        )
+
+        #expect(trees.count == 1)
+        #expect(trees.first?.children.map(\.id) == [laterOriginalReply.id, earlierOtherReply.id])
+    }
 }


### PR DESCRIPTION
Summary
- revert the private-mention changes so the branch only touches post replies while keeping their prior behavior intact
- update reply-threading visuals (card backgrounds, spacing, and line styling) so the UI stays consistent as threads scroll and chained replies remain grouped
- ensure each reply card surfaces its full content and reduce redundant labels/color contrast to keep the look subtle and intentional

Testing
- Not run (not requested)