### PR TITLE
Collapse consecutive status metadata in chat bubbles

### DIFF
--- a/fedi-reader/Services/AppState.swift
+++ b/fedi-reader/Services/AppState.swift
@@ -711,6 +711,7 @@ enum SheetDestination: Identifiable {
     case shareSheet(url: URL)
     case accountSwitcher
     case safariView(url: URL)
+    case videoPlayer(url: URL)
     
     var id: String {
         switch self {
@@ -721,6 +722,7 @@ enum SheetDestination: Identifiable {
         case .shareSheet: return "share"
         case .accountSwitcher: return "accountSwitcher"
         case .safariView(let url): return "safari-\(url.absoluteString)"
+        case .videoPlayer(let url): return "video-\(url.absoluteString)"
         }
     }
 }

--- a/fedi-reader/Services/VideoPlaybackAudioSessionCoordinator.swift
+++ b/fedi-reader/Services/VideoPlaybackAudioSessionCoordinator.swift
@@ -1,0 +1,103 @@
+import Foundation
+import os
+
+#if os(iOS)
+import AVFAudio
+
+protocol VideoPlaybackAudioSessionControlling: AnyObject {
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws
+}
+
+final class SystemVideoPlaybackAudioSession: VideoPlaybackAudioSessionControlling {
+    private let session: AVAudioSession
+
+    init(session: AVAudioSession = .sharedInstance()) {
+        self.session = session
+    }
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws {
+        try session.setCategory(category, mode: mode, options: options)
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        try session.setActive(active, options: options)
+    }
+}
+
+@MainActor
+final class VideoPlaybackAudioSessionCoordinator {
+    private static let logger = Logger(
+        subsystem: "app.fedi-reader",
+        category: "VideoPlaybackAudioSession"
+    )
+
+    private let session: VideoPlaybackAudioSessionControlling
+    private(set) var isSessionActive = false
+
+    init() {
+        self.session = SystemVideoPlaybackAudioSession()
+    }
+
+    init(session: VideoPlaybackAudioSessionControlling) {
+        self.session = session
+    }
+
+    func updatePlaybackState(isPlaying: Bool) {
+        if isPlaying {
+            activateIfNeeded()
+        } else {
+            deactivateIfNeeded()
+        }
+    }
+
+    func endPlayback() {
+        deactivateIfNeeded()
+    }
+
+    private func activateIfNeeded() {
+        guard !isSessionActive else { return }
+
+        do {
+            try session.setCategory(.playback, mode: .moviePlayback, options: [])
+            try session.setActive(true, options: [])
+            isSessionActive = true
+        } catch {
+            Self.logger.error("Failed to activate audio session: \(error.localizedDescription)")
+        }
+    }
+
+    private func deactivateIfNeeded() {
+        guard isSessionActive else { return }
+
+        do {
+            try session.setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+            Self.logger.error("Failed to deactivate audio session: \(error.localizedDescription)")
+        }
+
+        isSessionActive = false
+    }
+}
+#else
+@MainActor
+final class VideoPlaybackAudioSessionCoordinator {
+    private(set) var isSessionActive = false
+
+    func updatePlaybackState(isPlaying: Bool) {
+        isSessionActive = isPlaying
+    }
+
+    func endPlayback() {
+        isSessionActive = false
+    }
+}
+#endif

--- a/fedi-reader/Utilities/ChatMessageGroupingHelper.swift
+++ b/fedi-reader/Utilities/ChatMessageGroupingHelper.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+enum ChatMessageGroupingHelper {
+    static func groupMessages(
+        _ messages: [ChatMessage],
+        isGroupChat: Bool,
+        unknownAccount: MastodonAccount
+    ) -> [GroupedMessage] {
+        var groups: [GroupedMessage] = []
+        var currentGroup: [ChatMessage] = []
+        var currentSenderId: String?
+
+        for message in messages {
+            let senderId = message.status?.account.id ?? "unknown"
+
+            if senderId == currentSenderId {
+                currentGroup.append(message)
+                continue
+            }
+
+            appendCurrentGroup(
+                &groups,
+                currentGroup: currentGroup,
+                isGroupChat: isGroupChat,
+                unknownAccount: unknownAccount
+            )
+
+            currentGroup = [message]
+            currentSenderId = senderId
+        }
+
+        appendCurrentGroup(
+            &groups,
+            currentGroup: currentGroup,
+            isGroupChat: isGroupChat,
+            unknownAccount: unknownAccount
+        )
+
+        return groups
+    }
+
+    private static func appendCurrentGroup(
+        _ groups: inout [GroupedMessage],
+        currentGroup: [ChatMessage],
+        isGroupChat: Bool,
+        unknownAccount: MastodonAccount
+    ) {
+        guard let firstMessage = currentGroup.first else { return }
+        let account = firstMessage.status?.account ?? unknownAccount
+        groups.append(
+            GroupedMessage(
+                account: account,
+                messages: currentGroup,
+                isSent: firstMessage.isSent,
+                isGroupChat: isGroupChat
+            )
+        )
+    }
+}

--- a/fedi-reader/Utilities/MediaAttachmentPlaybackPolicy.swift
+++ b/fedi-reader/Utilities/MediaAttachmentPlaybackPolicy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum MediaAttachmentPlaybackPolicy: Sendable, Equatable {
+    case staticPreview
+    case inlineLoopingGifv
+    case explicitVideoPlayback
+
+    static func resolve(for type: MediaType, autoPlayGifs: Bool) -> MediaAttachmentPlaybackPolicy {
+        switch type {
+        case .gifv:
+            autoPlayGifs ? .inlineLoopingGifv : .staticPreview
+        case .video:
+            .explicitVideoPlayback
+        default:
+            .staticPreview
+        }
+    }
+}

--- a/fedi-reader/Views/Components/MediaAttachmentThumbnailView.swift
+++ b/fedi-reader/Views/Components/MediaAttachmentThumbnailView.swift
@@ -1,0 +1,188 @@
+import AVFoundation
+import SwiftUI
+
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+
+struct MediaAttachmentThumbnailView: View {
+    let attachment: MediaAttachment
+    let size: CGSize
+    let cornerRadius: CGFloat
+    let autoPlayGifs: Bool
+
+    private var playbackPolicy: MediaAttachmentPlaybackPolicy {
+        MediaAttachmentPlaybackPolicy.resolve(for: attachment.type, autoPlayGifs: autoPlayGifs)
+    }
+
+    private var previewURL: URL? {
+        URL(string: attachment.previewUrl ?? attachment.url)
+    }
+
+    private var mediaURL: URL? {
+        URL(string: attachment.url)
+    }
+
+    var body: some View {
+        ZStack {
+            AsyncImage(url: previewURL) { image in
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Rectangle()
+                    .fill(.tertiary)
+            }
+
+            if playbackPolicy == .inlineLoopingGifv, let mediaURL {
+                InlineLoopingVideoView(url: mediaURL)
+                    .allowsHitTesting(false)
+            }
+        }
+        .frame(width: size.width, height: size.height)
+        .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+        .overlay(alignment: .bottomTrailing) {
+            if attachment.type == .video || attachment.type == .gifv {
+                Image(systemName: attachment.type == .gifv ? "play.circle" : "play.circle.fill")
+                    .font(.roundedCaption)
+                    .padding(4)
+                    .glassEffect(.clear, in: Circle())
+                    .padding(6)
+            }
+        }
+    }
+}
+
+struct InlineLoopingVideoView: View {
+    let url: URL
+    @State private var playerController: LoopingVideoPlayerController?
+
+    var body: some View {
+        LoopingVideoLayerView(player: playerController?.player)
+            .onAppear {
+                guard playerController == nil else {
+                    playerController?.play()
+                    return
+                }
+
+                let controller = LoopingVideoPlayerController(url: url)
+                playerController = controller
+                controller.play()
+            }
+            .onDisappear {
+                playerController?.stop()
+                playerController = nil
+            }
+    }
+}
+
+private final class LoopingVideoPlayerController {
+    let player: AVQueuePlayer
+    private let looper: AVPlayerLooper
+
+    init(url: URL) {
+        let item = AVPlayerItem(url: url)
+        let player = AVQueuePlayer()
+        player.isMuted = true
+        player.volume = 0
+        player.actionAtItemEnd = .none
+        player.preventsDisplaySleepDuringVideoPlayback = false
+        player.automaticallyWaitsToMinimizeStalling = true
+
+        self.player = player
+        self.looper = AVPlayerLooper(player: player, templateItem: item)
+    }
+
+    func play() {
+        player.playImmediately(atRate: 1)
+    }
+
+    func stop() {
+        player.pause()
+        player.removeAllItems()
+    }
+
+    deinit {
+        stop()
+    }
+}
+
+#if os(iOS)
+private final class LoopingVideoPlayerUIView: UIView {
+    override class var layerClass: AnyClass {
+        AVPlayerLayer.self
+    }
+
+    var playerLayer: AVPlayerLayer {
+        layer as! AVPlayerLayer
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        playerLayer.videoGravity = .resizeAspectFill
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@MainActor
+private struct LoopingVideoLayerView: UIViewRepresentable {
+    typealias UIViewType = LoopingVideoPlayerUIView
+
+    let player: AVPlayer?
+
+    func makeUIView(
+        context: UIViewRepresentableContext<LoopingVideoLayerView>
+    ) -> LoopingVideoPlayerUIView {
+        LoopingVideoPlayerUIView()
+    }
+
+    func updateUIView(
+        _ uiView: LoopingVideoPlayerUIView,
+        context: UIViewRepresentableContext<LoopingVideoLayerView>
+    ) {
+        uiView.playerLayer.player = player
+    }
+}
+#elseif os(macOS)
+private final class LoopingVideoPlayerNSView: NSView {
+    let playerLayer = AVPlayerLayer()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer = playerLayer
+        playerLayer.videoGravity = .resizeAspectFill
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@MainActor
+private struct LoopingVideoLayerView: NSViewRepresentable {
+    typealias NSViewType = LoopingVideoPlayerNSView
+
+    let player: AVPlayer?
+
+    func makeNSView(
+        context: NSViewRepresentableContext<LoopingVideoLayerView>
+    ) -> LoopingVideoPlayerNSView {
+        LoopingVideoPlayerNSView()
+    }
+
+    func updateNSView(
+        _ nsView: LoopingVideoPlayerNSView,
+        context: NSViewRepresentableContext<LoopingVideoLayerView>
+    ) {
+        nsView.playerLayer.player = player
+    }
+}
+#endif

--- a/fedi-reader/Views/Components/Thread/CompactStatusRowView.swift
+++ b/fedi-reader/Views/Components/Thread/CompactStatusRowView.swift
@@ -5,6 +5,7 @@ struct CompactStatusRowView: View {
     let depth: Int
     @Environment(AppState.self) private var appState
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+    @AppStorage("autoPlayGifs") private var autoPlayGifs = false
     
     var displayStatus: Status {
         status.displayStatus
@@ -74,16 +75,7 @@ struct CompactStatusRowView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 6) {
                         ForEach(displayStatus.mediaAttachments.prefix(3)) { attachment in
-                            AsyncImage(url: URL(string: attachment.previewUrl ?? attachment.url)) { image in
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                            } placeholder: {
-                                Rectangle()
-                                    .fill(.tertiary)
-                            }
-                            .frame(width: 100, height: 100)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            mediaAttachmentView(attachment)
                         }
                     }
                 }
@@ -108,8 +100,33 @@ struct CompactStatusRowView: View {
             }
         }
     }
+
+    @ViewBuilder
+    private func mediaAttachmentView(_ attachment: MediaAttachment) -> some View {
+        let content = MediaAttachmentThumbnailView(
+            attachment: attachment,
+            size: CGSize(width: 100, height: 100),
+            cornerRadius: 6,
+            autoPlayGifs: autoPlayGifs
+        )
+
+        let playbackPolicy = MediaAttachmentPlaybackPolicy.resolve(
+            for: attachment.type,
+            autoPlayGifs: autoPlayGifs
+        )
+
+        if playbackPolicy == .explicitVideoPlayback, let videoURL = URL(string: attachment.url) {
+            Button {
+                appState.present(sheet: .videoPlayer(url: videoURL))
+            } label: {
+                content
+            }
+            .buttonStyle(.plain)
+        } else {
+            content
+        }
+    }
 }
 
 // MARK: - Reply Indicator
-
 

--- a/fedi-reader/Views/Components/VideoPlaybackSheet.swift
+++ b/fedi-reader/Views/Components/VideoPlaybackSheet.swift
@@ -1,0 +1,78 @@
+import AVKit
+import SwiftUI
+
+struct VideoPlaybackSheet: View {
+    let url: URL
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var player = AVPlayer()
+    @State private var timeControlObservation: NSKeyValueObservation?
+    @State private var playbackEndObserver: NSObjectProtocol?
+    @State private var audioSessionCoordinator = VideoPlaybackAudioSessionCoordinator()
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Color.black
+                .ignoresSafeArea()
+
+            VideoPlayer(player: player)
+                .ignoresSafeArea()
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(.white, .black.opacity(0.3))
+                    .padding()
+            }
+            .buttonStyle(.plain)
+        }
+        .task(id: url) {
+            configurePlayer()
+        }
+        .onDisappear {
+            tearDownPlayer()
+        }
+    }
+
+    private func configurePlayer() {
+        tearDownPlayer()
+
+        let item = AVPlayerItem(url: url)
+        player.replaceCurrentItem(with: item)
+
+        timeControlObservation = player.observe(\.timeControlStatus, options: [.initial, .new]) { observedPlayer, _ in
+            Task { @MainActor in
+                audioSessionCoordinator.updatePlaybackState(
+                    isPlaying: observedPlayer.timeControlStatus == .playing
+                )
+            }
+        }
+
+        playbackEndObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                audioSessionCoordinator.updatePlaybackState(isPlaying: false)
+            }
+        }
+
+        player.play()
+    }
+
+    private func tearDownPlayer() {
+        timeControlObservation = nil
+
+        if let playbackEndObserver {
+            NotificationCenter.default.removeObserver(playbackEndObserver)
+            self.playbackEndObserver = nil
+        }
+
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        audioSessionCoordinator.endPlayback()
+    }
+}

