### PR TITLE
chore: update Xcode workspace path after repo move

### DIFF
--- a/buildServer.json
+++ b/buildServer.json
@@ -12,7 +12,7 @@
 	"argv": [
 		"/opt/homebrew/bin/xcode-build-server"
 	],
-	"workspace": "/Users/sam/Developer/Git/Stygian Tech/iOS Applications/fedi-reader/fedi-reader.xcodeproj/project.xcworkspace",
+	"workspace": "/Users/sam/Developer/Git/Stygian Tech/ios-apps/fedi-reader/fedi-reader.xcodeproj/project.xcworkspace",
 	"build_root": "/Users/sam/Library/Developer/Xcode/DerivedData/fedi-reader-agbqyxupgtkfgzcfwqitcxdlphnn",
 	"scheme": "fedi-reader",
 	"kind": "xcode"


### PR DESCRIPTION
## What changed

- Updates the tracked Xcode build-server workspace path for the normalized local repository layout.
- Keeps source tooling pointed at the existing Xcode project after the repository directory moved.

## Why

The repository was moved into a kebab-case logical group, leaving the absolute workspace path in `buildServer.json` stale.

## Validation

- Xcode successfully enumerates the project targets and schemes using Xcode beta.
- Existing package dependencies resolve without lockfile changes.

## Risk

Low. This changes only the local Xcode build-server workspace path.