--- a/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
+++ b/fedi-reader/Views/Feed/Mentions/ChatBubble.swift
@@ -1,12 +1,11 @@
-import AVKit
 import SwiftUI
-import os
 
 struct ChatBubble: View {
     let message: ChatMessage
     let account: MastodonAccount
     let isSent: Bool
     let hiddenMentionHandles: Set<String>
+    let showsMetadata: Bool
     @Environment(AppState.self) private var appState
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("themeColor") private var themeColorName = "blue"
@@ -32,15 +31,14 @@ struct ChatBubble: View {
 
     private var displayPlainText: String {
         guard let status else { return "" }
-        return DirectMessageMentionFormatter.stripLeadingMentions(
-            from: status.content.htmlToPlainText,
-            hiddenHandles: hiddenMentionHandles
-        )
+        return displayText(for: status.content)
     }
 
     private var showsTextContent: Bool {
         !displayPlainText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
+
+    private let bubbleHorizontalInset: CGFloat = 14
     
     var body: some View {
         if let status = status {
@@ -60,7 +58,6 @@ struct ChatBubble: View {
                     standardMessageContent(status: status)
                 }
             }
-            .padding(.bottom, hasFavorites && embeddedLayout.candidate == nil ? 8 : 0) // Extra space for tapback
             .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
             .contextMenu {
                 Button {
@@ -85,33 +82,12 @@ struct ChatBubble: View {
 
     @ViewBuilder
     private func standardMessageContent(status: Status) -> some View {
-        Button {
-            appState.navigate(to: .status(status))
-        } label: {
-            VStack(alignment: isSent ? .trailing : .leading, spacing: 6) {
-                if showsTextContent {
-                    messageTextContent(status.content)
-                }
-
-                if !mediaAttachments.isEmpty {
-                    chatMediaAttachments
-                }
-
-                Text(message.createdAt, style: .time)
-                    .font(.roundedCaption2)
-                    .foregroundStyle(.secondary)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(messageBubbleShape.fill(messageBubbleColor))
-            .overlay(alignment: isSent ? .bottomLeading : .bottomTrailing) {
-                if hasFavorites {
-                    TapbackView(count: status.favouritesCount, isMine: isFavoritedByMe)
-                        .offset(x: isSent ? -8 : 8, y: 8)
-                }
+        VStack(alignment: isSent ? .trailing : .leading, spacing: 6) {
+            bubbleBody(status: status)
+            if showsMetadata {
+                messageMetadataRow
             }
         }
-        .buttonStyle(.plain)
     }
 
     @ViewBuilder
@@ -122,43 +98,28 @@ struct ChatBubble: View {
     ) -> some View {
         if let leadingContent = layout.leadingContent {
             messageTextBubble(
-                content: leadingContent,
-                status: status
+                content: leadingContent
             )
         }
 
         MessageLinkPreviewCard(
-            status: status,
             candidate: candidate,
             isSent: isSent
         )
 
         if let trailingContent = layout.trailingContent {
             messageTextBubble(
-                content: trailingContent,
-                status: status
+                content: trailingContent
             )
         }
 
         if !mediaAttachments.isEmpty {
-            Button {
-                appState.navigate(to: .status(status))
-            } label: {
-                chatMediaAttachments
-            }
-            .buttonStyle(.plain)
+            chatMediaAttachments
         }
 
-        HStack(spacing: 6) {
-            Text(message.createdAt, style: .time)
-                .font(.roundedCaption2)
-                .foregroundStyle(.secondary)
-
-            if hasFavorites {
-                TapbackView(count: status.favouritesCount, isMine: isFavoritedByMe)
-            }
+        if showsMetadata {
+            messageMetadataRow
         }
-        .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
     }
 
     private func toggleFavorite(status: Status) async {
@@ -175,46 +136,66 @@ struct ChatBubble: View {
             ForEach(mediaAttachments) { attachment in
                 ChatMediaAttachmentView(
                     attachment: attachment,
-                    isSent: isSent,
                     autoPlayGifs: autoPlayGifs
                 )
             }
         }
     }
 
-    @ViewBuilder
-    private func messageTextContent(_ content: String) -> some View {
-        if #available(iOS 15.0, macOS 12.0, *) {
-            HashtagLinkText(
-                content: content,
-                onHashtagTap: { appState.navigate(to: .hashtag($0)) },
-                emojiLookup: Dictionary(uniqueKeysWithValues: status?.emojis.map { ($0.shortcode, $0) } ?? []),
-                hiddenMentionHandles: hiddenMentionHandles
-            )
-            .font(.roundedBody)
-            .multilineTextAlignment(.leading)
-        } else {
-            Text(
-                DirectMessageMentionFormatter.stripLeadingMentions(
-                    from: content.htmlToPlainText,
-                    hiddenHandles: hiddenMentionHandles
-                )
-            )
-            .font(.roundedBody)
-            .multilineTextAlignment(.leading)
-        }
+    private func displayText(for content: String) -> String {
+        DirectMessageMentionFormatter.stripLeadingMentions(
+            from: content.htmlToPlainText,
+            hiddenHandles: hiddenMentionHandles
+        )
     }
 
-    private func messageTextBubble(content: String, status: Status) -> some View {
-        Button {
-            appState.navigate(to: .status(status))
-        } label: {
-            messageTextContent(content)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .background(messageBubbleShape.fill(messageBubbleColor))
+    private func messageTextContent(_ content: String) -> some View {
+        Text(displayText(for: content))
+            .font(.roundedBody)
+            .multilineTextAlignment(.leading)
+            .foregroundStyle(.primary)
+    }
+
+    private func messageTextBubble(content: String) -> some View {
+        messageTextContent(content)
+            .padding(.horizontal, bubbleHorizontalInset)
+            .padding(.vertical, 10)
+            .background(messageBubbleShape.fill(messageBubbleColor))
+    }
+
+    @ViewBuilder
+    private func bubbleBody(status: Status) -> some View {
+        VStack(alignment: isSent ? .trailing : .leading, spacing: 6) {
+            if showsTextContent {
+                messageTextContent(status.content)
+            }
+
+            if !mediaAttachments.isEmpty {
+                chatMediaAttachments
+            }
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, bubbleHorizontalInset)
+        .padding(.vertical, 10)
+        .background(messageBubbleShape.fill(messageBubbleColor))
+    }
+
+    private var messageMetadataRow: some View {
+        HStack(spacing: 6) {
+            if isSent, hasFavorites {
+                TapbackView(count: status?.favouritesCount ?? 0, isMine: isFavoritedByMe)
+            }
+
+            Text(message.createdAt, style: .time)
+                .font(.roundedCaption2)
+                .foregroundStyle(.secondary)
+
+            if !isSent, hasFavorites {
+                TapbackView(count: status?.favouritesCount ?? 0, isMine: isFavoritedByMe)
+            }
+        }
+        .padding(.leading, isSent ? 0 : bubbleHorizontalInset)
+        .padding(.trailing, isSent ? bubbleHorizontalInset : 0)
+        .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
     }
 
     private var messageBubbleShape: RoundedRectangle {
@@ -227,14 +208,11 @@ struct ChatBubble: View {
 }
 
 private struct MessageLinkPreviewCard: View {
-    let status: Status
     let candidate: MessageLinkPreviewCandidate
     let isSent: Bool
 
     @Environment(AppState.self) private var appState
     @Environment(\.openURL) private var openURL
-    @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
-
     @State private var linkPreview: LinkPreviewService.LinkPreview?
     @State private var authorAttribution: AuthorAttribution?
     @State private var resolvedAuthorAccount: MastodonAccount?
@@ -244,28 +222,23 @@ private struct MessageLinkPreviewCard: View {
     }
 
     var body: some View {
-        Button {
-            openLink(candidate.url)
-        } label: {
-            linkCardContent(for: candidate)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .glassEffect(.clear, in: cardBackgroundShape)
-                .clipShape(cardBackgroundShape)
-                .environment(\.openURL, authorLinkOpenURLAction)
-        }
-        .buttonStyle(.plain)
-        .frame(maxWidth: maxCardWidth, alignment: isSent ? .trailing : .leading)
-        .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
-        .task(id: previewURL?.absoluteString) {
-            await loadPreviewState()
-        }
+        linkCardContent(for: candidate)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .glassEffect(.clear, in: cardBackgroundShape)
+            .clipShape(cardBackgroundShape)
+            .environment(\.openURL, authorLinkOpenURLAction)
+            .frame(maxWidth: maxCardWidth, alignment: isSent ? .trailing : .leading)
+            .frame(maxWidth: .infinity, alignment: isSent ? .trailing : .leading)
+            .task(id: previewURL?.absoluteString) {
+                await loadPreviewState()
+            }
     }
 
     private var cardBackgroundShape: RoundedRectangle {
         RoundedRectangle(cornerRadius: 16)
     }
 
-    private var maxCardWidth: CGFloat { 520 }
+    private var maxCardWidth: CGFloat { 360 }
 
     private func linkCardContent(for candidate: MessageLinkPreviewCandidate) -> some View {
         let content = MessageLinkPreviewContentResolver.resolve(
@@ -280,7 +253,11 @@ private struct MessageLinkPreviewCard: View {
             imageURL: content.imageURL,
             providerDisplay: content.providerDisplay,
             authorName: content.authorName,
-            authorURL: content.authorURL,
+            authorURL: currentAuthorURL(
+                for: candidate,
+                authorAttribution: authorAttribution,
+                linkPreview: linkPreview
+            ),
             isMastodonAttribution: content.isMastodonAttribution,
             showLinkIcon: content.showLinkIcon,
             layout: .feed
@@ -313,22 +290,6 @@ private struct MessageLinkPreviewCard: View {
         linkPreview = preview
         authorAttribution = attribution
         resolvedAuthorAccount = authorAccount
-    }
-
-    private func openLink(_ url: URL) {
-        let preference = ArticleViewerPreference.from(raw: articleViewerPreferenceRaw)
-        switch preference {
-        case .externalBrowser:
-            openURL(url)
-        case .safari:
-            #if os(iOS)
-            appState.present(sheet: .safariView(url: url))
-            #else
-            openURL(url)
-            #endif
-        case .inApp:
-            appState.navigate(to: .article(url: url, status: status))
-        }
     }
 
     private func currentAuthorURL(
@@ -383,88 +344,19 @@ private struct MessageLinkPreviewCard: View {
 
 private struct ChatMediaAttachmentView: View {
     let attachment: MediaAttachment
-    let isSent: Bool
     let autoPlayGifs: Bool
 
     private var mediaSize: CGSize {
         MessageMediaLayoutResolver.size(for: attachment)
     }
 
-    private var imageURL: URL? {
-        URL(string: attachment.previewUrl ?? attachment.url)
-    }
-
-    private var videoURL: URL? {
-        (attachment.type == .gifv || attachment.type == .video) ? URL(string: attachment.url) : nil
-    }
-
-    private var shouldAutoplayVideo: Bool {
-        autoPlayGifs && videoURL != nil
-    }
-
     var body: some View {
-        ZStack {
-            // Base layer: always show preview/image
-            AsyncImage(url: imageURL) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            } placeholder: {
-                Rectangle()
-                    .fill(.tertiary)
-            }
-            .frame(width: mediaSize.width, height: mediaSize.height)
-
-            // Overlay: video player when autoplay is on
-            if shouldAutoplayVideo, let url = videoURL {
-                ChatGifvPlayerView(url: url)
-                    .frame(width: mediaSize.width, height: mediaSize.height)
-            }
-        }
-        .frame(width: mediaSize.width, height: mediaSize.height)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(alignment: .bottomTrailing) {
-            if attachment.type == .video || attachment.type == .gifv {
-                Image(systemName: attachment.type == .gifv ? "play.circle" : "video")
-                    .font(.roundedCaption)
-                    .padding(4)
-                    .glassEffect(.clear, in: Circle())
-                    .padding(6)
-            }
-        }
-    }
-}
-
-// MARK: - Chat GIFV Player View
-
-private struct ChatGifvPlayerView: View {
-    let url: URL
-    @State private var player: AVQueuePlayer?
-    @State private var looper: AVPlayerLooper?
-
-    var body: some View {
-        Group {
-            if let player {
-                VideoPlayer(player: player)
-                    .clipped()
-                    .onAppear {
-                        player.isMuted = true
-                        player.play()
-                    }
-            } else {
-                // Transparent until video loads so base AsyncImage preview shows through
-                Color.clear
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-            guard player == nil else { return }
-            let item = AVPlayerItem(url: url)
-            let queuePlayer = AVQueuePlayer(playerItem: item)
-            let loop = AVPlayerLooper(player: queuePlayer, templateItem: item)
-            player = queuePlayer
-            looper = loop
-        }
+        MediaAttachmentThumbnailView(
+            attachment: attachment,
+            size: mediaSize,
+            cornerRadius: 12,
+            autoPlayGifs: autoPlayGifs
+        )
     }
 }
 

--- a/fedi-reader/Views/Feed/Mentions/ChatMessageGroup.swift
+++ b/fedi-reader/Views/Feed/Mentions/ChatMessageGroup.swift
@@ -4,70 +4,58 @@ import os
 struct ChatMessageGroup: View {
     let group: GroupedMessage
     let hiddenMentionHandles: Set<String>
+    let maxContentWidth: CGFloat
     @Environment(AppState.self) private var appState
     
-    private let opposingSideMinimumSpace: CGFloat = 16
+    private let opposingSideMinimumSpace: CGFloat = 20
+    private let avatarSize: CGFloat = 28
+    private let messageTextInset: CGFloat = 14
+    private let metadataBottomOffset: CGFloat = 18
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter
+    }()
+
+    private var showsIncomingAvatar: Bool {
+        !group.isSent && group.isGroupChat
+    }
     
     var body: some View {
         if group.isSent {
-            // Sent messages (right-aligned)
             HStack(alignment: .bottom, spacing: 6) {
                 Spacer(minLength: opposingSideMinimumSpace)
                 
-                // Messages
                 VStack(alignment: .trailing, spacing: 4) {
-                    // Chat bubbles
-                    ForEach(group.messages) { message in
+                    ForEach(Array(group.messages.enumerated()), id: \.element.id) { index, message in
                         ChatBubble(
                             message: message,
                             account: group.account,
                             isSent: true,
-                            hiddenMentionHandles: hiddenMentionHandles
+                            hiddenMentionHandles: hiddenMentionHandles,
+                            showsMetadata: shouldShowMetadata(for: index)
                         )
                     }
                 }
+                .frame(maxWidth: maxContentWidth, alignment: .trailing)
                 .frame(maxWidth: .infinity, alignment: .trailing)
-                
-                // Avatar (only shown for first message in group)
-                if group.messages.first != nil {
-                    Button {
-                        if let currentAccount = appState.currentAccount?.mastodonAccount {
-                            appState.navigate(to: .profile(currentAccount))
-                        }
-                    } label: {
-                        ProfileAvatarView(url: group.account.avatarURL, size: 28)
-                    }
-                    .buttonStyle(.plain)
-                } else {
-                    // Spacer to align messages
-                    Circle()
-                        .fill(Color.clear)
-                        .frame(width: 28, height: 28)
-                }
             }
             .padding(.vertical, 4)
         } else {
-            // Received messages (left-aligned)
             HStack(alignment: .bottom, spacing: 6) {
-                // Avatar (only shown for first message in group)
-                if group.messages.first != nil {
+                if showsIncomingAvatar {
                     Button {
                         appState.navigate(to: .profile(group.account))
                     } label: {
-                        ProfileAvatarView(url: group.account.avatarURL, size: 28)
+                        ProfileAvatarView(url: group.account.avatarURL, size: avatarSize)
                     }
                     .buttonStyle(.plain)
-                } else {
-                    // Spacer to align messages
-                    Circle()
-                        .fill(Color.clear)
-                        .frame(width: 28, height: 28)
+                    .padding(.bottom, metadataBottomOffset)
                 }
                 
-                // Messages
                 VStack(alignment: .leading, spacing: 4) {
-                    // Account name (only for first message)
-                    if !group.messages.isEmpty {
+                    if group.isGroupChat && !group.messages.isEmpty {
                         HStack(spacing: 4) {
                             Button {
                                 appState.navigate(to: .profile(group.account))
@@ -81,24 +69,37 @@ struct ChatMessageGroup: View {
                             }
                             .buttonStyle(.plain)
                         }
+                        .padding(.leading, messageTextInset)
                     }
                     
                     // Chat bubbles
-                    ForEach(group.messages) { message in
+                    ForEach(Array(group.messages.enumerated()), id: \.element.id) { index, message in
                         ChatBubble(
                             message: message,
                             account: group.account,
                             isSent: false,
-                            hiddenMentionHandles: hiddenMentionHandles
+                            hiddenMentionHandles: hiddenMentionHandles,
+                            showsMetadata: shouldShowMetadata(for: index)
                         )
                     }
                 }
+                .frame(maxWidth: maxContentWidth, alignment: .leading)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
                 Spacer(minLength: opposingSideMinimumSpace)
             }
             .padding(.vertical, 4)
         }
+    }
+
+    private func shouldShowMetadata(for index: Int) -> Bool {
+        guard group.messages.indices.contains(index) else { return true }
+        guard index < group.messages.index(before: group.messages.endIndex) else { return true }
+        return timestampKey(for: group.messages[index]) != timestampKey(for: group.messages[index + 1])
+    }
+
+    private func timestampKey(for message: ChatMessage) -> String {
+        Self.timestampFormatter.string(from: message.createdAt)
     }
 }
 

--- a/fedi-reader/Views/Feed/Mentions/GroupAvatarView.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupAvatarView.swift
@@ -3,6 +3,23 @@ import os
 
 struct GroupAvatarView: View {
     let participants: [MastodonAccount]
+    var size: CGFloat = 56
+
+    private var twoAvatarSize: CGFloat {
+        size * (40 / 56)
+    }
+
+    private var gridSize: CGFloat {
+        size * 0.5
+    }
+
+    private var overlapSpacing: CGFloat {
+        -(size * (16 / 56))
+    }
+
+    private var strokeWidth: CGFloat {
+        max(1, size * (2 / 56))
+    }
     
     var body: some View {
         ZStack {
@@ -11,32 +28,32 @@ struct GroupAvatarView: View {
             
             if avatarsToShow.count == 2 {
                 // Two avatars: diagonal overlap
-                HStack(spacing: -16) {
-                    ProfileAvatarView(url: avatarsToShow[0].avatarURL, size: 40)
-                        .overlay(Circle().stroke(Color(.systemBackground), lineWidth: 2))
+                HStack(spacing: overlapSpacing) {
+                    ProfileAvatarView(url: avatarsToShow[0].avatarURL, size: twoAvatarSize)
+                        .overlay(Circle().stroke(Color(.systemBackground), lineWidth: strokeWidth))
 
-                    ProfileAvatarView(url: avatarsToShow[1].avatarURL, size: 40)
-                        .overlay(Circle().stroke(Color(.systemBackground), lineWidth: 2))
+                    ProfileAvatarView(url: avatarsToShow[1].avatarURL, size: twoAvatarSize)
+                        .overlay(Circle().stroke(Color(.systemBackground), lineWidth: strokeWidth))
                 }
-                .frame(width: 56, height: 56)
+                .frame(width: size, height: size)
             } else if avatarsToShow.count >= 3 {
                 // 3-4 avatars: 2x2 grid
-                let gridSize: CGFloat = 28
-                VStack(spacing: -4) {
-                    HStack(spacing: -4) {
+                let gridSpacing = -(size * (4 / 56))
+                VStack(spacing: gridSpacing) {
+                    HStack(spacing: gridSpacing) {
                         ProfileAvatarView(url: avatarsToShow[0].avatarURL, size: gridSize)
-                            .overlay(Circle().stroke(Color(.systemBackground), lineWidth: 1))
+                            .overlay(Circle().stroke(Color(.systemBackground), lineWidth: strokeWidth))
 
                         ProfileAvatarView(url: avatarsToShow[1].avatarURL, size: gridSize)
-                            .overlay(Circle().stroke(Color(.systemBackground), lineWidth: 1))
+                            .overlay(Circle().stroke(Color(.systemBackground), lineWidth: strokeWidth))
                     }
-                    HStack(spacing: -4) {
+                    HStack(spacing: gridSpacing) {
                         ProfileAvatarView(url: avatarsToShow[2].avatarURL, size: gridSize)
-                            .overlay(Circle().stroke(Color(.systemBackground), lineWidth: 1))
+                            .overlay(Circle().stroke(Color(.systemBackground), lineWidth: strokeWidth))
 
                         if avatarsToShow.count > 3 {
                             ProfileAvatarView(url: avatarsToShow[3].avatarURL, size: gridSize)
-                                .overlay(Circle().stroke(Color(.systemBackground), lineWidth: 1))
+                                .overlay(Circle().stroke(Color(.systemBackground), lineWidth: strokeWidth))
                         } else if participants.count > 3 {
                             // Show +N indicator
                             Circle()
@@ -54,15 +71,14 @@ struct GroupAvatarView: View {
                         }
                     }
                 }
-                .frame(width: 56, height: 56)
+                .frame(width: size, height: size)
             } else {
                 // Fallback: single avatar
-                ProfileAvatarView(url: avatarsToShow.first?.avatarURL, size: 56)
+                ProfileAvatarView(url: avatarsToShow.first?.avatarURL, size: size)
             }
         }
     }
 }
 
 // MARK: - Grouped Conversation Detail View
-
 

--- a/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedConversationDetailView.swift
@@ -10,7 +10,6 @@ struct GroupedConversationDetailView: View {
     @State private var messageText = ""
     @State private var isSending = false
     @FocusState private var isTextFieldFocused: Bool
-    @AppStorage("themeColor") private var themeColorName = "blue"
     
     private var timelineService: TimelineService? {
         timelineWrapper.service
@@ -19,6 +18,8 @@ struct GroupedConversationDetailView: View {
     @State private var statusContexts: [String: StatusContext] = [:]
     @State private var isLoadingThreads = false
     @State private var loadedContextStatusIds = Set<String>()
+    private let headerAvatarSize: CGFloat = 28
+    private let conversationHorizontalInset: CGFloat = 10
     
     private var currentGroupedConversation: GroupedConversation {
         guard let service = timelineService,
@@ -88,7 +89,11 @@ struct GroupedConversationDetailView: View {
                 ChatMessage(status: status, isSent: isSentMessage(status))
             }
 
-        return groupMessages(chronologicalMessages)
+        return ChatMessageGroupingHelper.groupMessages(
+            chronologicalMessages,
+            isGroupChat: isGroupChat,
+            unknownAccount: unknownAccount
+        )
     }
     
     private var canSend: Bool {
@@ -100,75 +105,67 @@ struct GroupedConversationDetailView: View {
         return status.account.id == currentId
     }
 
+    private func maxMessageContentWidth(for containerWidth: CGFloat) -> CGFloat {
+        let reservedHorizontalChrome: CGFloat = (conversationHorizontalInset * 2) + (isGroupChat ? 28 + 6 : 0) + 20
+        let availableWidth = max(containerWidth - reservedHorizontalChrome, 220)
+        let proportionalWidth = max(containerWidth * (isGroupChat ? 0.78 : 0.84), 240)
+        return min(min(availableWidth, proportionalWidth), 520)
+    }
+
     var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(groupedMessages) { group in
-                        ChatMessageGroup(group: group, hiddenMentionHandles: hiddenMentionHandles)
+        GeometryReader { geometry in
+            let resolvedMaxMessageContentWidth = maxMessageContentWidth(for: geometry.size.width)
+
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(groupedMessages) { group in
+                            ChatMessageGroup(
+                                group: group,
+                                hiddenMentionHandles: hiddenMentionHandles,
+                                maxContentWidth: resolvedMaxMessageContentWidth
+                            )
                             .id(group.id)
+                        }
                     }
+                    .padding(.horizontal, conversationHorizontalInset)
+                    .padding(.vertical, 8)
                 }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 8)
-            }
-            .scrollContentBackground(.hidden)
-            .scrollDismissesKeyboard(.interactively)
-            .onAppear {
-                if let lastGroup = groupedMessages.last {
-                    proxy.scrollTo(lastGroup.id, anchor: .bottom)
-                }
-            }
-            .onChange(of: groupedMessages.count) { _, _ in
-                if let lastGroup = groupedMessages.last {
-                    withAnimation {
+                .scrollContentBackground(.hidden)
+                .scrollDismissesKeyboard(.interactively)
+                .onAppear {
+                    if let lastGroup = groupedMessages.last {
                         proxy.scrollTo(lastGroup.id, anchor: .bottom)
                     }
                 }
-            }
-            .onChange(of: isTextFieldFocused) { _, focused in
-                if focused, let lastGroup = groupedMessages.last {
-                    withAnimation(.easeOut(duration: 0.25)) {
-                        proxy.scrollTo(lastGroup.id, anchor: .bottom)
+                .onChange(of: groupedMessages.count) { _, _ in
+                    if let lastGroup = groupedMessages.last {
+                        withAnimation {
+                            proxy.scrollTo(lastGroup.id, anchor: .bottom)
+                        }
                     }
                 }
-            }
-            .safeAreaInset(edge: .bottom, spacing: 0) {
-                composeBar
-                    .padding(.horizontal, 16)
-                    .padding(.top, 6)
-                    .padding(.bottom, 4)
+                .onChange(of: isTextFieldFocused) { _, focused in
+                    if focused, let lastGroup = groupedMessages.last {
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            proxy.scrollTo(lastGroup.id, anchor: .bottom)
+                        }
+                    }
+                }
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    composeBar
+                        .padding(.horizontal, 16)
+                        .padding(.top, 6)
+                        .padding(.bottom, 4)
+                }
             }
         }
         .navigationTitle(currentGroupedConversation.displayName)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(layoutMode.isCompact ? .hidden : .visible, for: .tabBar)
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                if isGroupChat {
-                    // Group chat: show menu with all participants
-                    Menu {
-                        ForEach(participants) { participant in
-                            Button {
-                                appState.navigate(to: .profile(participant))
-                            } label: {
-                                HStack(spacing: 8) {
-                                    CircularMenuAvatarView(url: participant.avatarURL, size: 24)
-                                    Text(participant.displayName)
-                                }
-                            }
-                        }
-                    } label: {
-                        Image(systemName: "person.2.circle")
-                    }
-                } else if let account = participants.first {
-                    // 1:1 chat: direct profile link
-                    Button {
-                        appState.navigate(to: .profile(account))
-                    } label: {
-                        Image(systemName: "person.circle")
-                    }
-                }
+            ToolbarItem(placement: .principal) {
+                conversationHeaderControl
             }
         }
         .task {
@@ -253,7 +250,7 @@ struct GroupedConversationDetailView: View {
                 } else {
                     Image(systemName: "arrow.up.circle.fill")
                         .font(.title3)
-                        .foregroundStyle(canSend ? ThemeColor.resolved(from: themeColorName).color : .gray)
+                        .foregroundStyle(canSend ? .primary : .secondary)
                 }
             }
             .buttonStyle(.plain)
@@ -296,45 +293,57 @@ struct GroupedConversationDetailView: View {
         }
     }
     
-    private func groupMessages(_ messages: [ChatMessage]) -> [GroupedMessage] {
-        var groups: [GroupedMessage] = []
-        var currentGroup: [ChatMessage] = []
-        var currentSenderId: String?
-        
-        for message in messages {
-            let senderId = message.status?.account.id ?? "unknown"
-            
-            // If same sender and within 5 minutes, add to current group
-            if let lastMessage = currentGroup.last,
-               senderId == currentSenderId,
-               abs(message.createdAt.timeIntervalSince(lastMessage.createdAt)) < 300 {
-                currentGroup.append(message)
-            } else {
-                // Start new group
-                if !currentGroup.isEmpty, let firstMessage = currentGroup.first {
-                    let account = firstMessage.status?.account ?? unknownAccount
-                    groups.append(GroupedMessage(
-                        account: account,
-                        messages: currentGroup,
-                        isSent: firstMessage.isSent
-                    ))
+    @ViewBuilder
+    private var conversationHeaderControl: some View {
+        if isGroupChat {
+            Menu {
+                ForEach(participants) { participant in
+                    Button {
+                        appState.navigate(to: .profile(participant))
+                    } label: {
+                        HStack(spacing: 8) {
+                            CircularMenuAvatarView(url: participant.avatarURL, size: 24)
+                            Text(participant.displayName)
+                        }
+                    }
                 }
-                currentGroup = [message]
-                currentSenderId = senderId
+            } label: {
+                conversationHeaderLabel(showsDisclosure: true)
+            }
+        } else if let account = participants.first {
+            Button {
+                appState.navigate(to: .profile(account))
+            } label: {
+                conversationHeaderLabel(showsDisclosure: false)
+            }
+            .buttonStyle(.plain)
+        } else {
+            Text(currentGroupedConversation.displayName)
+                .font(.roundedHeadline.weight(.semibold))
+                .lineLimit(1)
+        }
+    }
+
+    private func conversationHeaderLabel(showsDisclosure: Bool) -> some View {
+        HStack(spacing: 8) {
+            if isGroupChat {
+                GroupAvatarView(participants: participants, size: headerAvatarSize)
+            } else if let account = participants.first {
+                ProfileAvatarView(url: account.avatarURL, size: headerAvatarSize)
+            }
+
+            Text(currentGroupedConversation.displayName)
+                .font(.roundedHeadline.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+
+            if showsDisclosure {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
             }
         }
-        
-        // Add final group
-        if !currentGroup.isEmpty, let firstMessage = currentGroup.first {
-            let account = firstMessage.status?.account ?? unknownAccount
-            groups.append(GroupedMessage(
-                account: account,
-                messages: currentGroup,
-                isSent: firstMessage.isSent
-            ))
-        }
-        
-        return groups
+        .frame(maxWidth: 240)
     }
     
     private var unknownAccount: MastodonAccount {

--- a/fedi-reader/Views/Feed/Mentions/GroupedMessage.swift
+++ b/fedi-reader/Views/Feed/Mentions/GroupedMessage.swift
@@ -6,15 +6,21 @@ struct GroupedMessage: Identifiable {
     let account: MastodonAccount
     let messages: [ChatMessage]
     let isSent: Bool
+    let isGroupChat: Bool
     
-    init(account: MastodonAccount, messages: [ChatMessage], isSent: Bool = false) {
+    init(
+        account: MastodonAccount,
+        messages: [ChatMessage],
+        isSent: Bool = false,
+        isGroupChat: Bool = false
+    ) {
         self.id = "\(account.id)-\(messages.first?.id ?? UUID().uuidString)"
         self.account = account
         self.messages = messages
         self.isSent = isSent
+        self.isGroupChat = isGroupChat
     }
 }
 
 // MARK: - Chat Message Group
-
 

--- a/fedi-reader/Views/Feed/StatusDetailRowView.swift
+++ b/fedi-reader/Views/Feed/StatusDetailRowView.swift
@@ -11,6 +11,7 @@ struct StatusDetailRowView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.openURL) private var openURL
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+    @AppStorage("autoPlayGifs") private var autoPlayGifs = false
     @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
 
     @State private var authorAttribution: AuthorAttribution?
@@ -101,16 +102,7 @@ struct StatusDetailRowView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 8) {
                         ForEach(displayStatus.mediaAttachments) { attachment in
-                            AsyncImage(url: URL(string: attachment.previewUrl ?? attachment.url)) { image in
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                            } placeholder: {
-                                Rectangle()
-                                    .fill(.tertiary)
-                            }
-                            .frame(width: 150, height: 150)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                            mediaAttachmentView(attachment)
                         }
                     }
                 }
@@ -185,6 +177,32 @@ struct StatusDetailRowView: View {
         BoostAttributionChip(account: status.account) {
             HapticFeedback.play(.navigation)
             appState.navigate(to: .profile(status.account))
+        }
+    }
+
+    @ViewBuilder
+    private func mediaAttachmentView(_ attachment: MediaAttachment) -> some View {
+        let content = MediaAttachmentThumbnailView(
+            attachment: attachment,
+            size: CGSize(width: 150, height: 150),
+            cornerRadius: 8,
+            autoPlayGifs: autoPlayGifs
+        )
+
+        let playbackPolicy = MediaAttachmentPlaybackPolicy.resolve(
+            for: attachment.type,
+            autoPlayGifs: autoPlayGifs
+        )
+
+        if playbackPolicy == .explicitVideoPlayback, let videoURL = URL(string: attachment.url) {
+            Button {
+                appState.present(sheet: .videoPlayer(url: videoURL))
+            } label: {
+                content
+            }
+            .buttonStyle(.plain)
+        } else {
+            content
         }
     }
 

--- a/fedi-reader/Views/Feed/StatusRowView.swift
+++ b/fedi-reader/Views/Feed/StatusRowView.swift
@@ -7,6 +7,7 @@ struct StatusRowView: View {
     @Environment(ReadLaterManager.self) private var readLaterManager
     @Environment(TimelineServiceWrapper.self) private var timelineWrapper
     @AppStorage("showHandleInFeed") private var showHandleInFeed = false
+    @AppStorage("autoPlayGifs") private var autoPlayGifs = false
     @AppStorage("articleViewerPreference") private var articleViewerPreferenceRaw = ArticleViewerPreference.inApp.rawValue
     
     @State private var blueskyDescription: String?
@@ -260,26 +261,29 @@ struct StatusRowView: View {
         }
     }
     
+    @ViewBuilder
     private func mediaAttachmentView(_ attachment: MediaAttachment) -> some View {
-        AsyncImage(url: URL(string: attachment.previewUrl ?? attachment.url)) { image in
-            image
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        } placeholder: {
-            Rectangle()
-                .fill(.tertiary)
-        }
-        .frame(width: 150, height: 150)
-        .clipped()
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay(alignment: .bottomTrailing) {
-            if attachment.type == .video || attachment.type == .gifv {
-                Image(systemName: attachment.type == .gifv ? "play.circle" : "video")
-                    .font(.roundedCaption)
-                    .padding(4)
-                    .glassEffect(.clear, in: Circle())
-                    .padding(6)
+        let content = MediaAttachmentThumbnailView(
+            attachment: attachment,
+            size: CGSize(width: 150, height: 150),
+            cornerRadius: 8,
+            autoPlayGifs: autoPlayGifs
+        )
+
+        let playbackPolicy = MediaAttachmentPlaybackPolicy.resolve(
+            for: attachment.type,
+            autoPlayGifs: autoPlayGifs
+        )
+
+        if playbackPolicy == .explicitVideoPlayback, let videoURL = URL(string: attachment.url) {
+            Button {
+                appState.present(sheet: .videoPlayer(url: videoURL))
+            } label: {
+                content
             }
+            .buttonStyle(.plain)
+        } else {
+            content
         }
     }
     

--- a/fedi-reader/Views/Root/ContentView.swift
+++ b/fedi-reader/Views/Root/ContentView.swift
@@ -111,6 +111,8 @@ struct ContentView: View {
                 .environment(appState)
         case .safariView:
             EmptyView()
+        case .videoPlayer(let url):
+            VideoPlaybackSheet(url: url)
         }
     }
 }

--- a/fedi-readerTests/ConversationTests.swift
+++ b/fedi-readerTests/ConversationTests.swift
@@ -63,6 +63,56 @@ struct ConversationTests {
         #expect(group.messages.first?.isSent == true)
     }
 
+    @Test("Groups consecutive same-sender messages even minutes apart")
+    func groupsConsecutiveMessagesRegardlessOfTimeGap() {
+        let sender = MockStatusFactory.makeAccount(id: "sender-1", username: "sender1", displayName: "Sender One")
+        let firstStatus = MockStatusFactory.makeStatus(id: "message-1", account: sender)
+        let laterStatus = MockStatusFactory.makeStatus(id: "message-2", account: sender)
+
+        let messages = [
+            ChatMessage(
+                status: firstStatus.with(createdAt: Date(timeIntervalSince1970: 0)),
+                isSent: false
+            ),
+            ChatMessage(
+                status: laterStatus.with(createdAt: Date(timeIntervalSince1970: 900)),
+                isSent: false
+            )
+        ]
+
+        let groups = ChatMessageGroupingHelper.groupMessages(
+            messages,
+            isGroupChat: true,
+            unknownAccount: MockStatusFactory.makeAccount(id: "unknown")
+        )
+
+        #expect(groups.count == 1)
+        #expect(groups.first?.messages.count == 2)
+    }
+
+    @Test("Starts a new group when another sender interrupts")
+    func startsNewGroupWhenSenderChanges() {
+        let firstSender = MockStatusFactory.makeAccount(id: "sender-1", username: "sender1", displayName: "Sender One")
+        let secondSender = MockStatusFactory.makeAccount(id: "sender-2", username: "sender2", displayName: "Sender Two")
+
+        let messages = [
+            ChatMessage(status: MockStatusFactory.makeStatus(id: "message-1", account: firstSender), isSent: false),
+            ChatMessage(status: MockStatusFactory.makeStatus(id: "message-2", account: secondSender), isSent: false),
+            ChatMessage(status: MockStatusFactory.makeStatus(id: "message-3", account: firstSender), isSent: false)
+        ]
+
+        let groups = ChatMessageGroupingHelper.groupMessages(
+            messages,
+            isGroupChat: true,
+            unknownAccount: MockStatusFactory.makeAccount(id: "unknown")
+        )
+
+        #expect(groups.count == 3)
+        #expect(groups[0].account.id == firstSender.id)
+        #expect(groups[1].account.id == secondSender.id)
+        #expect(groups[2].account.id == firstSender.id)
+    }
+
     // MARK: - Filtering
 
     @Test("Filters private and direct messages only")
@@ -128,5 +178,41 @@ struct ConversationTests {
         let mastodonAccount = account.mastodonAccount
 
         #expect(mastodonAccount.id == "123")
+    }
+}
+
+private extension Status {
+    func with(createdAt: Date) -> Status {
+        Status(
+            id: id,
+            uri: uri,
+            url: url,
+            createdAt: createdAt,
+            account: account,
+            content: content,
+            visibility: visibility,
+            sensitive: sensitive,
+            spoilerText: spoilerText,
+            mediaAttachments: mediaAttachments,
+            mentions: mentions,
+            tags: tags,
+            emojis: emojis,
+            reblogsCount: reblogsCount,
+            favouritesCount: favouritesCount,
+            repliesCount: repliesCount,
+            application: application,
+            language: language,
+            reblog: reblog,
+            card: card,
+            poll: poll,
+            quote: quote,
+            favourited: favourited,
+            reblogged: reblogged,
+            muted: muted,
+            bookmarked: bookmarked,
+            pinned: pinned,
+            inReplyToId: inReplyToId,
+            inReplyToAccountId: inReplyToAccountId
+        )
     }
 }

--- a/fedi-readerTests/MediaAttachmentPlaybackPolicyTests.swift
+++ b/fedi-readerTests/MediaAttachmentPlaybackPolicyTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import fedi_reader
+
+@Suite("Media Attachment Playback Policy Tests")
+struct MediaAttachmentPlaybackPolicyTests {
+    @Test("Images always use a static preview")
+    func imagesAlwaysUseStaticPreview() {
+        #expect(
+            MediaAttachmentPlaybackPolicy.resolve(for: .image, autoPlayGifs: false) == .staticPreview
+        )
+        #expect(
+            MediaAttachmentPlaybackPolicy.resolve(for: .image, autoPlayGifs: true) == .staticPreview
+        )
+    }
+
+    @Test("GIFV autoplay follows the existing setting")
+    func gifvAutoplayDependsOnSetting() {
+        #expect(
+            MediaAttachmentPlaybackPolicy.resolve(for: .gifv, autoPlayGifs: false) == .staticPreview
+        )
+        #expect(
+            MediaAttachmentPlaybackPolicy.resolve(for: .gifv, autoPlayGifs: true) == .inlineLoopingGifv
+        )
+    }
+
+    @Test("Videos always require explicit playback")
+    func videosAlwaysRequireExplicitPlayback() {
+        #expect(
+            MediaAttachmentPlaybackPolicy.resolve(for: .video, autoPlayGifs: false) == .explicitVideoPlayback
+        )
+        #expect(
+            MediaAttachmentPlaybackPolicy.resolve(for: .video, autoPlayGifs: true) == .explicitVideoPlayback
+        )
+    }
+}

--- a/fedi-readerTests/VideoPlaybackAudioSessionCoordinatorTests.swift
+++ b/fedi-readerTests/VideoPlaybackAudioSessionCoordinatorTests.swift
@@ -1,0 +1,80 @@
+#if os(iOS)
+import AVFAudio
+import Foundation
+import Testing
+@testable import fedi_reader
+
+@Suite("Video Playback Audio Session Coordinator Tests")
+@MainActor
+struct VideoPlaybackAudioSessionCoordinatorTests {
+    @Test("Activates playback session only while video is playing")
+    func activatesPlaybackSessionWhilePlaying() {
+        let session = MockVideoPlaybackAudioSession()
+        let coordinator = VideoPlaybackAudioSessionCoordinator(session: session)
+
+        coordinator.updatePlaybackState(isPlaying: true)
+
+        #expect(session.categoryCalls.count == 1)
+        #expect(session.activeCalls.count == 1)
+        #expect(session.activeCalls[0].0)
+        #expect(session.activeCalls[0].1.isEmpty)
+        #expect(coordinator.isSessionActive)
+    }
+
+    @Test("Does not reactivate an already active session")
+    func doesNotReactivateActiveSession() {
+        let session = MockVideoPlaybackAudioSession()
+        let coordinator = VideoPlaybackAudioSessionCoordinator(session: session)
+
+        coordinator.updatePlaybackState(isPlaying: true)
+        coordinator.updatePlaybackState(isPlaying: true)
+
+        #expect(session.categoryCalls.count == 1)
+        #expect(session.activeCalls.count == 1)
+        #expect(session.activeCalls[0].0)
+        #expect(session.activeCalls[0].1.isEmpty)
+    }
+
+    @Test("Deactivates session and notifies other audio on stop")
+    func deactivatesSessionWhenPlaybackStops() {
+        let session = MockVideoPlaybackAudioSession()
+        let coordinator = VideoPlaybackAudioSessionCoordinator(session: session)
+
+        coordinator.updatePlaybackState(isPlaying: true)
+        coordinator.updatePlaybackState(isPlaying: false)
+
+        #expect(session.activeCalls.count == 2)
+        #expect(session.activeCalls[1].0 == false)
+        #expect(session.activeCalls[1].1 == [.notifyOthersOnDeactivation])
+        #expect(!coordinator.isSessionActive)
+    }
+
+    @Test("End playback is safe when no session is active")
+    func endPlaybackIsSafeWithoutActiveSession() {
+        let session = MockVideoPlaybackAudioSession()
+        let coordinator = VideoPlaybackAudioSessionCoordinator(session: session)
+
+        coordinator.endPlayback()
+
+        #expect(session.activeCalls.isEmpty)
+        #expect(!coordinator.isSessionActive)
+    }
+}
+
+private final class MockVideoPlaybackAudioSession: VideoPlaybackAudioSessionControlling {
+    var categoryCalls: [(AVAudioSession.Category, AVAudioSession.Mode, AVAudioSession.CategoryOptions)] = []
+    var activeCalls: [(Bool, AVAudioSession.SetActiveOptions)] = []
+
+    func setCategory(
+        _ category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions
+    ) throws {
+        categoryCalls.append((category, mode, options))
+    }
+
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+        activeCalls.append((active, options))
+    }
+}
+#endif


### PR DESCRIPTION
**Summary**
- collapse consecutive messages from the same user so display name, avatar, and timestamp are only shown once per run of replies
- align the shared metadata with the message text edge and move the timestamp out of the bubble for consistency

**Testing**
- Not run (not requested)